### PR TITLE
Embed tile id for cgra modeling

### DIFF
--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -70,7 +70,7 @@ class CgraRTL(Component):
                       data_mem_size_global, num_ctrl,
                       total_steps, 4, 2, s.num_mesh_ports,
                       s.num_mesh_ports, num_registers_per_reg_bank,
-                      FuList = FuList)
+                      FuList = FuList, id = i)
               for i in range(s.num_tiles)]
     s.data_mem = DataMemWithCrossbarRTL(NocPktType, DataType,
                                         data_mem_size_global,

--- a/cgra/CgraTemplateRTL.py
+++ b/cgra/CgraTemplateRTL.py
@@ -66,7 +66,7 @@ class CgraTemplateRTL(Component):
                       total_steps, 4, 2, s.num_mesh_ports,
                       s.num_mesh_ports,
                       num_registers_per_reg_bank,
-                      FuList = FuList)
+                      FuList = FuList, id = i)
               for i in range(s.num_tiles)]
     # FIXME: Need to enrish data-SPM-related user-controlled parameters, e.g., number of banks.
     s.data_mem = DataMemWithCrossbarRTL(NocPktType, DataType,


### PR DESCRIPTION
Tile id is missing for Cgra modeling, though functionality wise, it doesn't make any change IIRC.