### PR TITLE
Resolve combinational loops

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -72,6 +72,7 @@ class CgraRTL(Component):
                       data_mem_size_global, num_ctrl,
                       total_steps, 4, 2, s.num_mesh_ports,
                       s.num_mesh_ports,
+                      FuList = FuList,
                       const_list = preload_const[i])
               for i in range(s.num_tiles)]
     s.data_mem = DataMemWithCrossbarRTL(NocPktType, DataType,

--- a/cgra/CgraTemplateRTL.py
+++ b/cgra/CgraTemplateRTL.py
@@ -66,6 +66,7 @@ class CgraTemplateRTL(Component):
                       data_mem_size_global, num_ctrl,
                       total_steps, 4, 2, s.num_mesh_ports,
                       s.num_mesh_ports,
+                      FuList = FuList,
                       const_list = preload_const[i])
               for i in range(s.num_tiles)]
     # FIXME: Need to enrish data-SPM-related user-controlled parameters, e.g., number of banks.

--- a/cgra/test/CgraRTL_test.py
+++ b/cgra/test/CgraRTL_test.py
@@ -230,35 +230,35 @@ def test_homogeneous_2x2(cmdline_opts):
   th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
   run_sim(th)
 
-# def test_heterogeneous_king_mesh_2x2(cmdline_opts):
-#   topology = "KingMesh"
-#   th = init_param(topology)
-#   th.set_param("top.dut.tile[1].construct", FuList=[ShifterRTL])
-#   th.elaborate()
-#   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
-#                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
-#                        'ALWCOMBORDER'])
-#   th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
-#   run_sim(th)
-#
-# def test_vector_king_mesh_2x2(cmdline_opts):
-#   topology = "KingMesh"
-#   FuList = [AdderRTL,
-#             MulRTL,
-#             LogicRTL,
-#             ShifterRTL,
-#             PhiRTL,
-#             CompRTL,
-#             BranchRTL,
-#             MemUnitRTL,
-#             SelRTL,
-#             VectorMulComboRTL,
-#             VectorAdderComboRTL]
-#   th = init_param(topology, FuList)
-#   th.elaborate()
-#   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
-#                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
-#                        'ALWCOMBORDER'])
-#   th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
-#   run_sim(th)
+def test_heterogeneous_king_mesh_2x2(cmdline_opts):
+  topology = "KingMesh"
+  th = init_param(topology)
+  th.set_param("top.dut.tile[1].construct", FuList=[ShifterRTL])
+  th.elaborate()
+  th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
+                      ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
+                       'ALWCOMBORDER'])
+  th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
+  run_sim(th)
+
+def test_vector_king_mesh_2x2(cmdline_opts):
+  topology = "KingMesh"
+  FuList = [AdderRTL,
+            MulRTL,
+            LogicRTL,
+            ShifterRTL,
+            PhiRTL,
+            CompRTL,
+            BranchRTL,
+            MemUnitRTL,
+            SelRTL,
+            VectorMulComboRTL,
+            VectorAdderComboRTL]
+  th = init_param(topology, FuList)
+  th.elaborate()
+  th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
+                      ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
+                       'ALWCOMBORDER'])
+  th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
+  run_sim(th)
 

--- a/cgra/test/CgraRTL_test.py
+++ b/cgra/test/CgraRTL_test.py
@@ -24,6 +24,7 @@ from ...fu.single.MemUnitRTL import MemUnitRTL
 from ...fu.single.MulRTL import MulRTL
 from ...fu.single.PhiRTL import PhiRTL
 from ...fu.single.SelRTL import SelRTL
+from ...fu.single.RetRTL import RetRTL
 from ...fu.single.ShifterRTL import ShifterRTL
 from ...fu.vector.VectorMulComboRTL import VectorMulComboRTL
 from ...fu.vector.VectorAdderComboRTL import VectorAdderComboRTL
@@ -208,7 +209,18 @@ def init_param(topology, FuList = [MemUnitRTL, AdderRTL]):
 
 def test_homogeneous_2x2(cmdline_opts):
   topology = "Mesh"
-  FuList = [AdderRTL, MemUnitRTL]
+  # FuList = [AdderRTL, MemUnitRTL]
+  FuList = [AdderRTL,
+            MulRTL,
+            LogicRTL,
+            ShifterRTL,
+            PhiRTL,
+            CompRTL,
+            BranchRTL,
+            MemUnitRTL,
+            SelRTL,
+            RetRTL,
+           ]
   th = init_param(topology, FuList)
 
   th.elaborate()

