### PR TITLE
Add comment in workflow to remind users to update the submodules.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
+        # same as `git submodule update --init` to update submodules
         submodules: true
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ We can now use git to clone the VectorCGRA repo.
  % mkdir -p ${HOME}/cgra
  % cd ${HOME}/cgra
  % git clone https://github.com/tancheng/VectorCGRA.git
+ % cd VectorCGRA/
  % git submodule update --init
 ```
 


### PR DESCRIPTION
Users might overlook the `git submodule update --init` step because in the [workflow](https://github.com/tancheng/CGRA-Flow/blob/6d9bbb2886fba1ba0dd2af0dfca06cb2633015a4/.github/workflows/main.yml#L27), it's a step rather than a git command. I added a comment in the step to remind users to update the submodules.

```
============================================================================= warnings summary ==============================================================================
tile/test/TileRTL_test.py: 2340 warnings
  /root/anaconda3/envs/py39/lib/python3.9/ast.py:409: DeprecationWarning: visit_Num is deprecated; add visit_Constant
    return visitor(node)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================== 1 passed, 2340 warnings in 6.98s ======================================================================
```