### PR TITLE
Unify FUs between single-/multi-CGRA for rtl generation

### DIFF
--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -70,7 +70,7 @@ class CgraRTL(Component):
                       data_mem_size_global, num_ctrl,
                       total_steps, 4, 2, s.num_mesh_ports,
                       s.num_mesh_ports, num_registers_per_reg_bank,
-                      FuList = FuList)
+                      FuList = FuList, id = i)
               for i in range(s.num_tiles)]
     s.data_mem = DataMemWithCrossbarRTL(NocPktType, DataType,
                                         data_mem_size_global,

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -25,7 +25,7 @@ class CgraRTL(Component):
 
   def construct(s, DataType, PredicateType, CtrlPktType, CtrlSignalType,
                 NocPktType, CmdType, ControllerIdType, multi_cgra_rows,
-                multi_cgra_columns, controller_id, width, height,
+                multi_cgra_columns, width, height,
                 ctrl_mem_size, data_mem_size_global,
                 data_mem_size_per_bank, num_banks_per_cgra,
                 num_registers_per_reg_bank, num_ctrl,
@@ -70,7 +70,7 @@ class CgraRTL(Component):
                       data_mem_size_global, num_ctrl,
                       total_steps, 4, 2, s.num_mesh_ports,
                       s.num_mesh_ports, num_registers_per_reg_bank,
-                      FuList = FuList, id = i)
+                      FuList = FuList)
               for i in range(s.num_tiles)]
     s.data_mem = DataMemWithCrossbarRTL(NocPktType, DataType,
                                         data_mem_size_global,
@@ -81,11 +81,14 @@ class CgraRTL(Component):
     s.controller = ControllerRTL(ControllerIdType, CmdType, CtrlPktType,
                                  NocPktType, DataType, DataAddrType,
                                  multi_cgra_rows, multi_cgra_columns,
-                                 controller_id, controller2addr_map,
-                                 idTo2d_map)
+                                 controller2addr_map, idTo2d_map)
     s.ctrl_ring = RingNetworkRTL(CtrlPktType, CtrlRingPos, s.num_tiles, 1)
+    s.controller_id = InPort(ControllerIdType)
 
     # Connections
+    # Connects the controller id.
+    s.controller.controller_id //= s.controller_id
+
     # Connects data memory with controller.
     s.data_mem.recv_raddr[height] //= s.controller.send_to_tile_load_request_addr
     s.data_mem.recv_waddr[height] //= s.controller.send_to_tile_store_request_addr

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -70,7 +70,7 @@ class CgraRTL(Component):
                       data_mem_size_global, num_ctrl,
                       total_steps, 4, 2, s.num_mesh_ports,
                       s.num_mesh_ports, num_registers_per_reg_bank,
-                      FuList = FuList, id = i)
+                      FuList = FuList)
               for i in range(s.num_tiles)]
     s.data_mem = DataMemWithCrossbarRTL(NocPktType, DataType,
                                         data_mem_size_global,

--- a/cgra/CgraTemplateRTL.py
+++ b/cgra/CgraTemplateRTL.py
@@ -25,8 +25,7 @@ class CgraTemplateRTL(Component):
 
   def construct(s, DataType, PredicateType, CtrlPktType, CtrlSignalType,
                 NocPktType, CmdType, ControllerIdType, multi_cgra_rows,
-                multi_cgra_columns, controller_id,
-                ctrl_mem_size, data_mem_size_global,
+                multi_cgra_columns, ctrl_mem_size, data_mem_size_global,
                 data_mem_size_per_bank, num_banks_per_cgra,
                 num_registers_per_reg_bank, num_ctrl,
                 total_steps, FunctionUnit, FuList, TileList, LinkList,
@@ -66,7 +65,7 @@ class CgraTemplateRTL(Component):
                       total_steps, 4, 2, s.num_mesh_ports,
                       s.num_mesh_ports,
                       num_registers_per_reg_bank,
-                      FuList = FuList, id = i)
+                      FuList = FuList)
               for i in range(s.num_tiles)]
     # FIXME: Need to enrish data-SPM-related user-controlled parameters, e.g., number of banks.
     s.data_mem = DataMemWithCrossbarRTL(NocPktType, DataType,
@@ -79,10 +78,15 @@ class CgraTemplateRTL(Component):
     s.controller = ControllerRTL(ControllerIdType, CmdType, CtrlPktType,
                                  NocPktType, DataType, DataAddrType,
                                  multi_cgra_rows, multi_cgra_columns,
-                                 controller_id, controller2addr_map, idTo2d_map)
+                                 controller2addr_map, idTo2d_map)
     s.ctrl_ring = RingNetworkRTL(CtrlPktType, CtrlRingPos, s.num_tiles, 1)
 
