### PR TITLE
19 question about runing the example test

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ models into C++ simulators. VectorCGRA uses Verilator for Verilog import.
  $ sudo make install
 ```
 
+> If there's exception when make, can try with `apt-get install verilator` directly. (https://verilator.org/guide/latest/install.html)
+
  [4]: http://www.veripool.org/wiki/verilator
 
 ### Install git, Python headers, and libffi
@@ -93,6 +95,18 @@ commands will create and activate the virtual environment:
  % pip install hypothesis
  % pip list
 ```
+
+> If you are using Python 3.12, please install `pip install -U git+https://github.com/pymtl/pymtl3@pymtl4.0-dev` and checkout py312-dev branch, difference is:
+```python
+th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
+run_sim( th )
+```
+to
+```python
+# th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
+run_sim( th, cmdline_opts, duts=['dut'] )
+```
+
 Take a look at the [workflow](https://github.com/tancheng/VectorCGRA/blob/master/.github/workflows/python-package.yml) if you encounter any problem to run the test in this repo.
 
 ### Clone VectorCGRA repo

--- a/cgra/test/CGRAKingMeshRTL_test.py
+++ b/cgra/test/CGRAKingMeshRTL_test.py
@@ -116,8 +116,8 @@ def test_homo_2x2( cmdline_opts ):
   th.dut.set_metadata( VerilogVerilatorImportPass.vl_Wno_list,
                     ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
                      'ALWCOMBORDER'] )
-  th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
-  run_sim( th )
+  # th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
+  run_sim( th, cmdline_opts, duts=['dut'] )
 
 def test_hetero_2x2( cmdline_opts ):
   num_tile_inports  = 8
@@ -176,6 +176,6 @@ def test_hetero_2x2( cmdline_opts ):
                     ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
                      'ALWCOMBORDER'] )
   #th.set_param("top.dut.tile[1].construct", FuList=[MemUnitRTL,ShifterRTL])
-  th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
-  run_sim( th )
+  # th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
+  run_sim( th, cmdline_opts, duts=['dut'] )
 

--- a/cgra/test/CGRARTL_FIR_demo_test.py
+++ b/cgra/test/CGRARTL_FIR_demo_test.py
@@ -150,8 +150,8 @@ def test_homo_4x4( cmdline_opts ):
   th.dut.set_metadata( VerilogVerilatorImportPass.vl_Wno_list,
                     ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
                      'ALWCOMBORDER'] )
-  th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
-  run_sim( th )
+  # th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
+  run_sim( th, cmdline_opts, duts=['dut'] )
 
   reference = run_CGRAFL()[0]
 

--- a/cgra/test/CGRARTL_test.py
+++ b/cgra/test/CGRARTL_test.py
@@ -110,8 +110,8 @@ def test_homo_2x2( cmdline_opts ):
   th.dut.set_metadata( VerilogVerilatorImportPass.vl_Wno_list,
                     ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
                      'ALWCOMBORDER'] )
-  th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
-  run_sim( th )
+  # th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
+  run_sim( th, cmdline_opts, duts=['dut'] )
 
 def test_hetero_2x2( cmdline_opts ):
   num_tile_inports  = 4
@@ -163,7 +163,7 @@ def test_hetero_2x2( cmdline_opts ):
   th.dut.set_metadata( VerilogVerilatorImportPass.vl_Wno_list,
                     ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
                      'ALWCOMBORDER'] )
-  th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
+  # th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
   #th.set_param("top.dut.tile[1].construct", FuList=[MemUnitRTL,ShifterRTL])
-  run_sim( th )
+  run_sim( th, cmdline_opts, duts=['dut'] )
 

--- a/cgra/test/CGRASeparateCrossbarRTL_test.py
+++ b/cgra/test/CGRASeparateCrossbarRTL_test.py
@@ -143,8 +143,8 @@ def test_homo_2x2(cmdline_opts):
   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
                        'ALWCOMBORDER'])
-  th = config_model_with_cmdline_opts(th, cmdline_opts, duts=['dut'])
-  run_sim(th)
+  # th = config_model_with_cmdline_opts(th, cmdline_opts, duts=['dut'])
+  run_sim(th, cmdline_opts, duts=['dut'])
 
 def test_hetero_2x2(cmdline_opts):
   num_tile_inports  = 4
@@ -232,7 +232,7 @@ def test_hetero_2x2(cmdline_opts):
   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
                        'ALWCOMBORDER'])
