### PR TITLE
Enable ctrl proceeding on demand

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -57,4 +57,4 @@ jobs:
         mkdir -p build && cd build
         source ${HOME}/venv/bin/activate
         pytest .. -v --tb=short
-        pytest ../cgra/translate/CGRAKingMeshRTL_test.py -xvs --tb=short --test-verilog --dump-vtb --dump-vcd
+        pytest ../cgra/translate/VectorCGRAKingMeshRTL_test.py -xvs --tb=short --test-verilog --dump-vtb --dump-vcd

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -52,8 +52,9 @@ jobs:
         pip install pytest
         pip list
         
-    - name: Test with pytest
+    - name: Test and translate with pytest
       run: |
         mkdir -p build && cd build
         source ${HOME}/venv/bin/activate
         pytest .. -v --tb=short
+        pytest ../cgra/translate/CGRAKingMeshRTL_test.py -xvs --tb=short --test-verilog --dump-vtb --dump-vcd

--- a/cgra/CGRACL.py
+++ b/cgra/CGRACL.py
@@ -20,7 +20,8 @@ class CGRACL( Component ):
 
   def construct( s, FunctionUnit, FuList, DataType, PredicateType,
                  CtrlType, width, height, ctrl_mem_size, data_mem_size,
-                 num_ctrl, preload_ctrl, preload_data, preload_const ):
+                 num_ctrl, total_steps, preload_ctrl, preload_data,
+                 preload_const ):
 
     s.num_tiles = width * height
     s.num_mesh_ports = 4
@@ -30,7 +31,8 @@ class CGRACL( Component ):
 
     s.tile = [ TileCL( FunctionUnit, FuList, DataType, PredicateType,
                        CtrlType, ctrl_mem_size, data_mem_size,
-                       num_ctrl, preload_const[i], preload_ctrl[i], i )
+                       num_ctrl, total_steps, preload_const[i],
+                       preload_ctrl[i], i )
                        for i in range( s.num_tiles ) ]
     s.data_mem = DataMemCL( DataType, data_mem_size, height, height,
                             preload_data )

--- a/cgra/CGRAKingMeshRTL.py
+++ b/cgra/CGRAKingMeshRTL.py
@@ -22,8 +22,9 @@ from ..fu.flexible.FlexibleFuRTL import FlexibleFuRTL
 class CGRAKingMeshRTL( Component ):
 
   def construct( s, DataType, PredicateType, CtrlType, width, height,
-                 ctrl_mem_size, data_mem_size, num_ctrl, FunctionUnit,
-                 FuList, preload_data = None, preload_const = None ):
+                 ctrl_mem_size, data_mem_size, num_ctrl, total_steps,
+                 FunctionUnit, FuList, preload_data = None,
+                 preload_const = None ):
 
     s.num_tiles = width * height
     s.num_mesh_ports = 8
@@ -37,8 +38,8 @@ class CGRAKingMeshRTL( Component ):
     if preload_const == None:
       preload_const = [[DataType(0, 0)] for _ in range(width*height)]
     s.tile = [ TileRTL( DataType, PredicateType, CtrlType,
-                        ctrl_mem_size, data_mem_size,
-                        num_ctrl, 4, 2, s.num_mesh_ports,
+                        ctrl_mem_size, data_mem_size, num_ctrl,
+                        total_steps, 4, 2, s.num_mesh_ports,
                         s.num_mesh_ports, const_list = preload_const[i] )
                         for i in range( s.num_tiles ) ]
     s.data_mem = DataMemRTL( DataType, data_mem_size, height, height, preload_data )

--- a/cgra/CGRARTL.py
+++ b/cgra/CGRARTL.py
@@ -22,8 +22,9 @@ from ..fu.flexible.FlexibleFuRTL import FlexibleFuRTL
 class CGRARTL( Component ):
 
   def construct( s, DataType, PredicateType, CtrlType, width, height,
-                 ctrl_mem_size, data_mem_size, num_ctrl, FunctionUnit,
-                 FuList, preload_data = None, preload_const = None ):
+                 ctrl_mem_size, data_mem_size, num_ctrl, total_steps,
+                 FunctionUnit, FuList, preload_data = None,
+                 preload_const = None ):
 
     s.num_tiles = width * height
     s.num_mesh_ports = 4
@@ -37,8 +38,8 @@ class CGRARTL( Component ):
     if preload_const == None:
       preload_const = [[DataType(0, 0)] for _ in range(width*height)]
     s.tile = [ TileRTL( DataType, PredicateType, CtrlType,
-                        ctrl_mem_size, data_mem_size,
-                        num_ctrl, 4, 2, s.num_mesh_ports,
+                        ctrl_mem_size, data_mem_size, num_ctrl,
+                        total_steps, 4, 2, s.num_mesh_ports,
                         s.num_mesh_ports, const_list = preload_const[i] )
                         for i in range( s.num_tiles ) ]
     s.data_mem = DataMemRTL( DataType, data_mem_size, height, height, preload_data )

--- a/cgra/CGRATemplateRTL.py
+++ b/cgra/CGRATemplateRTL.py
@@ -22,9 +22,9 @@ from ..fu.flexible.FlexibleFuRTL import FlexibleFuRTL
 class CGRATemplateRTL( Component ):
 
   def construct( s, DataType, PredicateType, CtrlType, width, height,
-                 ctrl_mem_size, data_mem_size, num_ctrl, FunctionUnit,
-                 FuList, TileList, LinkList, dataSPM, preload_data = None,
-                 preload_const = None ):
+                 ctrl_mem_size, data_mem_size, num_ctrl, total_steps,
+                 FunctionUnit, FuList, TileList, LinkList, dataSPM,
+                 preload_data = None, preload_const = None ):
 
     # s.num_tiles = width * height
     s.num_tiles = len( TileList )