--- a/cgra/test/CgraRTL_test.py
+++ b/cgra/test/CgraRTL_test.py
@@ -90,7 +90,7 @@ class TestHarness(Component):
   def line_trace(s):
     return s.dut.line_trace()
 
-def init_param(topology, FuList = [MemUnitRTL, AdderRTL]):
+def init_param(topology, FuList = [MemUnitRTL, AdderRTL], data_bitwidth = 32):
   tile_ports = 4
   assert(topology == "Mesh" or topology == "KingMesh")
   if topology == "Mesh":
@@ -120,7 +120,7 @@ def init_param(topology, FuList = [MemUnitRTL, AdderRTL]):
   num_tiles = width * height
   DUT = CgraRTL
   FunctionUnit = FlexibleFuRTL
-  DataType = mk_data(32, 1)
+  DataType = mk_data(data_bitwidth, 1)
   PredicateType = mk_predicate(1, 1)
   
   CmdType = mk_bits(4)
@@ -159,7 +159,7 @@ def init_param(topology, FuList = [MemUnitRTL, AdderRTL]):
   NocPktType = mk_multi_cgra_noc_pkt(ncols = num_terminals,
                                      nrows = 1,
                                      addr_nbits = addr_nbits,
-                                     data_nbits = 32,
+                                     data_nbits = data_bitwidth,
                                      predicate_nbits = 1)
   pick_register = [FuInType(x + 1) for x in range(num_fu_inports)]
   tile_in_code = [TileInType(max(4 - x, 0)) for x in range(num_routing_outports)]
@@ -254,7 +254,8 @@ def test_vector_king_mesh_2x2(cmdline_opts):
             SelRTL,
             VectorMulComboRTL,
             VectorAdderComboRTL]
-  th = init_param(topology, FuList)
+  data_bitwidth = 64
+  th = init_param(topology, FuList, data_bitwidth)
   th.elaborate()
   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',

--- a/cgra/test/CgraRTL_test.py
+++ b/cgra/test/CgraRTL_test.py
@@ -208,43 +208,45 @@ def init_param(topology, FuList = [MemUnitRTL, AdderRTL]):
 
 def test_homogeneous_2x2(cmdline_opts):
   topology = "Mesh"
-  th = init_param(topology)
-  th.elaborate()
-  th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
-                      ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
-                       'ALWCOMBORDER'])
-  th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
-  run_sim(th)
-
-def test_heterogeneous_king_mesh_2x2(cmdline_opts):
-  topology = "KingMesh"
-  th = init_param(topology)
-  th.set_param("top.dut.tile[1].construct", FuList=[ShifterRTL])
-  th.elaborate()
-  th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
-                      ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
-                       'ALWCOMBORDER'])
-  th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
-  run_sim(th)
-
-def test_vector_king_mesh_2x2(cmdline_opts):
-  topology = "KingMesh"
-  FuList = [AdderRTL,
-            MulRTL,
-            LogicRTL,
-            ShifterRTL,
-            PhiRTL,
-            CompRTL,
-            BranchRTL,
-            MemUnitRTL,
-            SelRTL,
-            VectorMulComboRTL,
-            VectorAdderComboRTL]
+  FuList = [AdderRTL, MemUnitRTL]
   th = init_param(topology, FuList)
+
   th.elaborate()
-  th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
-                      ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
-                       'ALWCOMBORDER'])
+  # th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
+  #                     ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
+  #                      'ALWCOMBORDER'])
   th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
   run_sim(th)
+
+# def test_heterogeneous_king_mesh_2x2(cmdline_opts):
+#   topology = "KingMesh"
+#   th = init_param(topology)
+#   th.set_param("top.dut.tile[1].construct", FuList=[ShifterRTL])
+#   th.elaborate()
+#   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
+#                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
+#                        'ALWCOMBORDER'])
+#   th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
+#   run_sim(th)
+#
+# def test_vector_king_mesh_2x2(cmdline_opts):
+#   topology = "KingMesh"
+#   FuList = [AdderRTL,
+#             MulRTL,
+#             LogicRTL,
+#             ShifterRTL,
+#             PhiRTL,
+#             CompRTL,
+#             BranchRTL,
+#             MemUnitRTL,
+#             SelRTL,
+#             VectorMulComboRTL,
+#             VectorAdderComboRTL]
+#   th = init_param(topology, FuList)
+#   th.elaborate()
+#   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
+#                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
+#                        'ALWCOMBORDER'])
+#   th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
+#   run_sim(th)
 

