### PR TITLE
Enable Py3.9 and Py3.12

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7.13"]
+        python-version: ["3.7.13", "3.9.21", "3.12.8"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7.13", "3.9.21", "3.12.8"]
+        python-version: ["3.7.13", "3.9.20", "3.12.8"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
All Py3.7, Py3.9 and Py3.12 work after [Fix issue with pytest_cmdline_preparse #1](https://github.com/tancheng/pymtl3.1/pull/1)