@@ -40,9 +40,10 @@ class CGRATemplateRTL( Component ):
       # preload_const = [[DataType(0, 0)] for _ in range(width*height)]
       preload_const = [[DataType(0, 0)] for _ in range(s.num_tiles)]
     s.tile = [ TileRTL( DataType, PredicateType, CtrlType,
-                        ctrl_mem_size, data_mem_size,
-                        num_ctrl, 4, 2, s.num_mesh_ports,
-                        s.num_mesh_ports, FuList = FuList, const_list = preload_const[i] )
+                        ctrl_mem_size, data_mem_size, num_ctrl,
+                        total_steps, 4, 2, s.num_mesh_ports,
+                        s.num_mesh_ports, FuList = FuList,
+                        const_list = preload_const[i] )
                         for i in range( s.num_tiles ) ]
     s.data_mem = DataMemRTL( DataType, data_mem_size, dataSPM.getNumOfValidReadPorts(), dataSPM.getNumOfValidWritePorts(), preload_data )
 

--- a/cgra/test/CGRACL_FIR_demo_test.py
+++ b/cgra/test/CGRACL_FIR_demo_test.py
@@ -46,8 +46,9 @@ class TestHarness( Component ):
     AddrType = mk_bits( clog2( ctrl_mem_size ) )
 
     s.dut = DUT( FunctionUnit, FuList, DataType, PredicateType, CtrlType,
-                 width, height, ctrl_mem_size, data_mem_size, 100, src_opt,
-                 preload_data, preload_const )
+                 width, height, ctrl_mem_size, data_mem_size,
+                 len( src_opt[0] ), 100, src_opt, preload_data,
+                 preload_const )
     s.DataType = DataType
 
   def line_trace( s ):

--- a/cgra/test/CGRACL_test.py
+++ b/cgra/test/CGRACL_test.py
@@ -42,7 +42,8 @@ class TestHarness( Component ):
 
     s.dut = DUT( FunctionUnit, FuList, DataType, PredicateType,
                  CtrlType, width, height, ctrl_mem_size, data_mem_size,
-                 max_sim_steps, src_opt, preload_data, preload_const )
+                 len( src_opt[0] ), max_sim_steps, src_opt, preload_data,
+                 preload_const )
     s.DataType = DataType
 
   def line_trace( s ):

--- a/cgra/test/CGRAKingMeshRTL_test.py
+++ b/cgra/test/CGRAKingMeshRTL_test.py
@@ -45,7 +45,7 @@ class TestHarness( Component ):
 
     s.dut = DUT( DataType, PredicateType, CtrlType, width, height,
                  ctrl_mem_size, data_mem_size, len( src_opt[0] ),
-                 FunctionUnit, FuList )
+                 len( src_opt[0] ), FunctionUnit, FuList )
 
     for i in range( s.num_tiles ):
       connect( s.src_opt[i].send,     s.dut.recv_wopt[i]  )

--- a/cgra/test/CGRARTL_test.py
+++ b/cgra/test/CGRARTL_test.py
@@ -45,7 +45,7 @@ class TestHarness( Component ):
 
     s.dut = DUT( DataType, PredicateType, CtrlType, width, height,
                  ctrl_mem_size, data_mem_size, len( src_opt[0] ),
-                 FunctionUnit, FuList )
+                 len( src_opt[0] ), FunctionUnit, FuList )
 
     for i in range( s.num_tiles ):
       connect( s.src_opt[i].send,     s.dut.recv_wopt[i]  )

--- a/cgra/test/VectorCGRAKingMeshRTL_test.py
+++ b/cgra/test/VectorCGRAKingMeshRTL_test.py
@@ -54,7 +54,7 @@ class TestHarness( Component ):
 
     s.dut = DUT( DataType, PredicateType, CtrlType, width, height,
                  ctrl_mem_size, data_mem_size, len( src_opt[0] ),
-                 FunctionUnit, FuList )
+                 len( src_opt[0] ), FunctionUnit, FuList )
 
     for i in range( s.num_tiles ):
       connect( s.src_opt[i].send,     s.dut.recv_wopt[i]  )