+    s.controller_id = InPort(ControllerIdType)
+
     # Connections
+    # Connects controller id.
+    s.controller.controller_id //= s.controller_id
+
     # Connects data memory with controller.
     s.data_mem.recv_raddr[dataSPM.getNumOfValidReadPorts()] //= s.controller.send_to_tile_load_request_addr
     s.data_mem.recv_waddr[dataSPM.getNumOfValidWritePorts()] //= s.controller.send_to_tile_store_request_addr

--- a/cgra/CgraTemplateRTL.py
+++ b/cgra/CgraTemplateRTL.py
@@ -65,7 +65,7 @@ class CgraTemplateRTL(Component):
                       total_steps, 4, 2, s.num_mesh_ports,
                       s.num_mesh_ports,
                       num_registers_per_reg_bank,
-                      FuList = FuList, id = i)
+                      FuList = FuList)
               for i in range(s.num_tiles)]
     # FIXME: Need to enrish data-SPM-related user-controlled parameters, e.g., number of banks.
     s.data_mem = DataMemWithCrossbarRTL(NocPktType, DataType,

--- a/cgra/CgraTemplateRTL.py
+++ b/cgra/CgraTemplateRTL.py
@@ -66,7 +66,7 @@ class CgraTemplateRTL(Component):
                       total_steps, 4, 2, s.num_mesh_ports,
                       s.num_mesh_ports,
                       num_registers_per_reg_bank,
-                      FuList = FuList)
+                      FuList = FuList, id = i)
               for i in range(s.num_tiles)]
     # FIXME: Need to enrish data-SPM-related user-controlled parameters, e.g., number of banks.
     s.data_mem = DataMemWithCrossbarRTL(NocPktType, DataType,

--- a/cgra/test/CgraRTL_test.py
+++ b/cgra/test/CgraRTL_test.py
@@ -151,7 +151,7 @@ def init_param(topology, FuList = [MemUnitRTL, AdderRTL],
           3: [3, 0],
   }
 
-  cgra_id_nbits = clogs(num_terminals)
+  cgra_id_nbits = clog2(num_terminals)
   addr_nbits = clog2(data_mem_size_global)
   predicate_nbits = 1
 

--- a/cgra/test/CgraRTL_test.py
+++ b/cgra/test/CgraRTL_test.py
@@ -106,9 +106,9 @@ def init_param(topology, FuList = [MemUnitRTL, AdderRTL],
   num_fu_outports = 2
   num_routing_outports = num_tile_outports + num_fu_inports
   ctrl_mem_size = 6
-  data_mem_size_global = 512
+  data_mem_size_global = 4096
   data_mem_size_per_bank = 32
-  num_banks_per_cgra = 2
+  num_banks_per_cgra = 24
   width = width
   height = height
   num_terminals = 4
@@ -131,10 +131,10 @@ def init_param(topology, FuList = [MemUnitRTL, AdderRTL],
   ControllerIdType = mk_bits(clog2(num_terminals))
   controller_id = 1
   controller2addr_map = {
-          0: [0, 3],
-          1: [4, 7],
-          2: [8, 11],
-          3: [12, 15],
+          0: [0,    1023],
+          1: [1024, 2047],
+          2: [2048, 3071],
+          3: [3072, 4095],
   }
 
   idTo2d_map = {

--- a/cgra/test/CgraRTL_test.py
+++ b/cgra/test/CgraRTL_test.py
@@ -92,7 +92,8 @@ class TestHarness(Component):
   def line_trace(s):
     return s.dut.line_trace()
 
-def init_param(topology, FuList = [MemUnitRTL, AdderRTL], data_bitwidth = 32):
+def init_param(topology, FuList = [MemUnitRTL, AdderRTL],
+               width = 2, height = 2, data_bitwidth = 32):
   tile_ports = 4
   assert(topology == "Mesh" or topology == "KingMesh")
   if topology == "Mesh":
@@ -108,8 +109,8 @@ def init_param(topology, FuList = [MemUnitRTL, AdderRTL], data_bitwidth = 32):
   data_mem_size_global = 512
   data_mem_size_per_bank = 32
   num_banks_per_cgra = 2
-  width = 2
-  height = 2
+  width = width
+  height = height
   num_terminals = 4
   num_ctrl_actions = 6
   num_ctrl_operations = 64
@@ -214,42 +215,64 @@ def init_param(topology, FuList = [MemUnitRTL, AdderRTL], data_bitwidth = 32):
                    controller2addr_map, idTo2d_map)
   return th
 
-def test_homogeneous_2x2(cmdline_opts):
+# def test_homogeneous_2x2(cmdline_opts):
+#   topology = "Mesh"
+#   # FuList = [AdderRTL, MemUnitRTL]
+#   FuList = [AdderRTL,
+#             MulRTL,
+#             LogicRTL,
+#             ShifterRTL,
+#             PhiRTL,
+#             CompRTL,
+#             BranchRTL,
+#             MemUnitRTL,
+#             SelRTL,
+#             RetRTL,
+#            ]
+#   th = init_param(topology, FuList)
+# 
+#   th.elaborate()
+#   # th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
+#   #                     ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
+#   #                      'ALWCOMBORDER'])
+#   th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
+#   run_sim(th)
+# 
+# def test_heterogeneous_king_mesh_2x2(cmdline_opts):
+#   topology = "KingMesh"
+#   th = init_param(topology)
+#   th.set_param("top.dut.tile[1].construct", FuList=[ShifterRTL])
+#   th.elaborate()
+#   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
+#                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
+#                        'ALWCOMBORDER'])
+#   th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
+#   run_sim(th)
+# 
+# def test_vector_king_mesh_2x2(cmdline_opts):
+#   topology = "KingMesh"
+#   FuList = [AdderRTL,
+#             MulRTL,
+#             LogicRTL,
+#             ShifterRTL,
+#             PhiRTL,
+#             CompRTL,
+#             BranchRTL,
+#             MemUnitRTL,
+#             SelRTL,
+#             VectorMulComboRTL,
+#             VectorAdderComboRTL]
+#   data_bitwidth = 64
+#   th = init_param(topology, FuList, data_bitwidth = data_bitwidth)
+#   th.elaborate()
+#   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
+#                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
+#                        'ALWCOMBORDER'])
+#   th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
+#   run_sim(th)
+
+def test_vector_mesh_12x12(cmdline_opts):
   topology = "Mesh"
-  # FuList = [AdderRTL, MemUnitRTL]
-  FuList = [AdderRTL,
-            MulRTL,
-            LogicRTL,
-            ShifterRTL,
-            PhiRTL,
-            CompRTL,
-            BranchRTL,
-            MemUnitRTL,
-            SelRTL,
-            RetRTL,
-           ]
-  th = init_param(topology, FuList)
-
-  th.elaborate()
-  # th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
-  #                     ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
-  #                      'ALWCOMBORDER'])
-  th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
-  run_sim(th)
-
-def test_heterogeneous_king_mesh_2x2(cmdline_opts):
-  topology = "KingMesh"
-  th = init_param(topology)
-  th.set_param("top.dut.tile[1].construct", FuList=[ShifterRTL])
-  th.elaborate()
-  th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
-                      ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
-                       'ALWCOMBORDER'])
-  th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
-  run_sim(th)
-
-def test_vector_king_mesh_2x2(cmdline_opts):
-  topology = "KingMesh"
   FuList = [AdderRTL,
             MulRTL,
             LogicRTL,
@@ -261,8 +284,9 @@ def test_vector_king_mesh_2x2(cmdline_opts):
             SelRTL,
             VectorMulComboRTL,
             VectorAdderComboRTL]
-  data_bitwidth = 64
-  th = init_param(topology, FuList, data_bitwidth)
+  data_bitwidth = 32
+  th = init_param(topology, FuList, width = 12, height = 12,
+                  data_bitwidth = data_bitwidth)
   th.elaborate()
   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',

--- a/cgra/test/CgraRTL_test.py
+++ b/cgra/test/CgraRTL_test.py
@@ -180,7 +180,7 @@ def init_param(topology, FuList = [MemUnitRTL, AdderRTL],
   
   NocPktType = mk_multi_cgra_noc_pkt(ncols = num_terminals,
                                      nrows = 1,
-                                     ntiles = width * height,
+                                     ntiles = num_tiles,
                                      addr_nbits = addr_nbits,
                                      data_nbits = data_bitwidth,
                                      predicate_nbits = 1,

--- a/cgra/test/CgraTemplateRTL_test.py
+++ b/cgra/test/CgraTemplateRTL_test.py
@@ -69,7 +69,7 @@ class TestHarness(Component):
                 # CGRA terminals on x/y. Assume in total 4, though this
                 # test is for single CGRA.
                 1, 4,
-                controller_id, ctrl_mem_size, data_mem_size_global,
+                ctrl_mem_size, data_mem_size_global,
                 data_mem_size_per_bank, num_banks_per_cgra,
                 num_registers_per_reg_bank,
                 ctrl_steps, ctrl_steps, FunctionUnit, FuList,
@@ -77,6 +77,7 @@ class TestHarness(Component):
                 idTo2d_map)
 
     # Connections
+    s.dut.controller_id //= controller_id
     s.src_ctrl_pkt.send //= s.dut.recv_from_cpu_ctrl_pkt
 
     s.dut.send_to_noc.rdy //= 0

--- a/controller/ControllerRTL.py
+++ b/controller/ControllerRTL.py
@@ -22,7 +22,7 @@ class ControllerRTL(Component):
 
   def construct(s, ControllerIdType, CmdType, CtrlPktType, NocPktType,
                 CGRADataType, CGRAAddrType, multi_cgra_rows,
-                multi_cgra_columns, controller_id, controller2addr_map,
+                multi_cgra_columns, controller2addr_map,
                 idTo2d_map):
 
     assert(multi_cgra_columns >= multi_cgra_rows)
@@ -32,6 +32,8 @@ class ControllerRTL(Component):
     YType = mk_bits(max(clog2(multi_cgra_rows), 1))
 
     # Interface
+    s.controller_id = InPort(ControllerIdType)
+
     # Request from/to other CGRA via NoC.
     s.recv_from_noc = RecvIfcRTL(NocPktType)
     s.send_to_noc = SendIfcRTL(NocPktType)
@@ -59,32 +61,13 @@ class ControllerRTL(Component):
     s.send_to_tile_store_request_addr_queue = ChannelRTL(CGRAAddrType, latency = 1)
     s.send_to_tile_store_request_data_queue = ChannelRTL(CGRADataType, latency = 1)
 
-    # s.recv_from_other_cmd_queue = ChannelRTL(CmdType, latency = 1, num_entries = 2)
-    # s.send_to_tile_cmd_queue = ChannelRTL(CmdType, latency = 1, num_entries = 2)
-    # s.send_to_other_cmd_queue = ChannelRTL(CmdType, latency = 1, num_entries = 2)
-
     # Crossbar with 3 inports (load and store requests towards remote
     # memory, and load response from local memory) and 1 outport (only
     # allow one request be sent out per cycle).
     # TODO: Include other cmd requests, e.g., dynamic rescheduling,
     # termination).
     s.crossbar = XbarBypassQueueRTL(NocPktType, 3, 1)
-
     s.recv_ctrl_pkt_queue = NormalQueueRTL(CtrlPktType)
-
-    # # TODO: below ifcs should be connected through another NoC within
-    # # one CGRA, instead of per-tile and performing like a bus.
-    # # Configuration signals to be written into and read from per-tile
-    # # control memory.
-    # s.recv_waddr = [RecvIfcRTL(AddrType) for _ in range(s.num_tiles)]
-    # s.recv_wopt = [RecvIfcRTL(CtrlType) for _ in range(s.num_tiles)]
-
-    # s.send_waddr = [SendIfcRTL(AddrType) for _ in range(s.num_tiles)]
-    # s.send_wopt = [SendIfcRTL(CtrlType) for _ in range(s.num_tiles)]
-
-    # # Cmd to invoke/terminate tiles execution.
-    # s.recv_cmd = [RecvIfcRTL(b2) for _ in range(s.num_tiles)]
-    # s.send_cmd = [SendIfcRTL(b2) for _ in range(s.num_tiles)]
 
 
     # LUT for global data address mapping.
@@ -144,10 +127,10 @@ class ControllerRTL(Component):
       s.crossbar.recv[kLoadRequestInportIdx].val @= s.recv_from_tile_load_request_pkt_queue.send.val
       s.recv_from_tile_load_request_pkt_queue.send.rdy @= s.crossbar.recv[kLoadRequestInportIdx].rdy
       s.crossbar.recv[kLoadRequestInportIdx].msg @= \
-          NocPktType(controller_id,
+          NocPktType(s.controller_id,
                      0,
-                     s.idTo2d_x_lut[controller_id], # src_x
-                     s.idTo2d_y_lut[controller_id], # src_y
+                     s.idTo2d_x_lut[s.controller_id], # src_x
+                     s.idTo2d_y_lut[s.controller_id], # src_y
                      0, # dst_x
                      0, # dst_y
                      0,
@@ -164,10 +147,10 @@ class ControllerRTL(Component):
       s.crossbar.recv[kStoreRequestInportIdx].val @= s.recv_from_tile_store_request_pkt_queue.send.val
       s.recv_from_tile_store_request_pkt_queue.send.rdy @= s.crossbar.recv[kStoreRequestInportIdx].rdy
       s.crossbar.recv[kStoreRequestInportIdx].msg @= \
-          NocPktType(controller_id,
+          NocPktType(s.controller_id,
                      0,
-                     s.idTo2d_x_lut[controller_id], # src_x
-                     s.idTo2d_y_lut[controller_id], # src_y
+                     s.idTo2d_x_lut[s.controller_id], # src_x
+                     s.idTo2d_y_lut[s.controller_id], # src_y
                      0, # dst_x
                      0, # dst_y
                      0,
@@ -184,10 +167,10 @@ class ControllerRTL(Component):
           s.recv_from_tile_load_response_pkt_queue.send.val
       s.recv_from_tile_load_response_pkt_queue.send.rdy @= s.crossbar.recv[kLoadResponseInportIdx].rdy
       s.crossbar.recv[kLoadResponseInportIdx].msg @= \
-          NocPktType(controller_id,
+          NocPktType(s.controller_id,
                      0,
-                     s.idTo2d_x_lut[controller_id], # src_x
-                     s.idTo2d_y_lut[controller_id], # src_y
+                     s.idTo2d_x_lut[s.controller_id], # src_x
+                     s.idTo2d_y_lut[s.controller_id], # src_y
                      0, # dst_x
                      0, # dst_y
                      0,

--- a/controller/test/ControllerRTL_test.py
+++ b/controller/test/ControllerRTL_test.py
@@ -58,11 +58,11 @@ class TestHarness(Component):
                           PktType, MsgType, AddrType,
                           # Number of controllers globally (x/y dimension).
                           1, num_terminals,
-                          controller_id,
                           controller2addr_map,
                           idTo2d_map)
 
     # Connections
+    s.dut.controller_id //= controller_id
     s.src_from_tile_load_request_pkt_en_rdy.send //= s.dut.recv_from_tile_load_request_pkt
     s.src_from_tile_load_response_pkt_en_rdy.send //= s.dut.recv_from_tile_load_response_pkt
     s.src_from_tile_store_request_pkt_en_rdy.send //= s.dut.recv_from_tile_store_request_pkt
@@ -236,9 +236,13 @@ expected_to_noc_pkts = [
 
 def test_simple():
   print("controller2addr_map: ", controller2addr_map)
-  th = TestHarness(ControllerIdType, CtrlPktType,
-                   CmdType, DataType,
-                   AddrType, Pkt, controller_id,
+  th = TestHarness(ControllerIdType,
+                   CtrlPktType,
+                   CmdType,
+                   DataType,
+                   AddrType,
+                   Pkt,
+                   controller_id,
                    from_tile_load_request_pkts,
                    from_tile_load_response_pkts,
                    from_tile_store_request_pkts,
@@ -251,6 +255,7 @@ def test_simple():
                    expected_to_tile_store_request_data_msgs,
                    from_noc_pkts,
                    expected_to_noc_pkts,
-                   controller2addr_map, idTo2d_map,
+                   controller2addr_map,
+                   idTo2d_map,
                    nterminals)
   run_sim(th)

--- a/fu/vector/VectorAdderComboRTL.py
+++ b/fu/vector/VectorAdderComboRTL.py
@@ -22,7 +22,7 @@ class VectorAdderComboRTL(Component):
 
   def construct(s, DataType, PredicateType, CtrlType,
                 num_inports, num_outports, data_mem_size,
-                num_lanes = 4, data_bandwidth = 64):
+                num_lanes = 4, data_bandwidth = 32):
 
     # Constants
     assert(data_bandwidth % num_lanes == 0)

--- a/fu/vector/VectorMulComboRTL.py
+++ b/fu/vector/VectorMulComboRTL.py
@@ -21,7 +21,7 @@ class VectorMulComboRTL(Component):
 
   def construct(s, DataType, PredicateType, CtrlType,
                 num_inports, num_outports, data_mem_size,
-                num_lanes = 4, data_bandwidth = 64):
+                num_lanes = 4, data_bandwidth = 32):
 
     # Constants
     assert(data_bandwidth % num_lanes == 0)

--- a/lib/cmd_type.py
+++ b/lib/cmd_type.py
@@ -12,6 +12,8 @@
 
 from pymtl3 import *
 
+NUM_CMDS = 8
+
 CMD_LAUNCH        = 0
 CMD_PAUSE         = 1
 CMD_TERMINATE     = 2

--- a/lib/opt_type.py
+++ b/lib/opt_type.py
@@ -12,6 +12,8 @@
 
 from pymtl3 import *
 
+NUM_OPTS = 64
+
 OPT_START                 = Bits6( 0  )
 OPT_NAH                   = Bits6( 1  )
 OPT_PAS                   = Bits6( 31 )

--- a/noc/CrossbarRTL.py
+++ b/noc/CrossbarRTL.py
@@ -17,7 +17,7 @@ from ..lib.opt_type import *
 class CrossbarRTL(Component):
 
   def construct(s, DataType, PredicateType, CtrlType, num_inports = 5,
-                num_outports = 5, id = 0):
+                num_outports = 5):
 
     InType = mk_bits(clog2(num_inports + 1))
     num_index = num_inports if num_inports != 1 else 2

--- a/scale_out/MeshMultiCgraRTL.py
+++ b/scale_out/MeshMultiCgraRTL.py
@@ -38,7 +38,7 @@ class MeshMultiCgraRTL(Component):
 
     # Interface
     # Request from/to CPU.
-    s.recv_from_cpu_ctrl_pkt = [RecvIfcRTL(CtrlPktType) for _ in range(s.num_terminals)]
+    s.recv_from_cpu_ctrl_pkt = RecvIfcRTL(CtrlPktType)
 
     # Components
     for cgra_row in range(cgra_rows):
@@ -48,7 +48,7 @@ class MeshMultiCgraRTL(Component):
     s.cgra = [CgraRTL(CGRADataType, PredicateType, CtrlPktType,
                       CtrlSignalType, NocPktType, CmdType,
                       ControllerIdType, cgra_rows, cgra_columns,
-                      terminal_id, tile_columns, tile_rows,
+                      tile_columns, tile_rows,
                       ctrl_mem_size, data_mem_size_global,
                       data_mem_size_per_bank, num_banks_per_cgra,
                       num_registers_per_reg_bank,
@@ -56,19 +56,23 @@ class MeshMultiCgraRTL(Component):
                       "Mesh", controller2addr_map, idTo2d_map,
                       preload_data = None)
               for terminal_id in range(s.num_terminals)]
+
+    # Connects controller id.
+    for terminal_id in range(s.num_terminals):
+      s.cgra[terminal_id].controller_id //= terminal_id
+
     # Latency is 1.
     s.mesh = MeshNetworkRTL(NocPktType, MeshPos, cgra_columns, cgra_rows, 1)
 
     # Connections
-    # s.recv_from_cpu_ctrl_pkt //= s.cgra[0].recv_from_cpu_ctrl_pkt
     for i in range(s.num_terminals):
       s.mesh.send[i] //= s.cgra[i].recv_from_noc
       s.mesh.recv[i] //= s.cgra[i].send_to_noc
 
-    for i in range(s.num_terminals):
-      # s.cgra[i].recv_from_cpu_ctrl_pkt.val //= 0
-      # s.cgra[i].recv_from_cpu_ctrl_pkt.msg //= CtrlPktType()
-      s.recv_from_cpu_ctrl_pkt[i] //= s.cgra[i].recv_from_cpu_ctrl_pkt
+    s.recv_from_cpu_ctrl_pkt //= s.cgra[0].recv_from_cpu_ctrl_pkt
+    for i in range(1, s.num_terminals):
+      s.cgra[i].recv_from_cpu_ctrl_pkt.val //= 0
+      s.cgra[i].recv_from_cpu_ctrl_pkt.msg //= CtrlPktType()
 
     # Connects the tiles on the boundary of each two ajacent CGRAs.
     for cgra_row in range(cgra_rows):

--- a/scale_out/MeshMultiCgraRTL.py
+++ b/scale_out/MeshMultiCgraRTL.py
@@ -38,7 +38,7 @@ class MeshMultiCgraRTL(Component):
 
     # Interface
     # Request from/to CPU.
-    s.recv_from_cpu_ctrl_pkt = RecvIfcRTL(CtrlPktType)
+    s.recv_from_cpu_ctrl_pkt = [RecvIfcRTL(CtrlPktType) for _ in range(s.num_terminals)]
 
     # Components
     for cgra_row in range(cgra_rows):
@@ -60,14 +60,15 @@ class MeshMultiCgraRTL(Component):
     s.mesh = MeshNetworkRTL(NocPktType, MeshPos, cgra_columns, cgra_rows, 1)
 
     # Connections
-    s.recv_from_cpu_ctrl_pkt //= s.cgra[0].recv_from_cpu_ctrl_pkt
+    # s.recv_from_cpu_ctrl_pkt //= s.cgra[0].recv_from_cpu_ctrl_pkt
     for i in range(s.num_terminals):
       s.mesh.send[i] //= s.cgra[i].recv_from_noc
       s.mesh.recv[i] //= s.cgra[i].send_to_noc
 
-    for i in range(1, s.num_terminals):
-      s.cgra[i].recv_from_cpu_ctrl_pkt.val //= 0
-      s.cgra[i].recv_from_cpu_ctrl_pkt.msg //= CtrlPktType()
+    for i in range(s.num_terminals):
+      # s.cgra[i].recv_from_cpu_ctrl_pkt.val //= 0
+      # s.cgra[i].recv_from_cpu_ctrl_pkt.msg //= CtrlPktType()
+      s.recv_from_cpu_ctrl_pkt[i] //= s.cgra[i].recv_from_cpu_ctrl_pkt
 
     # Connects the tiles on the boundary of each two ajacent CGRAs.
     for cgra_row in range(cgra_rows):

--- a/scale_out/RingMultiCgraRTL.py
+++ b/scale_out/RingMultiCgraRTL.py
@@ -48,7 +48,7 @@ class RingMultiCgraRTL(Component):
                       ControllerIdType,
                       # Constructs the topology as 1d.
                       1, s.num_terminals,
-                      terminal_id, tile_columns, tile_rows,
+                      tile_columns, tile_rows,
                       ctrl_mem_size, data_mem_size_global,
                       data_mem_size_per_bank, num_banks_per_cgra,
                       num_registers_per_reg_bank,
@@ -59,6 +59,10 @@ class RingMultiCgraRTL(Component):
     s.ring = RingNetworkRTL(NocPktType, RingPos, s.num_terminals, 1)
 
     # Connections
+    # Connects the controller id.
+    for terminal_id in range(s.num_terminals):
+      s.cgra[terminal_id].controller_id //= terminal_id
+
     s.recv_from_cpu_ctrl_pkt //= s.cgra[0].recv_from_cpu_ctrl_pkt
     for i in range(s.num_terminals):
       s.ring.send[i] //= s.cgra[i].recv_from_noc

--- a/scale_out/test/MeshMultiCgraRTL_test.py
+++ b/scale_out/test/MeshMultiCgraRTL_test.py
@@ -113,7 +113,6 @@ def test_homo_2x2_2x2(cmdline_opts):
     controller2addr_map[i] = [i * per_cgra_data_size,
                               (i + 1) * per_cgra_data_size - 1]
 
-  num_commands = NUM_CMDS
   cmd_nbits = clog2(NUM_CMDS)
   num_registers_per_reg_bank = 16
   CmdType = mk_bits(cmd_nbits)
@@ -148,9 +147,9 @@ def test_homo_2x2_2x2(cmdline_opts):
                                      addr_nbits = data_addr_nbits,
                                      data_nbits = data_nbits,
                                      predicate_nbits = predicate_nbits,
-                                     ctrl_actions = num_commands,
+                                     ctrl_actions = NUM_CMDS,
                                      ctrl_mem_size = ctrl_mem_size,
-                                     ctrl_operations = num_ctrl_operations,
+                                     ctrl_operations = NUM_OPTS,
                                      ctrl_fu_inports = num_fu_inports,
                                      ctrl_fu_outports = num_fu_outports,
                                      ctrl_tile_inports = num_tile_inports,

--- a/scale_out/test/MeshMultiCgraRTL_test.py
+++ b/scale_out/test/MeshMultiCgraRTL_test.py
@@ -76,7 +76,7 @@ def test_homo_3x3_4x4(cmdline_opts):
   num_fu_outports = 2
   num_routing_outports = num_tile_outports + num_fu_inports
   ctrl_mem_size = 6
-  data_mem_size_global = 32
+  data_mem_size_global = 128
   data_mem_size_per_bank = 4
   num_banks_per_cgra = 2
   cgra_rows = 3
@@ -119,6 +119,11 @@ def test_homo_3x3_4x4(cmdline_opts):
           1: [8, 15],
           2: [16, 23],
           3: [24, 31],
+          4: [32, 39],
+          5: [40, 47],
+          6: [48, 55],
+          7: [56, 63],
+          8: [64, 71],
   }
   CtrlPktType = \
       mk_intra_cgra_pkt(width * height,

--- a/scale_out/test/MeshMultiCgraRTL_test.py
+++ b/scale_out/test/MeshMultiCgraRTL_test.py
@@ -61,7 +61,10 @@ class TestHarness(Component):
       s.src_ctrl_pkt[i].send //= s.dut.recv_from_cpu_ctrl_pkt[i]
 
   def done(s):
-    return s.src_ctrl_pkt.done()
+    for i in range(s.num_terminals):
+      if not s.src_ctrl_pkt[i].done():
+        return False
+    return True
 
   def line_trace(s):
     return s.dut.line_trace()

--- a/systolic/CgraSystolicArrayRTL.py
+++ b/systolic/CgraSystolicArrayRTL.py
@@ -67,8 +67,7 @@ class CgraSystolicArrayRTL(Component):
                       data_mem_size_global, num_ctrl,
                       total_steps, 4, 2, s.num_mesh_ports,
                       s.num_mesh_ports, num_registers_per_reg_bank,
-                      FuList = FuList,
-                      id = i)
+                      FuList = FuList)
               for i in range(s.num_tiles)]
     s.data_mem = DataMemWithCrossbarRTL(NocPktType, DataType,
                                         data_mem_size_global,
@@ -81,11 +80,14 @@ class CgraSystolicArrayRTL(Component):
     s.controller = ControllerRTL(ControllerIdType, CmdType, CtrlPktType,
                                  NocPktType, DataType, DataAddrType,
                                  1, 1,
-                                 controller_id, controller2addr_map,
+                                 controller2addr_map,
                                  idTo2d_map)
     s.ctrl_ring = RingNetworkRTL(CtrlPktType, CtrlRingPos, s.num_tiles, 1)
 
     # Connections
+    # Connects controller id.
+    s.controller.controller_id //= controller_id
+
     # Connects data memory with controller.
     s.data_mem.recv_raddr[4] //= s.controller.send_to_tile_load_request_addr
     s.data_mem.recv_waddr[4] //= s.controller.send_to_tile_store_request_addr

--- a/tile/TileRTL.py
+++ b/tile/TileRTL.py
@@ -40,8 +40,7 @@ class TileRTL(Component):
                 num_fu_inports, num_fu_outports, num_tile_inports,
                 num_tile_outports, num_registers_per_reg_bank = 16,
                 Fu = FlexibleFuRTL,
-                FuList = [PhiRTL, AdderRTL, CompRTL, MulRTL, BranchRTL, MemUnitRTL],
-                id = 0):
+                FuList = [PhiRTL, AdderRTL, CompRTL, MulRTL, BranchRTL, MemUnitRTL]):
 
     # Constants.
     num_routing_xbar_inports = num_tile_inports
@@ -80,7 +79,7 @@ class TileRTL(Component):
     s.fu_crossbar = CrossbarRTL(DataType, PredicateType,
                                 CtrlSignalType,
                                 num_fu_xbar_inports,
-                                num_fu_xbar_outports, id)
+                                num_fu_xbar_outports)
     s.register_cluster = \
         RegisterClusterRTL(DataType, CtrlSignalType, num_fu_inports,
                            num_registers_per_reg_bank)


### PR DESCRIPTION
 - Align FU types for 4x4 CGRA and 2x2 multi-cgra (each with 2x2 tiles).
 - Make controller id as port to facilitate hierarchical synthesis, https://github.com/tancheng/VectorCGRA/issues/93.