--- a/fu/single/AdderCL.py
+++ b/fu/single/AdderCL.py
@@ -59,7 +59,7 @@ class AdderCL(Fu):
       s.recv_predicate.rdy @= b1(0)
       s.recv_opt.rdy @= 0
 
-      if s.recv_opt.val & s.send_out[0].rdy:
+      if s.recv_opt.val:
         if s.recv_opt.msg.fu_in[0] != 0:
           s.in0 @= zext(s.recv_opt.msg.fu_in[0] - 1, FuInType)
         if s.recv_opt.msg.fu_in[1] != 0:
@@ -99,7 +99,7 @@ class AdderCL(Fu):
                                           s.recv_predicate.msg.predicate)
           s.recv_all_val @= s.recv_in[s.in0_idx].val & \
                             ((s.recv_opt.msg.predicate == b1(0)) | s.recv_predicate.val)
-          s.send_out[0].val @= s.recv_all_val & s.send_out[0].rdy
+          s.send_out[0].val @= s.recv_all_val
           s.recv_in[s.in0_idx].rdy @= s.recv_all_val & s.send_out[0].rdy
           s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
 
@@ -125,7 +125,7 @@ class AdderCL(Fu):
 
           s.recv_all_val @= s.recv_in[s.in0_idx].val & \
                             ((s.recv_opt.msg.predicate == b1(0)) | s.recv_predicate.val)
-          s.send_out[0].val @= s.recv_all_val & s.send_out[0].rdy
+          s.send_out[0].val @= s.recv_all_val
           s.recv_in[s.in0_idx].rdy @= s.recv_all_val & s.send_out[0].rdy
           s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
 

--- a/fu/single/AdderRTL.py
+++ b/fu/single/AdderRTL.py
@@ -58,7 +58,7 @@ class AdderRTL(Fu):
       # Though different operations might not need to consume
       # all the operands, as long as the opcode indicating it
       # is an operand, the data would disappear from the register.
-      if s.recv_opt.val & s.send_out[0].rdy:
+      if s.recv_opt.val:
         if s.recv_opt.msg.fu_in[0] != 0:
           s.in0 @= zext(s.recv_opt.msg.fu_in[0] - 1, FuInType)
         if s.recv_opt.msg.fu_in[1] != 0:
@@ -98,7 +98,7 @@ class AdderRTL(Fu):
                                           s.recv_predicate.msg.predicate)
           s.recv_all_val @= s.recv_in[s.in0_idx].val & \
                             ((s.recv_opt.msg.predicate == b1(0)) | s.recv_predicate.val)
-          s.send_out[0].val @= s.recv_all_val & s.send_out[0].rdy
+          s.send_out[0].val @= s.recv_all_val
           s.recv_in[s.in0_idx].rdy @= s.recv_all_val & s.send_out[0].rdy
           s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
 
@@ -122,7 +122,7 @@ class AdderRTL(Fu):
                                           s.recv_predicate.msg.predicate)
           s.recv_all_val @= s.recv_in[s.in0_idx].val & \
                             ((s.recv_opt.msg.predicate == b1(0)) | s.recv_predicate.val)
-          s.send_out[0].val @= s.recv_all_val & s.send_out[0].rdy
+          s.send_out[0].val @= s.recv_all_val
           s.recv_in[s.in0_idx].rdy @= s.recv_all_val & s.send_out[0].rdy
           s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
 

--- a/fu/single/BranchRTL.py
+++ b/fu/single/BranchRTL.py
@@ -53,7 +53,7 @@ class BranchRTL(Fu):
       s.recv_predicate.rdy @= b1(0)
       s.recv_opt.rdy @= 0
 
-      if s.recv_opt.val & s.send_out[0].rdy & s.send_out[1].rdy:
+      if s.recv_opt.val:
         if s.recv_opt.msg.fu_in[0] != FuInType(0):
           s.in0 @= s.recv_opt.msg.fu_in[0] - FuInType(1)
 