--- a/cgra/translate/CGRARTL_hetero_test.py
+++ b/cgra/translate/CGRARTL_hetero_test.py
@@ -65,7 +65,7 @@ src_opt           = [ [ CtrlType( OPT_INC, b1( 0 ), pickRegister, [
 def test_elaborate():
   dut = CGRARTL( DataType, PredicateType, CtrlType, width, height,
                  ctrl_mem_size, data_mem_size, len( src_opt[0] ),
-                 FunctionUnit, FuList )
+                 len( src_opt[0] ), FunctionUnit, FuList )
   dut.apply( DefaultPassGroup(linetrace=True) )
   dut.sim_reset()
   dut.sim_tick()
@@ -75,7 +75,7 @@ def test_elaborate():
 def test_translate( cmdline_opts ):
   dut = CGRARTL( DataType, PredicateType, CtrlType, width, height,
                  ctrl_mem_size, data_mem_size, len( src_opt[0] ),
-                 FunctionUnit, FuList )
+                 len( src_opt[0] ), FunctionUnit, FuList )
   dut.set_metadata( VerilogTranslationPass.explicit_module_name,
                     f'CGRAHeteroRTL' )
   dut.set_metadata( VerilogVerilatorImportPass.vl_Wno_list,

--- a/cgra/translate/CGRARTL_test.py
+++ b/cgra/translate/CGRARTL_test.py
@@ -77,7 +77,7 @@ src_opt           = [ [ CtrlType( OPT_INC, b1( 0 ), pickRegister, [
 def test_elaborate():
   dut = CGRARTL( DataType, PredicateType, CtrlType, width, height,
                  ctrl_mem_size, data_mem_size, len( src_opt[0] ),
-                 FunctionUnit, FuList )
+                 len( src_opt[0] ), FunctionUnit, FuList )
   dut.apply( DefaultPassGroup(linetrace=True) )
   dut.sim_reset()
   dut.sim_tick()
@@ -87,7 +87,7 @@ def test_elaborate():
 def test_translate( cmdline_opts ):
   dut = CGRARTL( DataType, PredicateType, CtrlType, width, height,
                  ctrl_mem_size, data_mem_size, len( src_opt[0] ),
-                 FunctionUnit, FuList )
+                 len( src_opt[0] ), FunctionUnit, FuList )
   dut.set_metadata( VerilogTranslationPass.explicit_module_name,
                     f'CGRARTL' )
   config_model_with_cmdline_opts( dut, cmdline_opts, duts=[] )

--- a/cgra/translate/CGRATemplateRTL_test.py
+++ b/cgra/translate/CGRATemplateRTL_test.py
@@ -67,7 +67,7 @@ class TestHarness( Component ):
 
     s.dut = DUT( DataType, PredicateType, CtrlType, width, height,
                  ctrl_mem_size, data_mem_size, len( src_opt[0] ),
-                 FunctionUnit, FuList, tileList, linkList, dataSPM )
+                 len( src_opt[0] ), FunctionUnit, FuList, tileList, linkList, dataSPM )
 
     for i in range( s.num_tiles ):
       connect( s.src_opt[i].send,     s.dut.recv_wopt[i]  )

--- a/cgra/translate/VectorCGRAKingMeshRTL_test.py
+++ b/cgra/translate/VectorCGRAKingMeshRTL_test.py
@@ -53,7 +53,7 @@ class TestHarness( Component ):
 
     s.dut = DUT( DataType, PredicateType, CtrlType, width, height,
                  ctrl_mem_size, data_mem_size, len( src_opt[0] ),
-                 FunctionUnit, fu_list )
+                 len( src_opt[0] ), FunctionUnit, fu_list )
 
     for i in range( s.num_tiles ):
       connect( s.src_opt[i].send,     s.dut.recv_wopt[i]  )

--- a/fu/basic/Fu.py
+++ b/fu/basic/Fu.py
@@ -16,7 +16,8 @@ from ...lib.opt_type    import *
 class Fu( Component ):
 
   def construct( s, DataType, PredicateType, CtrlType,
-                 num_inports, num_outports, data_mem_size=4, latency = 1 ):
+                 num_inports, num_outports, data_mem_size = 4,
+                 latency = 1 ):
 
     # Constant
     AddrType      = mk_bits( clog2( data_mem_size ) )
@@ -58,11 +59,12 @@ class Fu( Component ):
     @update
     def update_signal():
       for j in range( num_outports ):
-        # s.recv_const.rdy @= s.send_out[j].rdy | s.recv_const.rdy
-        # s.recv_opt.rdy @= s.send_out[j].rdy | s.recv_opt.rdy
         s.recv_rdy_vector[j] @= s.send_out[j].rdy
       s.recv_const.rdy @= reduce_or( s.recv_rdy_vector ) & ( s.latency == latency - 1 )
-      s.recv_opt.rdy   @= reduce_or( s.recv_rdy_vector ) & ( s.latency == latency - 1 )
+      # OPT_NAH doesn't require consuming any input.
+      s.recv_opt.rdy   @= (( s.recv_opt.msg.ctrl == OPT_NAH ) | \
+                           reduce_or( s.recv_rdy_vector ) ) & \
+                          ( s.latency == latency - 1 )
 
     @update
     def update_mem():

--- a/fu/basic/Fu.py
+++ b/fu/basic/Fu.py
@@ -2,10 +2,11 @@
 ==========================================================================
 Fu.py
 ==========================================================================
-Simple generic functional unit for CGRA tile.
+Simple generic functional unit for CGRA tile. This is the basic functional
+unit that can be inherited by both the CL and RTL modules.
 
 Author : Cheng Tan
-  Date : November 27, 2019
+  Date : August 6, 2023
 """
 
 from pymtl3             import *
@@ -15,14 +16,15 @@ from ...lib.opt_type    import *
 class Fu( Component ):
 
   def construct( s, DataType, PredicateType, CtrlType,
-                 num_inports, num_outports, data_mem_size=4 ):
+                 num_inports, num_outports, data_mem_size=4, latency = 1 ):
 
     # Constant
     AddrType      = mk_bits( clog2( data_mem_size ) )
     s.const_zero  = DataType(0, 0)
-    num_entries = 2
+    num_entries   = 2
     CountType     = mk_bits( clog2( num_entries + 1 ) )
     FuInType      = mk_bits( clog2( num_inports + 1 ) )
+    LatencyType = mk_bits( clog2( latency + 1 ) )
 
     # Interface
     s.recv_in        = [ RecvIfcRTL( DataType ) for _ in range( num_inports ) ]
@@ -42,6 +44,16 @@ class Fu( Component ):
 
     # Components
     s.recv_rdy_vector = Wire( num_outports )
+    s.latency = Wire( LatencyType )
+
+    @update_ff
+    def proceed_latency():
+      if s.recv_opt.msg.ctrl == OPT_START:
+        s.latency <<= LatencyType( 0 )
+      elif s.latency == latency - 1:
+        s.latency <<= LatencyType( 0 )
+      else:
+        s.latency <<= s.latency + LatencyType( 1 )
 
     @update
     def update_signal():
@@ -49,8 +61,8 @@ class Fu( Component ):
         # s.recv_const.rdy @= s.send_out[j].rdy | s.recv_const.rdy
         # s.recv_opt.rdy @= s.send_out[j].rdy | s.recv_opt.rdy
         s.recv_rdy_vector[j] @= s.send_out[j].rdy
-      s.recv_const.rdy @= reduce_or( s.recv_rdy_vector )
-      s.recv_opt.rdy   @= reduce_or( s.recv_rdy_vector )
+      s.recv_const.rdy @= reduce_or( s.recv_rdy_vector ) & ( s.latency == latency - 1 )
+      s.recv_opt.rdy   @= reduce_or( s.recv_rdy_vector ) & ( s.latency == latency - 1 )
 
     @update
     def update_mem():

--- a/fu/single/AdderCL.py
+++ b/fu/single/AdderCL.py
@@ -1,0 +1,106 @@
+"""
+==========================================================================
+AdderCL.py
+==========================================================================
+Adder for CGRA tile. The latency is parameterizable.
+
+Author : Cheng Tan
+  Date : Aug 5, 2023
+
+"""
+
+from pymtl3             import *
+from ...lib.ifcs import SendIfcRTL, RecvIfcRTL
+from ...lib.opt_type    import *
+from ..basic.Fu         import Fu
+
+class AdderCL( Fu ):
+
+  def construct( s, DataType, PredicateType, CtrlType,
+                 num_inports, num_outports, data_mem_size, latency = 1 ):
+
+    super( AdderCL, s ).construct( DataType, PredicateType, CtrlType,
+                                   num_inports, num_outports,
+                                   data_mem_size, latency )
+
+    # Constant
+    s.const_one = DataType(1, 1)
+    FuInType    = mk_bits( clog2( num_inports + 1 ) )
+    num_entries = 2
+    CountType   = mk_bits( clog2( num_entries + 1 ) )
+    idx_nbits   = clog2( num_inports )
+    LatencyType = mk_bits( clog2( latency + 1 ) )
+
+    # Component
+    s.in0     = Wire( FuInType )
+    s.in1     = Wire( FuInType )
+    s.in0_idx = Wire( idx_nbits )
+    s.in1_idx = Wire( idx_nbits )
+
+    s.in0_idx //= s.in0[0:idx_nbits]
+    s.in1_idx //= s.in1[0:idx_nbits]
+
+    @update
+    def comb_logic():
+
+      s.in0 @= 0
+      s.in1 @= 0
+      s.recv_predicate.rdy @= 0
+      # For pick input register
+      for i in range( num_inports ):
+        s.recv_in[i].rdy @= b1( 0 )
+
+      for i in range( num_outports ):
+        s.send_out[i].en  @= s.recv_opt.en
+        s.send_out[i].msg @= DataType()
+
+      s.recv_predicate.rdy @= b1( 0 )
+
+      if s.recv_opt.en:
+        if s.recv_opt.msg.fu_in[0] != 0:
+          s.in0 @= zext(s.recv_opt.msg.fu_in[0] - 1, FuInType)
+          s.recv_in[s.in0_idx].rdy @= b1( 1 )
+        if s.recv_opt.msg.fu_in[1] != 0:
+          s.in1 @= zext(s.recv_opt.msg.fu_in[1] - 1, FuInType)
+          s.recv_in[s.in1_idx].rdy @= b1( 1 )
+        if s.recv_opt.msg.predicate == b1( 1 ):
+          s.recv_predicate.rdy @= b1( 1 )
+
+      s.send_out[0].msg.predicate @= s.recv_in[s.in0_idx].msg.predicate & \
+                                     s.recv_in[s.in1_idx].msg.predicate
+
+
+#      s.send_out[0].en = s.recv_opt.en
+
+      if s.recv_opt.msg.ctrl == OPT_ADD:
+        s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload + s.recv_in[s.in1_idx].msg.payload
+        s.send_out[0].msg.predicate @= s.recv_in[s.in0_idx].msg.predicate & s.recv_in[s.in1_idx].msg.predicate
+        if s.recv_opt.en & ( (s.recv_in_count[s.in0_idx] == 0) | \
+                             (s.recv_in_count[s.in1_idx] == 0) ):
+          s.recv_in[s.in0_idx].rdy @= b1( 0 )
+          s.recv_in[s.in1_idx].rdy @= b1( 0 )
+          s.send_out[0].msg.predicate @= b1( 0 )
+      elif s.recv_opt.msg.ctrl == OPT_ADD_CONST:
+        s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload + s.recv_const.msg.payload
+        s.send_out[0].msg.predicate @= s.recv_in[s.in0_idx].msg.predicate
+      elif s.recv_opt.msg.ctrl == OPT_INC:
+        s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload + s.const_one.payload
+        s.send_out[0].msg.predicate @= s.recv_in[s.in0_idx].msg.predicate
+      elif s.recv_opt.msg.ctrl == OPT_SUB:
+        s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload - s.recv_in[s.in1_idx].msg.payload
+        s.send_out[0].msg.predicate @= s.recv_in[s.in0_idx].msg.predicate
+        if s.recv_opt.en & ( (s.recv_in_count[s.in0_idx] == 0) | \
+                             (s.recv_in_count[s.in1_idx] == 0) ):
+          s.recv_in[s.in0_idx].rdy @= b1( 0 )
+          s.recv_in[s.in1_idx].rdy @= b1( 0 )
+          s.send_out[0].msg.predicate @= b1( 0 )
+      elif s.recv_opt.msg.ctrl == OPT_PAS:
+        s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload
+        s.send_out[0].msg.predicate @= s.recv_in[s.in0_idx].msg.predicate
+      else:
+        for j in range( num_outports ):
+          s.send_out[j].en @= b1( 0 )
+
+      if s.recv_opt.msg.predicate == b1( 1 ):
+        s.send_out[0].msg.predicate @= s.send_out[0].msg.predicate & \
+                                       s.recv_predicate.msg.predicate

--- a/fu/single/test/AdderCL_test.py
+++ b/fu/single/test/AdderCL_test.py
@@ -1,0 +1,105 @@
+"""
+==========================================================================
+AluRTL_test.py
+==========================================================================
+Test cases for all functional units.
+
+Author : Cheng Tan
+  Date : November 27, 2019
+
+"""
+
+from pymtl3                       import *
+from ....lib.test_sinks           import TestSinkRTL
+from ....lib.test_srcs            import TestSrcRTL
+
+from ..AdderCL                    import AdderCL
+from ....mem.const.ConstQueueRTL  import ConstQueueRTL
+from ....lib.opt_type             import *
+from ....lib.messages             import *
+
+#-------------------------------------------------------------------------
+# Test harness
+#-------------------------------------------------------------------------
+
+class TestHarness( Component ):
+
+  def construct( s, FunctionUnit, DataType, PredicateType, ConfigType,
+                 num_inports, num_outports, data_mem_size,
+                 src0_msgs, src1_msgs, src2_msgs, src_const,
+                 ctrl_msgs, sink_msgs, latency ):
+
+    s.src_in0       = TestSrcRTL( DataType,      src0_msgs )
+    s.src_in1       = TestSrcRTL( DataType,      src1_msgs )
+    s.src_predicate = TestSrcRTL( PredicateType, src2_msgs )
+    s.src_opt       = TestSrcRTL( ConfigType,    ctrl_msgs )
+    s.sink_out      = TestSinkRTL( DataType,      sink_msgs )
+
+    s.const_queue = ConstQueueRTL( DataType, src_const )
+    s.dut = FunctionUnit( DataType, PredicateType, ConfigType,
+                          num_inports, num_outports, data_mem_size,
+                          latency )
+
+    for i in range( num_inports ):
+      s.dut.recv_in_count[i] //= 1
+
+    connect( s.src_in0.send,       s.dut.recv_in[0]         )
+    connect( s.src_in1.send,       s.dut.recv_in[1]         )
+    connect( s.src_predicate.send, s.dut.recv_predicate     )
+    connect( s.dut.recv_const,     s.const_queue.send_const )
+    connect( s.src_opt.send,       s.dut.recv_opt           )
+    connect( s.dut.send_out[0],    s.sink_out.recv          )
+
+  def done( s ):
+    return s.src_in0.done() and s.src_in1.done() and\
+           s.src_opt.done() and s.sink_out.done()
+
+  def line_trace( s ):
+    return s.dut.line_trace()
+
+def run_sim( test_harness, max_cycles=100 ):
+  test_harness.elaborate()
+  test_harness.apply( DefaultPassGroup() )
+  test_harness.sim_reset()
+
+  # Run simulation
+  ncycles = 0
+  print()
+  print( "{}:{}".format( ncycles, test_harness.line_trace() ))
+  while not test_harness.done() and ncycles < max_cycles:
+    test_harness.sim_tick()
+    ncycles += 1
+    print( "{}:{}".format( ncycles, test_harness.line_trace() ))
+
+  # Check timeout
+  assert ncycles < max_cycles
+
+  test_harness.sim_tick()
+  test_harness.sim_tick()
+  test_harness.sim_tick()
+
+def test_alu():
+  FU            = AdderCL
+  DataType      = mk_data( 16, 1 )
+  PredicateType = mk_predicate( 1, 1 )
+  ConfigType    = mk_ctrl()
+  data_mem_size = 8
+  num_inports   = 2
+  num_outports  = 1
+  latency       = 4
+  FuInType      = mk_bits( clog2( num_inports + 1 ) )
+  pickRegister  = [ FuInType( x+1 ) for x in range( num_inports ) ]
+  src_in0       = [ DataType(1, 1), DataType(7, 1), DataType(4, 1) ]
+  src_in1       = [ DataType(2, 1), DataType(3, 1), DataType(1, 1) ]
+  src_predicate = [ PredicateType(1, 0), PredicateType(1, 0), PredicateType(1, 1) ]
+  src_const     = [ DataType(5, 1), DataType(0, 0), DataType(7, 1) ]
+  sink_out      = [ DataType(6, 0), DataType(4, 0), DataType(11, 1) ]
+  src_opt       = [ ConfigType( OPT_ADD_CONST, b1( 1 ), pickRegister ),
+                    ConfigType( OPT_SUB,       b1( 1 ), pickRegister ),
+                    ConfigType( OPT_ADD_CONST, b1( 1 ), pickRegister ) ]
+  th = TestHarness( FU, DataType, PredicateType, ConfigType,
+                    num_inports, num_outports, data_mem_size,
+                    src_in0, src_in1, src_predicate, src_const, src_opt,
+                    sink_out, latency )
+  run_sim( th )
+

--- a/fu/single/test/AdderRTL_test.py
+++ b/fu/single/test/AdderRTL_test.py
@@ -1,0 +1,103 @@
+"""
+==========================================================================
+AluRTL_test.py
+==========================================================================
+Test cases for all functional units.
+
+Author : Cheng Tan
+  Date : November 27, 2019
+
+"""
+
+from pymtl3                       import *
+from ....lib.test_sinks           import TestSinkRTL
+from ....lib.test_srcs            import TestSrcRTL
+
+from ..AdderRTL                   import AdderRTL
+from ....mem.const.ConstQueueRTL  import ConstQueueRTL
+from ....lib.opt_type             import *
+from ....lib.messages             import *
+
+#-------------------------------------------------------------------------
+# Test harness
+#-------------------------------------------------------------------------
+
+class TestHarness( Component ):
+
+  def construct( s, FunctionUnit, DataType, PredicateType, ConfigType,
+                 num_inports, num_outports, data_mem_size,
+                 src0_msgs, src1_msgs, src2_msgs, src_const,
+                 ctrl_msgs, sink_msgs ):
+
+    s.src_in0       = TestSrcRTL( DataType,      src0_msgs )
+    s.src_in1       = TestSrcRTL( DataType,      src1_msgs )
+    s.src_predicate = TestSrcRTL( PredicateType, src2_msgs )
+    s.src_opt       = TestSrcRTL( ConfigType,    ctrl_msgs )
+    s.sink_out      = TestSinkRTL( DataType,      sink_msgs )
+
+    s.const_queue = ConstQueueRTL( DataType, src_const )
+    s.dut = FunctionUnit( DataType, PredicateType, ConfigType,
+                          num_inports, num_outports, data_mem_size )
+
+    for i in range( num_inports ):
+      s.dut.recv_in_count[i] //= 1
+
+    connect( s.src_in0.send,       s.dut.recv_in[0]         )
+    connect( s.src_in1.send,       s.dut.recv_in[1]         )
+    connect( s.src_predicate.send, s.dut.recv_predicate     )
+    connect( s.dut.recv_const,     s.const_queue.send_const )
+    connect( s.src_opt.send,       s.dut.recv_opt           )
+    connect( s.dut.send_out[0],    s.sink_out.recv          )
+
+  def done( s ):
+    return s.src_in0.done() and s.src_in1.done() and\
+           s.src_opt.done() and s.sink_out.done()
+
+  def line_trace( s ):
+    return s.dut.line_trace()
+
+def run_sim( test_harness, max_cycles=100 ):
+  test_harness.elaborate()
+  test_harness.apply( DefaultPassGroup() )
+  test_harness.sim_reset()
+
+  # Run simulation
+  ncycles = 0
+  print()
+  print( "{}:{}".format( ncycles, test_harness.line_trace() ))
+  while not test_harness.done() and ncycles < max_cycles:
+    test_harness.sim_tick()
+    ncycles += 1
+    print( "{}:{}".format( ncycles, test_harness.line_trace() ))
+
+  # Check timeout
+  assert ncycles < max_cycles
+
+  test_harness.sim_tick()
+  test_harness.sim_tick()
+  test_harness.sim_tick()
+
+def test_alu():
+  FU            = AdderRTL
+  DataType      = mk_data( 16, 1 )
+  PredicateType = mk_predicate( 1, 1 )
+  ConfigType    = mk_ctrl()
+  data_mem_size = 8
+  num_inports   = 2
+  num_outports  = 1
+  FuInType      = mk_bits( clog2( num_inports + 1 ) )
+  pickRegister  = [ FuInType( x+1 ) for x in range( num_inports ) ]
+  src_in0       = [ DataType(1, 1), DataType(7, 1), DataType(4, 1) ]
+  src_in1       = [ DataType(2, 1), DataType(3, 1), DataType(1, 1) ]
+  src_predicate = [ PredicateType(1, 0), PredicateType(1, 0), PredicateType(1, 1) ]
+  src_const     = [ DataType(5, 1), DataType(0, 0), DataType(7, 1) ]
+  sink_out      = [ DataType(6, 0), DataType(4, 0), DataType(11, 1) ]
+  src_opt       = [ ConfigType( OPT_ADD_CONST, b1( 1 ), pickRegister ),
+                    ConfigType( OPT_SUB,       b1( 1 ), pickRegister ),
+                    ConfigType( OPT_ADD_CONST, b1( 1 ), pickRegister ) ]
+  th = TestHarness( FU, DataType, PredicateType, ConfigType,
+                    num_inports, num_outports, data_mem_size,
+                    src_in0, src_in1, src_predicate, src_const, src_opt,
+                    sink_out )
+  run_sim( th )
+

--- a/mem/ctrl/CtrlMemRTL.py
+++ b/mem/ctrl/CtrlMemRTL.py
@@ -49,7 +49,9 @@ class CtrlMemRTL( Component ):
 
     @update
     def update_signal():
-      if (total_ctrl_steps > 0 and s.times == TimeType( total_ctrl_steps )) | (s.reg_file.rdata[0].ctrl == OPT_START):
+      if ( ( total_ctrl_steps > 0 ) & \
+           ( s.times == TimeType( total_ctrl_steps ) ) ) | \
+         (s.reg_file.rdata[0].ctrl == OPT_START):
         s.send_ctrl.en @= b1( 0 )
       else:
         s.send_ctrl.en @= s.send_ctrl.rdy # s.recv_raddr[i].rdy
@@ -59,11 +61,13 @@ class CtrlMemRTL( Component ):
     @update_ff
     def update_raddr():
       if s.reg_file.rdata[0].ctrl != OPT_START:
-        if total_ctrl_steps == 0 or s.times < TimeType( total_ctrl_steps ):
+        if ( total_ctrl_steps == 0 ) | \
+           ( s.times < TimeType( total_ctrl_steps ) ):
           s.times <<= s.times + TimeType( 1 )
         # Reads the next ctrl signal only when the current one is done.
         if s.send_ctrl.rdy:
-          if zext(s.reg_file.raddr[0] + 1, PCType) == PCType( ctrl_count_per_iter ):
+          if zext(s.reg_file.raddr[0] + 1, PCType) == \
+             PCType( ctrl_count_per_iter ):
             s.reg_file.raddr[0] <<= AddrType( 0 )
           else:
             s.reg_file.raddr[0] <<= s.reg_file.raddr[0] + AddrType( 1 )

--- a/mem/ctrl/CtrlMemRTL.py
+++ b/mem/ctrl/CtrlMemRTL.py
@@ -17,12 +17,19 @@ from ...lib.opt_type import *
 
 class CtrlMemRTL( Component ):
 
-  def construct( s, CtrlType, ctrl_mem_size, num_ctrl=4 ):
+  def construct( s, CtrlType, ctrl_mem_size, ctrl_count_per_iter = 4,
+                 total_ctrl_steps = 4 ):
+
+    # The total_ctrl_steps indicates the number of steps the ctrl
+    # signals should proceed. For example, if the number of ctrl
+    # signals is 4 and they need to repeat 5 times, then the total
+    # number of steps should be 4 * 5 = 20.
+    # assert( ctrl_mem_size <= total_ctrl_steps )
 
     # Constant
-    # assert( ctrl_mem_size <= num_ctrl )
     AddrType = mk_bits( clog2( ctrl_mem_size ) )
-    TimeType = mk_bits( clog2( num_ctrl+1 ) )
+    PCType   = mk_bits( clog2( ctrl_count_per_iter + 1 ) )
+    TimeType = mk_bits( clog2( total_ctrl_steps + 1 ) )
     last_item = AddrType( ctrl_mem_size - 1 )
 
     # Interface
@@ -42,7 +49,7 @@ class CtrlMemRTL( Component ):
 
     @update
     def update_signal():
-      if (s.times == TimeType( num_ctrl )) | (s.reg_file.rdata[0].ctrl == OPT_START):
+      if (total_ctrl_steps > 0 and s.times == TimeType( total_ctrl_steps )) | (s.reg_file.rdata[0].ctrl == OPT_START):
         s.send_ctrl.en @= b1( 0 )
       else:
         s.send_ctrl.en @= s.send_ctrl.rdy # s.recv_raddr[i].rdy
@@ -52,12 +59,14 @@ class CtrlMemRTL( Component ):
     @update_ff
     def update_raddr():
       if s.reg_file.rdata[0].ctrl != OPT_START:
-        if s.times < TimeType( num_ctrl ):
+        if total_ctrl_steps == 0 or s.times < TimeType( total_ctrl_steps ):
           s.times <<= s.times + TimeType( 1 )
-        if s.reg_file.raddr[0] < last_item:
-          s.reg_file.raddr[0] <<= s.reg_file.raddr[0] + AddrType( 1 )
-        else:
-          s.reg_file.raddr[0] <<= AddrType( 0 )
+        # Reads the next ctrl signal only when the current one is done.
+        if s.send_ctrl.rdy:
+          if zext(s.reg_file.raddr[0] + 1, PCType) == PCType( ctrl_count_per_iter ):
+            s.reg_file.raddr[0] <<= AddrType( 0 )
+          else:
+            s.reg_file.raddr[0] <<= s.reg_file.raddr[0] + AddrType( 1 )
 
   def line_trace( s ):
     out_str  = "||".join([ str(data) for data in s.reg_file.regs ])

--- a/systolic/SystolicCL.py
+++ b/systolic/SystolicCL.py
@@ -19,7 +19,8 @@ class SystolicCL( Component ):
 
   def construct( s, FunctionUnit, FuList, DataType, PredicateType,
                  CtrlType, width, height, ctrl_mem_size, data_mem_size,
-                 num_ctrl, preload_ctrl, preload_data, preload_const ):
+                 num_ctrl, total_steps, preload_ctrl, preload_data,
+                 preload_const ):
 
     # Constant
     NORTH = 0
@@ -35,7 +36,7 @@ class SystolicCL( Component ):
     # Components
     s.tile = [ TileCL( FunctionUnit, FuList, DataType, PredicateType,
                        CtrlType, ctrl_mem_size, data_mem_size, num_ctrl,
-                       preload_const[i], preload_ctrl[i] )
+                       total_steps, preload_const[i], preload_ctrl[i] )
                        for i in range( s.num_tiles ) ]
     s.data_mem = DataMemCL( DataType, data_mem_size, height, height,
                             preload_data )

--- a/systolic/test/SystolicCL_test.py
+++ b/systolic/test/SystolicCL_test.py
@@ -42,8 +42,9 @@ class TestHarness( Component ):
                   for i in range( height-1 ) ]
 
     s.dut = DUT( FunctionUnit, FuList, DataType, PredicateType, CtrlType,
-                 width, height, ctrl_mem_size, data_mem_size, ctrl_mem_size,
-                 src_opt, preload_data, preload_const )
+                 width, height, ctrl_mem_size, data_mem_size,
+                 len( src_opt[0] ), 0, src_opt,
+                 preload_data, preload_const )
 
     for i in range( height-1 ):
       connect( s.dut.send_data[i],  s.sink_out[i].recv )

--- a/tile/TileCL.py
+++ b/tile/TileCL.py
@@ -20,7 +20,7 @@ from ..rf.RegisterRTL            import RegisterRTL
 class TileCL( Component ):
 
   def construct( s, Fu, FuList, DataType, PredicateType, CtrlType,
-                 ctrl_mem_size, data_mem_size, num_ctrl,
+                 ctrl_mem_size, data_mem_size, num_ctrl, total_steps,
                  const_list, opt_list, id=0 ):
 
     # Constant
@@ -49,7 +49,8 @@ class TileCL( Component ):
     s.const_queue = ConstQueueRTL( DataType, const_list )
     s.crossbar    = CrossbarRTL( DataType, PredicateType, CtrlType, num_xbar_inports,
                                  num_xbar_outports, bypass_point, id )
-    s.ctrl_mem    = CtrlMemCL( CtrlType, ctrl_mem_size, num_ctrl, opt_list, id )
+    s.ctrl_mem    = CtrlMemCL( CtrlType, ctrl_mem_size, num_ctrl, total_steps,
+                               opt_list, id )
     s.channel     = [ ChannelRTL ( DataType ) for _ in range( num_xbar_outports ) ]
 
     # Additional one register for partial predication

--- a/tile/TileRTL.py
+++ b/tile/TileRTL.py
@@ -26,7 +26,7 @@ class TileRTL( Component ):
 
   def construct( s, DataType, PredicateType, CtrlType,
                  ctrl_mem_size, data_mem_size, num_ctrl,
-                 num_fu_inports, num_fu_outports,
+                 total_steps, num_fu_inports, num_fu_outports,
                  num_connect_inports, num_connect_outports,
                  Fu=FlexibleFuRTL,
                  FuList=[PhiRTL,AdderRTL,CompRTL,MulRTL,BranchRTL,MemUnitRTL],
@@ -60,7 +60,7 @@ class TileRTL( Component ):
     s.const_queue = ConstQueueRTL( DataType, const_list if const_list != None else [DataType(0)])
     s.crossbar = CrossbarRTL( DataType, PredicateType, CtrlType,
                               num_xbar_inports, num_xbar_outports )
-    s.ctrl_mem = CtrlMemRTL( CtrlType, ctrl_mem_size, num_ctrl )
+    s.ctrl_mem = CtrlMemRTL( CtrlType, ctrl_mem_size, num_ctrl, total_steps )
     s.channel  = [ ChannelRTL( DataType ) for _ in range( num_xbar_outports ) ]
 
     # Additional one register for partial predication

--- a/tile/test/TileCL_test.py
+++ b/tile/test/TileCL_test.py
@@ -44,8 +44,8 @@ class TestHarness( Component ):
                   for i in range( num_tile_outports ) ]
 
     s.dut = DUT( FunctionUnit, FuList, DataType, PredicateType, CtrlType,
-                 ctrl_mem_size, data_mem_size, len(src_opt), src_const,
-                 src_opt )
+                 ctrl_mem_size, data_mem_size, len(src_opt), len(src_opt),
+                 src_const, src_opt )
 
     for i in range( num_tile_inports ):
       connect( s.src_data[i].send, s.dut.recv_data[i] )
@@ -85,7 +85,7 @@ def run_sim( test_harness, max_cycles=100 ):
     print( "{}:{}".format( ncycles, test_harness.line_trace() ))
 
   # Check timeout
-  assert ncycles < max_cycles
+  assert ncycles <= max_cycles
 
   test_harness.sim_tick()
   test_harness.sim_tick()

--- a/tile/test/TileRTL_test.py
+++ b/tile/test/TileRTL_test.py
@@ -53,8 +53,8 @@ class TestHarness( Component ):
 
     s.dut           = DUT( DataType, PredicateType, CtrlType,
                            ctrl_mem_size, data_mem_size, len(src_opt),
-                           num_fu_inports, num_fu_outports, 4, 4,
-                           FunctionUnit, FuList )
+                           len(src_opt), num_fu_inports, num_fu_outports,
+                           4, 4, FunctionUnit, FuList )
 
     # connect( s.src_predicate.send, s.dut.reg_predicate )
     connect( s.src_opt.send,       s.dut.recv_wopt     )

--- a/tile/translate/TileRTL_test.py
+++ b/tile/translate/TileRTL_test.py
@@ -62,8 +62,8 @@ src_opt       = [ CtrlType( OPT_NAH, b1( 0 ), pickRegister, [
 
 def test_elaborate():
   dut = TileRTL( DataType, PredicateType, CtrlType, ctrl_mem_size,
-                 data_mem_size, len(src_opt), num_fu_inports,
-                 num_fu_outports, 4, 4, FunctionUnit, FuList )
+                 data_mem_size, len( src_opt ), len( src_opt ),
+                 num_fu_inports, num_fu_outports, 4, 4, FunctionUnit, FuList )
   dut.apply( DefaultPassGroup(linetrace=True) )
   dut.sim_reset()
   dut.sim_tick()
@@ -72,8 +72,9 @@ def test_elaborate():
 # TODO: fix import by either suppressing warnings or address them
 def test_translate( cmdline_opts ):
   dut = TileRTL( DataType, PredicateType, CtrlType, ctrl_mem_size,
-                 data_mem_size, len(src_opt), num_fu_inports,
-                 num_fu_outports, 4, 4, FunctionUnit, FuList )
+                 data_mem_size, len( src_opt ), len( src_opt ),
+                 num_fu_inports, num_fu_outports, 4, 4,
+                 FunctionUnit, FuList )
   dut.set_metadata( VerilogTranslationPass.explicit_module_name,
                     f'TileRTL' )
   config_model_with_cmdline_opts( dut, cmdline_opts, duts=[] )

--- a/tile/translate/TileVectorRTL_test.py
+++ b/tile/translate/TileVectorRTL_test.py
@@ -68,8 +68,9 @@ src_opt       = [ CtrlType( OPT_NAH, b1( 0 ), pickRegister, [
 
 def test_elaborate():
   dut = TileRTL( DataType, PredicateType, CtrlType, ctrl_mem_size,
-                 data_mem_size, len(src_opt), num_fu_inports,
-                 num_fu_outports, 4, 4, FunctionUnit, FuList )
+                 data_mem_size, len( src_opt ), len( src_opt ),
+                 num_fu_inports, num_fu_outports, 4, 4,
+                 FunctionUnit, FuList )
   dut.apply( DefaultPassGroup(linetrace=True) )
   dut.sim_reset()
   dut.sim_tick()
@@ -78,8 +79,9 @@ def test_elaborate():
 # TODO: fix import by either suppressing warnings or address them
 def test_translate( cmdline_opts ):
   dut = TileRTL( DataType, PredicateType, CtrlType, ctrl_mem_size,
-                       data_mem_size, len(src_opt), num_fu_inports,
-                       num_fu_outports, 4, 4, FunctionUnit, FuList )
+                 data_mem_size, len(src_opt), len(src_opt),
+                 num_fu_inports, num_fu_outports, 4, 4,
+                 FunctionUnit, FuList )
   dut.set_metadata( VerilogTranslationPass.explicit_module_name,
                     f'TileVectorRTL' )
   config_model_with_cmdline_opts( dut, cmdline_opts, duts=[] )


### PR DESCRIPTION
Enable ctrl signal proceed based on whether the current one is consumed rather than per-cycle proceeding. This provides the infrastructure for variant latency functional units (e.g., multi-cycle computation, DVFS-enabled FUs, and not fixed load/store from cache).

Might need to check whether this introduces combinational loops.