### PR TITLE
Add linetrace=True in DefaultPassGroup

### DIFF
--- a/mem/const/test/ConstQueueDynamicRTL_test.py
+++ b/mem/const/test/ConstQueueDynamicRTL_test.py
@@ -42,12 +42,9 @@ def run_sim(test_harness, max_cycles = 20):
   while not test_harness.done() and ncycles < max_cycles:
     test_harness.sim_tick()
     ncycles += 1
-    # print("\n{}: {}".format(ncycles, test_harness.line_trace()))
 
   for i in range(3):
     test_harness.sim_tick()
-    # print("\nextra clk {}: {}".format(i, test_harness.line_trace()))
-  # print("\nmem: {}".format(test_harness.line_trace()))
 
 
 def test_const_num_lt_mem():

--- a/mem/const/test/ConstQueueDynamicRTL_test.py
+++ b/mem/const/test/ConstQueueDynamicRTL_test.py
@@ -35,19 +35,19 @@ class TestHarness(Component):
 
 def run_sim(test_harness, max_cycles = 20):
   test_harness.elaborate()
-  test_harness.apply(DefaultPassGroup())
+  test_harness.apply(DefaultPassGroup(linetrace = True))
   test_harness.sim_reset()
 
   ncycles = 0
   while not test_harness.done() and ncycles < max_cycles:
     test_harness.sim_tick()
     ncycles += 1
-    print("\n{}: {}".format(ncycles, test_harness.line_trace()))
+    # print("\n{}: {}".format(ncycles, test_harness.line_trace()))
 
   for i in range(3):
     test_harness.sim_tick()
-    print("\nextra clk {}: {}".format(i, test_harness.line_trace()))
-  print("\nmem: {}".format(test_harness.line_trace()))
+    # print("\nextra clk {}: {}".format(i, test_harness.line_trace()))
+  # print("\nmem: {}".format(test_harness.line_trace()))
 
 
 def test_const_num_lt_mem():


### PR DESCRIPTION
`test_harness.apply(DefaultPassGroup(linetrace = True))` can enable the simulator to automatically call the line_trace method.