--- a/fu/single/CompRTL.py
+++ b/fu/single/CompRTL.py
@@ -57,7 +57,7 @@ class CompRTL(Fu):
       s.recv_predicate.rdy @= b1(0)
       s.recv_opt.rdy @= 0
 
-      if s.recv_opt.val & s.send_out[0].rdy:
+      if s.recv_opt.val:
         if s.recv_opt.msg.fu_in[0] != FuInType( 0 ):
           s.in0 @= s.recv_opt.msg.fu_in[0] - FuInType(1)
         if s.recv_opt.msg.fu_in[1] != FuInType(0):

--- a/fu/single/LogicRTL.py
+++ b/fu/single/LogicRTL.py
@@ -53,7 +53,7 @@ class LogicRTL(Fu):
       s.recv_predicate.rdy @= b1(0)
       s.recv_opt.rdy @= 0
 
-      if s.recv_opt.val & s.send_out[0].rdy:
+      if s.recv_opt.val:
         if s.recv_opt.msg.fu_in[0] != FuInType(0):
           s.in0 @= s.recv_opt.msg.fu_in[0] - FuInType(1)
         if s.recv_opt.msg.fu_in[1] != FuInType(0):
@@ -93,7 +93,7 @@ class LogicRTL(Fu):
                                           s.recv_predicate.msg.predicate)
           s.recv_all_val @= s.recv_in[s.in0_idx].val & \
                             ((s.recv_opt.msg.predicate == b1(0)) | s.recv_predicate.val)
-          s.send_out[0].val @= s.recv_all_val & s.send_out[0].rdy
+          s.send_out[0].val @= s.recv_all_val
           s.recv_in[s.in0_idx].rdy @= s.recv_all_val & s.send_out[0].rdy
           s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
 

--- a/fu/single/MemUnitRTL.py
+++ b/fu/single/MemUnitRTL.py
@@ -69,7 +69,7 @@ class MemUnitRTL(Component):
       s.recv_predicate.rdy @= b1(0)
       s.recv_opt.rdy @= 0
 
-      if s.recv_opt.val & s.send_out[0].rdy:
+      if s.recv_opt.val:
         if s.recv_opt.msg.fu_in[0] != 0:
           s.in0 @= zext(s.recv_opt.msg.fu_in[0] - 1, FuInType)
         if s.recv_opt.msg.fu_in[1] != 0:

--- a/fu/single/MulRTL.py
+++ b/fu/single/MulRTL.py
@@ -53,7 +53,7 @@ class MulRTL(Fu):
       s.recv_predicate.rdy @= b1(0)
       s.recv_opt.rdy @= 0
 
-      if s.recv_opt.val & s.send_out[0].rdy:
+      if s.recv_opt.val:
         if s.recv_opt.msg.fu_in[0] != 0:
           s.in0 @= zext(s.recv_opt.msg.fu_in[0] - 1, FuInType)
         if s.recv_opt.msg.fu_in[1] != 0:

--- a/fu/single/PhiRTL.py
+++ b/fu/single/PhiRTL.py
@@ -55,7 +55,7 @@ class PhiRTL(Fu):
       s.recv_predicate.rdy @= b1(0)
       s.recv_opt.rdy @= 0
 
-      if s.recv_opt.val & s.send_out[0].rdy:
+      if s.recv_opt.val:
         if s.recv_opt.msg.fu_in[0] != FuInType(0):
           s.in0 @= s.recv_opt.msg.fu_in[0] - FuInType(1)
         if s.recv_opt.msg.fu_in[1] != FuInType(0):

--- a/fu/single/RetRTL.py
+++ b/fu/single/RetRTL.py
@@ -50,7 +50,7 @@ class RetRTL(Fu):
       s.recv_predicate.rdy @= b1(0)
       s.recv_opt.rdy @= 0
 
-      if s.recv_opt.val & s.send_out[0].rdy:
+      if s.recv_opt.val:
         if s.recv_opt.msg.fu_in[0] != FuInType(0):
           s.in0 @= s.recv_opt.msg.fu_in[0] - FuInType(1)
 