-  th = config_model_with_cmdline_opts(th, cmdline_opts, duts=['dut'])
+  # th = config_model_with_cmdline_opts(th, cmdline_opts, duts=['dut'])
   #th.set_param("top.dut.tile[1].construct", FuList=[MemUnitRTL,ShifterRTL])
-  run_sim(th)
+  run_sim(th, cmdline_opts, duts=['dut'])
 

--- a/cgra/test/CGRAWithControllerRTL_test.py
+++ b/cgra/test/CGRAWithControllerRTL_test.py
@@ -151,6 +151,6 @@ def test_homo_2x2(cmdline_opts):
   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
                        'ALWCOMBORDER'])
-  th = config_model_with_cmdline_opts(th, cmdline_opts, duts=['dut'])
-  run_sim(th)
+  # th = config_model_with_cmdline_opts(th, cmdline_opts, duts=['dut'])
+  run_sim(th, cmdline_opts, duts=['dut'])
 

--- a/cgra/test/CGRA_custom_test.py
+++ b/cgra/test/CGRA_custom_test.py
@@ -122,8 +122,8 @@ def test_homo_2x2( cmdline_opts ):
   th.dut.set_metadata( VerilogVerilatorImportPass.vl_Wno_list,
                     ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
                      'ALWCOMBORDER'] )
-  th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
-  run_sim( th )
+  # th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
+  run_sim( th, cmdline_opts, duts=['dut'] )
 
 def test_hetero_2x2( cmdline_opts ):
   num_tile_inports  = 8
@@ -185,6 +185,6 @@ def test_hetero_2x2( cmdline_opts ):
                     ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
                      'ALWCOMBORDER'] )
   #th.set_param("top.dut.tile[1].construct", FuList=[MemUnitRTL,ShifterRTL])
-  th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
-  run_sim( th )
+  # th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
+  run_sim( th, cmdline_opts, duts=['dut'] )
 

--- a/cgra/test/VectorCGRAKingMeshRTL_test.py
+++ b/cgra/test/VectorCGRAKingMeshRTL_test.py
@@ -125,6 +125,6 @@ def test_homo_4x4( cmdline_opts ):
   # th.dut.set_metadata( VerilogVerilatorImportPass.vl_Wno_list,
   #                   ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
   #                    'ALWCOMBORDER'] )
-  th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
-  run_sim( th )
+  # th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
+  run_sim( th, cmdline_opts, duts=['dut'] )
 

--- a/cgra/translate/CGRAMemBottomRTL_matmul_2x2_test.py
+++ b/cgra/translate/CGRAMemBottomRTL_matmul_2x2_test.py
@@ -305,7 +305,7 @@ def test_CGRA_systolic(cmdline_opts):
   # th.dut.set_metadata( VerilogVerilatorImportPass.vl_Wno_list,
   #                   ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
   #                    'ALWCOMBORDER'] )
-  th = config_model_with_cmdline_opts(th, cmdline_opts, duts=['dut'])
+  # th = config_model_with_cmdline_opts(th, cmdline_opts, duts=['dut'])
 
-  run_sim(th)
+  run_sim(th, cmdline_opts, duts=['dut'])
 

--- a/cgra/translate/CGRASeparateCrossbarRTL_test.py
+++ b/cgra/translate/CGRASeparateCrossbarRTL_test.py
@@ -143,6 +143,6 @@ def test_homo_2x2(cmdline_opts):
   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
                        'ALWCOMBORDER'])
-  th = config_model_with_cmdline_opts(th, cmdline_opts, duts=['dut'])
-  run_sim(th)
+  # th = config_model_with_cmdline_opts(th, cmdline_opts, duts=['dut'])
+  run_sim(th, cmdline_opts, duts=['dut'])
 

--- a/cgra/translate/CGRATemplateRTL_test.py
+++ b/cgra/translate/CGRATemplateRTL_test.py
@@ -360,7 +360,7 @@ def test_cgra_universal( cmdline_opts, paramCGRA = None):
   th.dut.set_metadata( VerilogVerilatorImportPass.vl_Wno_list,
                     ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
                      'ALWCOMBORDER'] )
-  th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
+  # th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
 
   if paramCGRA != None:
     for tile in tiles:
@@ -371,4 +371,4 @@ def test_cgra_universal( cmdline_opts, paramCGRA = None):
             targetTile = "top.dut.tile[" + str(tile.getIndex(tiles)) + "].construct"
             th.set_param(targetTile, FuList=targetFuList)
 
-  run_sim( th )
+  run_sim( th, cmdline_opts, duts=['dut'] )

--- a/cgra/translate/CGRAWithControllerRTL_test.py
+++ b/cgra/translate/CGRAWithControllerRTL_test.py
@@ -151,6 +151,6 @@ def test_homo_2x2(cmdline_opts):
   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
                        'ALWCOMBORDER'])
-  th = config_model_with_cmdline_opts(th, cmdline_opts, duts=['dut'])
-  run_sim(th)
+  # th = config_model_with_cmdline_opts(th, cmdline_opts, duts=['dut'])
+  run_sim(th, cmdline_opts, duts=['dut'])
 

--- a/cgra/translate/VectorCGRAKingMeshRTL_test.py
+++ b/cgra/translate/VectorCGRAKingMeshRTL_test.py
@@ -138,7 +138,7 @@ def test_homo_4x4( cmdline_opts ):
   # th.dut.set_metadata( VerilogVerilatorImportPass.vl_Wno_list,
   #                   ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
   #                    'ALWCOMBORDER'] )
-  th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
+  # th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
 
-  run_sim( th )
+  run_sim( th, cmdline_opts, duts=['dut'] )
 

--- a/scale_out/test/RingMultiCGRARTL_test.py
+++ b/scale_out/test/RingMultiCGRARTL_test.py
@@ -161,6 +161,6 @@ def test_homo_2x2(cmdline_opts):
   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
                        'ALWCOMBORDER'])
-  th = config_model_with_cmdline_opts(th, cmdline_opts, duts=['dut'])
-  run_sim(th)
+  # th = config_model_with_cmdline_opts(th, cmdline_opts, duts=['dut'])
+  run_sim(th, cmdline_opts, duts=['dut'])
 

--- a/scale_out/translate/RingMultiCGRARTL_test.py
+++ b/scale_out/translate/RingMultiCGRARTL_test.py
@@ -161,6 +161,6 @@ def test_homo_2x2(cmdline_opts):
   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
                        'ALWCOMBORDER'])
-  th = config_model_with_cmdline_opts(th, cmdline_opts, duts=['dut'])
-  run_sim(th)
+  # th = config_model_with_cmdline_opts(th, cmdline_opts, duts=['dut'])
+  run_sim(th, cmdline_opts, duts=['dut'])
 

--- a/tile/test/TileRTL_test.py
+++ b/tile/test/TileRTL_test.py
@@ -151,6 +151,6 @@ def test_tile_alu( cmdline_opts ):
   th.dut.set_metadata( VerilogVerilatorImportPass.vl_Wno_list,
                     ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
                      'ALWCOMBORDER'] )
-  th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
-  run_sim( th )
+  # th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
+  run_sim( th, cmdline_opts, duts=['dut'] )
 

--- a/tile/test/TileSeparateCrossbarRTL_test.py
+++ b/tile/test/TileSeparateCrossbarRTL_test.py
@@ -150,6 +150,6 @@ def test_tile_alu(cmdline_opts):
   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
                        'ALWCOMBORDER'])
-  th = config_model_with_cmdline_opts(th, cmdline_opts, duts=['dut'])
-  run_sim(th)
+  # th = config_model_with_cmdline_opts(th, cmdline_opts, duts=['dut'])
+  run_sim(th, cmdline_opts, duts=['dut'])
 


### PR DESCRIPTION
I reproduced [issue19](https://github.com/tancheng/VectorCGRA/issues/19) with Python3.12, two actions are required to fix issue. As Python version upgrade may impact other repos, so I PR to a new branch py312-dev first, need confirm with you if all good to merge to master.

Changes:
1. pymtl version (refer to https://github.com/pymtl/pymtl3/issues/283)
`pip install -U git+[https://github.com/pymtl/pymtl3@](https://github.com/tancheng/pymtl3.1@yo-struct-list-fix)pymtl4.0-dev`
2. Remove explicit invoke config_model_with_cmdline_opts, it is contained in run_sim now
```
# th = config_model_with_cmdline_opts( th, cmdline_opts, duts=['dut'] )
run_sim( th, cmdline_opts, duts=['dut'] )
```

Above are updated in readme also.