--- a/fu/single/SelRTL.py
+++ b/fu/single/SelRTL.py
@@ -9,7 +9,8 @@ Author : Cheng Tan
 """
 
 from pymtl3 import *
-from ...lib.basic.val_rdy.ifcs import ValRdySendIfcRTL, ValRdyRecvIfcRTL
+from ...lib.basic.val_rdy.ifcs import ValRdyRecvIfcRTL as RecvIfcRTL
+from ...lib.basic.val_rdy.ifcs import ValRdySendIfcRTL as SendIfcRTL
 from ...lib.opt_type import *
 
 class SelRTL(Component):
@@ -26,17 +27,17 @@ class SelRTL(Component):
     CountType = mk_bits(clog2(num_entries + 1))
 
     # Interface
-    s.recv_in = [ValRdyRecvIfcRTL(DataType) for _ in range(num_inports)]
-    s.recv_predicate = ValRdyRecvIfcRTL(PredicateType)
-    s.recv_const = ValRdyRecvIfcRTL(DataType)
-    s.recv_opt = ValRdyRecvIfcRTL(CtrlType)
-    s.send_out = [ValRdySendIfcRTL(DataType) for _ in range(num_outports)]
+    s.recv_in = [RecvIfcRTL(DataType) for _ in range(num_inports)]
+    s.recv_predicate = RecvIfcRTL(PredicateType)
+    s.recv_const = RecvIfcRTL(DataType)
+    s.recv_opt = RecvIfcRTL(CtrlType)
+    s.send_out = [SendIfcRTL(DataType) for _ in range(num_outports)]
 
     # Redundant interfaces for MemUnit
-    s.to_mem_raddr = ValRdySendIfcRTL(AddrType)
-    s.from_mem_rdata = ValRdyRecvIfcRTL(DataType)
-    s.to_mem_waddr = ValRdySendIfcRTL(AddrType)
-    s.to_mem_wdata = ValRdySendIfcRTL(DataType)
+    s.to_mem_raddr = SendIfcRTL(AddrType)
+    s.from_mem_rdata = RecvIfcRTL(DataType)
+    s.to_mem_waddr = SendIfcRTL(AddrType)
+    s.to_mem_wdata = SendIfcRTL(DataType)
 
     s.in0 = Wire(FuInType)
     s.in1 = Wire(FuInType)
@@ -83,7 +84,7 @@ class SelRTL(Component):
         s.send_out[i].val @= 0
         s.send_out[i].msg @= DataType()
 
-      if s.recv_opt.val & s.send_out[0].rdy:
+      if s.recv_opt.val:
         if s.recv_opt.msg.fu_in[0] != FuInType(0):
           s.in0 @= s.recv_opt.msg.fu_in[0] - FuInType(1)
         if s.recv_opt.msg.fu_in[1] != FuInType(0):

--- a/fu/single/ShifterRTL.py
+++ b/fu/single/ShifterRTL.py
@@ -54,7 +54,7 @@ class ShifterRTL(Fu):
       s.recv_predicate.rdy @= b1(0)
       s.recv_opt.rdy @= 0
 
-      if s.recv_opt.val & s.send_out[0].rdy:
+      if s.recv_opt.val:
         if s.recv_opt.msg.fu_in[0] != FuInType(0):
           s.in0 @= s.recv_opt.msg.fu_in[0] - FuInType(1)
         if s.recv_opt.msg.fu_in[1] != FuInType(0):

--- a/mem/data/DataMemWithCrossbarRTL.py
+++ b/mem/data/DataMemWithCrossbarRTL.py
@@ -167,7 +167,7 @@ class DataMemWithCrossbarRTL(Component):
         s.recv_wdata[i].rdy @= 0
         s.recv_wdata_bypass_q[i].recv.val @= 0
 
-      if s.init_mem_done == b1(0):
+      if s.init_mem_done == 0:
         for b in range(num_banks):
           s.reg_file[b].waddr[0] @= trunc(s.init_mem_addr, PerBankAddrType)
           s.reg_file[b].wdata[0] @= s.preload_data_per_bank[b][trunc(s.init_mem_addr, PreloadDataPerBankSizeType)]


### PR DESCRIPTION
The `val/rdy` ifcs are leveraged for hand-shake.
 - We allow `rdy` to be dependent on `val`, but should avoid `val` depending on `rdy`, otherwise, loops exist.

Related issues:
 - https://github.com/tancheng/VectorCGRA/issues/13
 - https://github.com/tancheng/VectorCGRA/issues/39