### PR TITLE
[P0] Allow tile issue COMPLETE signals on ring

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -82,3 +82,5 @@ jobs:
         pytest ../scale_out/test/MeshMultiCgraRTL_test.py -xvs --test-verilog --dump-vtb --dump-vcd
         # Const Queue
         pytest ../mem/const/test/ConstQueueDynamicRTL_test.py -xvs
+        # CtrlMemDynamicRTL
+        pytest ../mem/ctrl/test/CtrlMemDynamicRTL_test.py -xvs --tb=short

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -63,7 +63,7 @@ jobs:
         # Simulation across all tests.
         pytest .. -v --tb=short
         # CtrlMemDynamicRTL
-        pytest ../mem/ctrl/test/CtrlMemDynamicRTL_test.py -xvs --tb=short
+        pytest ../mem/ctrl/test/CtrlMemDynamicRTL_test.py -xvs
         # Tile translation.
         pytest ../tile/test/TileRTL_test.py -xvs --test-verilog --dump-vtb --dump-vcd
         # Controller

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -62,6 +62,8 @@ jobs:
         source ${HOME}/venv/bin/activate
         # Simulation across all tests.
         pytest .. -v --tb=short
+        # CtrlMemDynamicRTL
+        pytest ../mem/ctrl/test/CtrlMemDynamicRTL_test.py -xvs --tb=short
         # Tile translation.
         pytest ../tile/test/TileRTL_test.py -xvs --test-verilog --dump-vtb --dump-vcd
         # Controller
@@ -82,5 +84,3 @@ jobs:
         pytest ../scale_out/test/MeshMultiCgraRTL_test.py -xvs --test-verilog --dump-vtb --dump-vcd
         # Const Queue
         pytest ../mem/const/test/ConstQueueDynamicRTL_test.py -xvs
-        # CtrlMemDynamicRTL
-        pytest ../mem/ctrl/test/CtrlMemDynamicRTL_test.py -xvs --tb=short

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -66,7 +66,7 @@ class CgraRTL(Component):
                       CtrlSignalType, ctrl_mem_size,
                       data_mem_size_global, num_ctrl,
                       total_steps, 4, 2, s.num_mesh_ports,
-                      s.num_mesh_ports, num_registers_per_reg_bank,
+                      s.num_mesh_ports, s.num_tiles, num_registers_per_reg_bank,
                       FuList = FuList)
               for i in range(s.num_tiles)]
     s.data_mem = DataMemWithCrossbarRTL(NocPktType, DataType,
@@ -103,9 +103,9 @@ class CgraRTL(Component):
     s.send_to_cpu_pkt //=  s.controller.send_to_cpu_pkt
 
     # Connects ring with each control memory.
-    s.ctrl_ring.send[0] //= s.controller.recv_from_ctrl_ring_pkt
-    for i in range(1, s.num_tiles + 1):
-      s.ctrl_ring.send[i] //= s.tile[i-1].recv_ctrl_pkt
+    for i in range(s.num_tiles):
+      s.ctrl_ring.send[i] //= s.tile[i].recv_ctrl_pkt
+    s.ctrl_ring.send[s.num_tiles] //= s.controller.recv_from_ctrl_ring_pkt
 
     for i in range(s.num_tiles):
       s.ctrl_ring.recv[i] //= s.tile[i].send_towards_controller_pkt

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -108,14 +108,10 @@ class CgraRTL(Component):
     s.ctrl_ring.send[0] //= s.controller.recv_from_ctrl_ring_ctrl_pkt
     for i in range(1, s.num_tiles + 1):
       s.ctrl_ring.send[i] //= s.tile[i-1].recv_ctrl_pkt
-    # s.ctrl_ring.send[s.num_tiles].rdy //= s.controller.recv_from_ctrl_ring_ctrl_pkt.rdy
-    # s.ctrl_ring.send[s.num_tiles].msg //= s.controller.recv_from_ctrl_ring_ctrl_pkt.msg
-
 
     s.ctrl_ring.recv[0] //= s.controller.send_to_ctrl_ring_ctrl_pkt
     for i in range(1, s.num_tiles + 1):
-      s.ctrl_ring.recv[i].val //= s.tile[i-1].send_pkt.val
-      s.ctrl_ring.recv[i].msg //= s.tile[i-1].send_pkt.msg
+      s.ctrl_ring.recv[i] //= s.tile[i-1].send_pkt
 
     for i in range(s.num_tiles):
 

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -49,6 +49,7 @@ class CgraRTL(Component):
     s.recv_from_cpu_pkt = RecvIfcRTL(CtrlPktType)
     s.recv_from_noc = RecvIfcRTL(NocPktType)
     s.send_to_noc = SendIfcRTL(NocPktType)
+    s.send_to_cpu_pkt = SendIfcRTL(CtrlPktType)
 
     # Interfaces on the boundary of the CGRA.
     s.recv_data_on_boundary_south = [RecvIfcRTL(DataType) for _ in range(width )]
@@ -100,6 +101,7 @@ class CgraRTL(Component):
 
     # Connects the ctrl interface between CPU and controller.
     s.recv_from_cpu_pkt //= s.controller.recv_from_cpu_pkt
+    s.send_to_cpu_pkt //=  s.controller.send_to_cpu_pkt
 
     # Connects ring with each control memory.
     for i in range(s.num_tiles):

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -82,7 +82,7 @@ class CgraRTL(Component):
                                  NocPktType, DataType, DataAddrType,
                                  multi_cgra_rows, multi_cgra_columns,
                                  controller2addr_map, idTo2d_map)
-    s.ctrl_ring = RingNetworkRTL(CtrlPktType, CtrlRingPos, s.num_tiles, 1)
+    s.ctrl_ring = RingNetworkRTL(CtrlPktType, CtrlRingPos, s.num_tiles + 1, 1)
     s.controller_id = InPort(ControllerIdType)
 
     # Connections

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -103,9 +103,9 @@ class CgraRTL(Component):
     s.send_to_cpu_pkt //=  s.controller.send_to_cpu_pkt
 
     # Connects ring with each control memory.
-    for i in range(s.num_tiles):
-      s.ctrl_ring.send[i] //= s.tile[i].recv_ctrl_pkt
-    s.ctrl_ring.send[s.num_tiles] //= s.controller.recv_from_ctrl_ring_pkt
+    s.ctrl_ring.send[0] //= s.controller.recv_from_ctrl_ring_pkt
+    for i in range(1, s.num_tiles + 1):
+      s.ctrl_ring.send[i] //= s.tile[i-1].recv_ctrl_pkt
 
     for i in range(s.num_tiles):
       s.ctrl_ring.recv[i] //= s.tile[i].send_towards_controller_pkt

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -6,7 +6,6 @@ CgraRTL.py
 Author : Cheng Tan
   Date : Dec 22, 2024
 """
-from pymtl3 import *
 from ..controller.ControllerRTL import ControllerRTL
 from ..lib.basic.val_rdy.ifcs import ValRdyRecvIfcRTL as RecvIfcRTL
 from ..lib.basic.val_rdy.ifcs import ValRdySendIfcRTL as SendIfcRTL

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -38,7 +38,7 @@ class CgraRTL(Component):
       s.num_mesh_ports = 8
 
     s.num_tiles = width * height
-    # An additional router for Controller to receive CMD_COMPLETE signal from Ring to Cpu.
+    # An additional router for controller to receive CMD_COMPLETE signal from Ring to CPU.
     CtrlRingPos = mk_ring_pos(s.num_tiles + 1)
     CtrlAddrType = mk_bits(clog2(ctrl_mem_size))
     DataAddrType = mk_bits(clog2(data_mem_size_global))
@@ -80,8 +80,8 @@ class CgraRTL(Component):
                                  NocPktType, DataType, DataAddrType,
                                  multi_cgra_rows, multi_cgra_columns,
                                  controller2addr_map, idTo2d_map)
-    # An additional router for Controller to receive CMD_COMPLETE signal from Ring to Cpu.
-    #                                                                             For latency per hop.
+    # An additional router for controller to receive CMD_COMPLETE signal from Ring to CPU.
+    # The last argument of 1 is for the latency per hop.
     s.ctrl_ring = RingNetworkRTL(CtrlPktType, CtrlRingPos, s.num_tiles + 1, 1)
     s.controller_id = InPort(ControllerIdType)
 

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -105,8 +105,12 @@ class CgraRTL(Component):
     s.recv_from_cpu_pkt //= s.controller.recv_from_cpu_pkt
 
     # Connects ring with each control memory.
-    for i in range(s.num_tiles):
-      s.ctrl_ring.send[i] //= s.tile[i].recv_ctrl_pkt
+    s.ctrl_ring.send[0] //= s.controller.recv_from_ctrl_ring_ctrl_pkt
+    for i in range(1, s.num_tiles + 1):
+      s.ctrl_ring.send[i] //= s.tile[i-1].recv_ctrl_pkt
+    # s.ctrl_ring.send[s.num_tiles].rdy //= s.controller.recv_from_ctrl_ring_ctrl_pkt.rdy
+    # s.ctrl_ring.send[s.num_tiles].msg //= s.controller.recv_from_ctrl_ring_ctrl_pkt.msg
+
 
     s.ctrl_ring.recv[0] //= s.controller.send_to_ctrl_ring_ctrl_pkt
     for i in range(1, s.num_tiles + 1):

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -109,9 +109,9 @@ class CgraRTL(Component):
       s.ctrl_ring.send[i] //= s.tile[i].recv_ctrl_pkt
 
     s.ctrl_ring.recv[0] //= s.controller.send_to_ctrl_ring_ctrl_pkt
-    for i in range(1, s.num_tiles):
-      s.ctrl_ring.recv[i].val //= 0
-      s.ctrl_ring.recv[i].msg //= CtrlPktType()
+    for i in range(1, s.num_tiles + 1):
+      s.ctrl_ring.recv[i].val //= s.tile[i-1].send_pkt.val
+      s.ctrl_ring.recv[i].msg //= s.tile[i-1].send_pkt.msg
 
     for i in range(s.num_tiles):
 
@@ -205,6 +205,7 @@ class CgraRTL(Component):
   def line_trace(s):
     res = "||\n".join([(("[tile"+str(i)+"]: ") + x.line_trace() + x.ctrl_mem.line_trace())
                        for (i,x) in enumerate(s.tile)])
+    res += "\n :: [" + s.ctrl_ring.line_trace() + "]    \n"
     res += "\n :: [" + s.data_mem.line_trace() + "]    \n"
     return res
 

--- a/cgra/CgraTemplateRTL.py
+++ b/cgra/CgraTemplateRTL.py
@@ -38,6 +38,7 @@ class CgraTemplateRTL(Component):
 
     # Interfaces
     s.recv_from_cpu_pkt = RecvIfcRTL(CtrlPktType)
+    s.send_to_cpu_pkt = SendIfcRTL(CtrlPktType)
     s.recv_from_noc = RecvIfcRTL(NocPktType)
     s.send_to_noc = SendIfcRTL(NocPktType)
 
@@ -97,6 +98,7 @@ class CgraTemplateRTL(Component):
 
     # Connects the ctrl interface between CPU and controller.
     s.recv_from_cpu_pkt //= s.controller.recv_from_cpu_pkt
+    s.send_to_cpu_pkt //= s.controller.send_to_cpu_pkt
 
     # Connects ring with each control memory.
     for i in range(s.num_tiles):

--- a/cgra/CgraTemplateRTL.py
+++ b/cgra/CgraTemplateRTL.py
@@ -60,7 +60,7 @@ class CgraTemplateRTL(Component):
                       CtrlSignalType, ctrl_mem_size,
                       data_mem_size_global, num_ctrl,
                       total_steps, 4, 2, s.num_mesh_ports,
-                      s.num_mesh_ports,
+                      s.num_mesh_ports, s.num_tiles,
                       num_registers_per_reg_bank,
                       FuList = FuList)
               for i in range(s.num_tiles)]

--- a/cgra/CgraTemplateRTL.py
+++ b/cgra/CgraTemplateRTL.py
@@ -106,7 +106,7 @@ class CgraTemplateRTL(Component):
     for i in range(s.num_tiles):
       s.ctrl_ring.send[i] //= s.tile[i].recv_ctrl_pkt
 
-    s.ctrl_ring.recv[0] //= s.controller.send_to_ctrl_ring_ctrl_pkt
+    s.ctrl_ring.recv[0] //= s.controller.send_to_ctrl_ring_pkt
     for i in range(1, s.num_tiles):
       s.ctrl_ring.recv[i].val //= 0
       s.ctrl_ring.recv[i].msg //= CtrlPktType()

--- a/cgra/CgraTemplateRTL.py
+++ b/cgra/CgraTemplateRTL.py
@@ -30,7 +30,7 @@ class CgraTemplateRTL(Component):
 
     s.num_mesh_ports = 8
     s.num_tiles = len(TileList)
-    # An additional port for Controller to receive CMD_COMPLETE signal from Ring to Cpu.
+    # An additional router for controller to receive CMD_COMPLETE signal from Ring to CPU.
     CtrlRingPos = mk_ring_pos(s.num_tiles + 1)
     CtrlAddrType = mk_bits(clog2(ctrl_mem_size))
     DataAddrType = mk_bits(clog2(data_mem_size_global))
@@ -77,8 +77,8 @@ class CgraTemplateRTL(Component):
                                  NocPktType, DataType, DataAddrType,
                                  multi_cgra_rows, multi_cgra_columns,
                                  controller2addr_map, idTo2d_map)
-    # An additional port for Controller to receive CMD_COMPLETE signal from Ring to Cpu.
-    #                                                                             For latency per hop.
+    # An additional router for controller to receive CMD_COMPLETE signal from Ring to CPU.
+    # The last argument of 1 is for the latency per hop.
     s.ctrl_ring = RingNetworkRTL(CtrlPktType, CtrlRingPos, s.num_tiles + 1, 1)
 
     s.controller_id = InPort(ControllerIdType)

--- a/cgra/test/CgraRTL_test.py
+++ b/cgra/test/CgraRTL_test.py
@@ -226,6 +226,7 @@ def init_param(topology, FuList = [MemUnitRTL, AdderRTL],
                   pick_register, tile_in_code, fu_out_code)
       ] for i in range(num_tiles)]
 
+  # vc_id needs to be 1 due to the message might traverse across the date line via ring.
   #                                       cgra_id, src,       dst, opaque, vc, ctrl_action
   complete_signal_sink_out = [CtrlPktType(      0,   0, num_tiles,      0,  1, ctrl_action = CMD_COMPLETE)]
   

--- a/cgra/test/CgraRTL_test.py
+++ b/cgra/test/CgraRTL_test.py
@@ -75,8 +75,8 @@ class TestHarness(Component):
     # when there is no NoC for single CGRA test, 
     # we have to connect from_noc and to_noc in testbench.
     s.src_ctrl_pkt.send //= s.dut.recv_from_cpu_pkt
-    s.dut.send_to_noc //= s.bypass_queue.recv
-    s.bypass_queue.send //= s.dut.recv_from_noc
+    s.dut.send_to_inter_cgra_noc //= s.bypass_queue.recv
+    s.bypass_queue.send //= s.dut.recv_from_inter_cgra_noc
 
     s.complete_signal_sink_out.recv //= s.dut.send_to_cpu_pkt
 
@@ -225,7 +225,9 @@ def init_param(topology, FuList = [MemUnitRTL, AdderRTL],
       CtrlPktType(0, 0,  i,  0,    0,  CMD_LAUNCH, 0, OPT_ADD, 0,
                   pick_register, tile_in_code, fu_out_code)
       ] for i in range(num_tiles)]
-  complete_signal_sink_out = [CtrlPktType(0, 0, num_tiles, 0, 1, ctrl_action = CMD_COMPLETE)]
+
+  #                                       cgra_id, src,       dst, opaque, vc, ctrl_action
+  complete_signal_sink_out = [CtrlPktType(      0,   0, num_tiles,      0,  1, ctrl_action = CMD_COMPLETE)]
   
   src_ctrl_pkt = []
   for opt_per_tile in src_opt_per_tile:

--- a/cgra/test/CgraRTL_test.py
+++ b/cgra/test/CgraRTL_test.py
@@ -225,7 +225,7 @@ def init_param(topology, FuList = [MemUnitRTL, AdderRTL],
       CtrlPktType(0, 0,  i,  0,    0,  CMD_LAUNCH, 0, OPT_ADD, 0,
                   pick_register, tile_in_code, fu_out_code)
       ] for i in range(num_tiles)]
-  complete_signal_sink_out = [CtrlPktType(0, 0, 0, 0, 0, ctrl_action = CMD_COMPLETE)]
+  complete_signal_sink_out = [CtrlPktType(0, 0, num_tiles, 0, 1, ctrl_action = CMD_COMPLETE)]
   
   src_ctrl_pkt = []
   for opt_per_tile in src_opt_per_tile:

--- a/cgra/test/CgraRTL_test.py
+++ b/cgra/test/CgraRTL_test.py
@@ -99,7 +99,7 @@ class TestHarness(Component):
       s.dut.recv_data_on_boundary_east[tile_row].msg //= DataType()
 
   def done(s):
-    return s.src_ctrl_pkt.done()
+    return s.src_ctrl_pkt.done() and s.complete_signal_sink_out.done()
 
   def line_trace(s):
     return s.dut.line_trace()

--- a/cgra/test/CgraTemplateRTL_test.py
+++ b/cgra/test/CgraTemplateRTL_test.py
@@ -279,6 +279,8 @@ def test_cgra_universal(cmdline_opts, paramCGRA = None):
       CtrlPktType(0, 0,  i,  0,    0,  CMD_LAUNCH, 0, OPT_ADD, 0,
                   pick_register, tile_in_code, fu_out_code)
       ] for i in range(num_tiles)]
+
+  # vc_id needs to be 1 due to the message might traverse across the date line via ring.
   #                                       cgra_id, src,       dst, opaque, vc, ctrl_action
   complete_signal_sink_out = [CtrlPktType(      0,   0, num_tiles,      0,  1, ctrl_action = CMD_COMPLETE)]
 

--- a/cgra/test/CgraTemplateRTL_test.py
+++ b/cgra/test/CgraTemplateRTL_test.py
@@ -89,8 +89,8 @@ class TestHarness(Component):
     # As we always first issue request pkt from CPU to NoC, 
     # when there is no NoC for single CGRA test, 
     # we have to connect from_noc and to_noc in testbench.
-    s.dut.send_to_noc //= s.bypass_queue.recv
-    s.bypass_queue.send //= s.dut.recv_from_noc
+    s.dut.send_to_inter_cgra_noc //= s.bypass_queue.recv
+    s.bypass_queue.send //= s.dut.recv_from_inter_cgra_noc
     s.complete_signal_sink_out.recv //= s.dut.send_to_cpu_pkt
 
   def done(s):
@@ -279,7 +279,8 @@ def test_cgra_universal(cmdline_opts, paramCGRA = None):
       CtrlPktType(0, 0,  i,  0,    0,  CMD_LAUNCH, 0, OPT_ADD, 0,
                   pick_register, tile_in_code, fu_out_code)
       ] for i in range(num_tiles)]
-  complete_signal_sink_out = [CtrlPktType(0, 0, num_tiles, 0, 1, ctrl_action = CMD_COMPLETE)]
+  #                                       cgra_id, src,       dst, opaque, vc, ctrl_action
+  complete_signal_sink_out = [CtrlPktType(      0,   0, num_tiles,      0,  1, ctrl_action = CMD_COMPLETE)]
 
   src_ctrl_pkt = []
   for opt_per_tile in src_opt_per_tile:

--- a/cgra/test/CgraTemplateRTL_test.py
+++ b/cgra/test/CgraTemplateRTL_test.py
@@ -9,12 +9,13 @@ Author : Cheng Tan
 
 """
 
-from pymtl3 import *
 from pymtl3.passes.backends.verilog import (VerilogTranslationPass,
                                             VerilogVerilatorImportPass)
 from pymtl3.stdlib.test_utils import (run_sim,
                                       config_model_with_cmdline_opts)
+
 from ..CgraTemplateRTL import CgraTemplateRTL
+from ...fu.double.SeqMulAdderRTL import SeqMulAdderRTL
 from ...fu.flexible.FlexibleFuRTL import FlexibleFuRTL
 from ...fu.single.AdderRTL import AdderRTL
 from ...fu.single.BranchRTL import BranchRTL
@@ -25,12 +26,12 @@ from ...fu.single.MulRTL import MulRTL
 from ...fu.single.PhiRTL import PhiRTL
 from ...fu.single.RetRTL import RetRTL
 from ...fu.single.SelRTL import SelRTL
-from ...fu.double.SeqMulAdderRTL import SeqMulAdderRTL
 from ...fu.single.ShifterRTL import ShifterRTL
+from ...lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL
 from ...lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
 from ...lib.basic.val_rdy.queues import BypassQueueRTL
-from ...lib.messages import *
 from ...lib.cmd_type import *
+from ...lib.messages import *
 from ...lib.opt_type import *
 from ...lib.util.common import *
 
@@ -60,10 +61,11 @@ class TestHarness(Component):
                 data_mem_size_global, data_mem_size_per_bank,
                 num_banks_per_cgra, num_registers_per_reg_bank,
                 src_ctrl_pkt, ctrl_steps, TileList,
-                LinkList, dataSPM, controller2addr_map, idTo2d_map):
+                LinkList, dataSPM, controller2addr_map, idTo2d_map, complete_signal_sink_out):
 
     s.num_tiles = len(TileList)
     s.src_ctrl_pkt = TestSrcRTL(CtrlPktType, src_ctrl_pkt)
+    s.complete_signal_sink_out = TestSinkRTL(CtrlPktType, complete_signal_sink_out)
 
     s.dut = DUT(DataType, PredicateType, CtrlPktType, CtrlSignalType,
                 NocPktType, CmdType, ControllerIdType,
@@ -89,6 +91,7 @@ class TestHarness(Component):
     # we have to connect from_noc and to_noc in testbench.
     s.dut.send_to_noc //= s.bypass_queue.recv
     s.bypass_queue.send //= s.dut.recv_from_noc
+    s.complete_signal_sink_out.recv //= s.dut.send_to_cpu_pkt
 
   def done(s):
     return s.src_ctrl_pkt.done()
@@ -175,9 +178,6 @@ class Link:
     if s.fromMem:
       s.dstTile.fromMem = True
 
-
-import platform
-import pytest
 
 def test_cgra_universal(cmdline_opts, paramCGRA = None):
   num_tile_inports  = 8
@@ -279,6 +279,7 @@ def test_cgra_universal(cmdline_opts, paramCGRA = None):
       CtrlPktType(0, 0,  i,  0,    0,  CMD_LAUNCH, 0, OPT_ADD, 0,
                   pick_register, tile_in_code, fu_out_code)
       ] for i in range(num_tiles)]
+  complete_signal_sink_out = [CtrlPktType(0, 0, 0, 0, 0, ctrl_action = CMD_COMPLETE)]
 
   src_ctrl_pkt = []
   for opt_per_tile in src_opt_per_tile:
@@ -420,7 +421,7 @@ def test_cgra_universal(cmdline_opts, paramCGRA = None):
                    data_mem_size_per_bank, num_banks_per_cgra,
                    num_registers_per_reg_bank,
                    src_ctrl_pkt, ctrl_mem_size, tiles, links, dataSPM,
-                   controller2addr_map, idTo2d_map)
+                   controller2addr_map, idTo2d_map, complete_signal_sink_out)
 
   th.elaborate()
   th.dut.set_metadata(VerilogTranslationPass.explicit_module_name,

--- a/cgra/test/CgraTemplateRTL_test.py
+++ b/cgra/test/CgraTemplateRTL_test.py
@@ -94,7 +94,7 @@ class TestHarness(Component):
     s.complete_signal_sink_out.recv //= s.dut.send_to_cpu_pkt
 
   def done(s):
-    return s.src_ctrl_pkt.done()
+    return s.src_ctrl_pkt.done() and s.complete_signal_sink_out.done()
 
   def line_trace(s):
     return s.dut.line_trace()
@@ -279,7 +279,7 @@ def test_cgra_universal(cmdline_opts, paramCGRA = None):
       CtrlPktType(0, 0,  i,  0,    0,  CMD_LAUNCH, 0, OPT_ADD, 0,
                   pick_register, tile_in_code, fu_out_code)
       ] for i in range(num_tiles)]
-  complete_signal_sink_out = [CtrlPktType(0, 0, 0, 0, 0, ctrl_action = CMD_COMPLETE)]
+  complete_signal_sink_out = [CtrlPktType(0, 0, num_tiles, 0, 1, ctrl_action = CMD_COMPLETE)]
 
   src_ctrl_pkt = []
   for opt_per_tile in src_opt_per_tile:

--- a/controller/ControllerRTL.py
+++ b/controller/ControllerRTL.py
@@ -118,15 +118,21 @@ class ControllerRTL(Component):
     # format can be in a universal fashion to support both data and config. Later
     # on, the format can be packet-based or flit-based.
     s.recv_from_cpu_pkt //= s.recv_from_cpu_pkt_queue.recv
+    s.send_to_cpu_pkt_queue.recv //= s.recv_from_ctrl_ring_pkt
     s.send_to_cpu_pkt //= s.send_to_cpu_pkt_queue.send
 
-    @update
-    def update_send_to_cpu_signal():
-        s.send_to_cpu_pkt_queue.recv.val @= 0
-        s.send_to_cpu_pkt_queue.recv.msg @= CpuPktType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-        if s.recv_from_ctrl_ring_pkt.val:
-            s.send_to_cpu_pkt_queue.recv.msg @= s.recv_from_ctrl_ring_pkt.msg
-            s.send_to_cpu_pkt_queue.recv.val @= 1
+    # @update
+    # def update_send_to_cpu_signal():
+    #     s.send_to_cpu_pkt_queue.recv.val @= 0
+    #     s.send_to_cpu_pkt_queue.recv.msg @= CpuPktType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    #     # print('~~~~~~~~~~~~~~~~~~')
+    #     # s.recv_from_ctrl_ring_pkt.rdy @= 1
+    #     if s.recv_from_ctrl_ring_pkt.val:
+    #         # print(f'----------------------')
+    #         # print(str(s.recv_from_ctrl_ring_pkt.msg))
+    #         # print(f'++++++++++++++++++++++')
+    #         s.send_to_cpu_pkt_queue.recv.msg @= s.recv_from_ctrl_ring_pkt.msg
+    #         s.send_to_cpu_pkt_queue.recv.val @= 1
 
     @update
     def update_received_msg():

--- a/controller/ControllerRTL.py
+++ b/controller/ControllerRTL.py
@@ -8,7 +8,6 @@ Author : Cheng Tan
   Date : Dec 2, 2024
 """
 
-from pymtl3 import *
 from ..lib.basic.val_rdy.ifcs import RecvIfcRTL as RecvIfcRTL
 from ..lib.basic.val_rdy.ifcs import SendIfcRTL as SendIfcRTL
 from ..lib.basic.val_rdy.queues import NormalQueueRTL
@@ -121,18 +120,6 @@ class ControllerRTL(Component):
     s.send_to_cpu_pkt_queue.recv //= s.recv_from_ctrl_ring_pkt
     s.send_to_cpu_pkt //= s.send_to_cpu_pkt_queue.send
 
-    # @update
-    # def update_send_to_cpu_signal():
-    #     s.send_to_cpu_pkt_queue.recv.val @= 0
-    #     s.send_to_cpu_pkt_queue.recv.msg @= CpuPktType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-    #     # print('~~~~~~~~~~~~~~~~~~')
-    #     # s.recv_from_ctrl_ring_pkt.rdy @= 1
-    #     if s.recv_from_ctrl_ring_pkt.val:
-    #         # print(f'----------------------')
-    #         # print(str(s.recv_from_ctrl_ring_pkt.msg))
-    #         # print(f'++++++++++++++++++++++')
-    #         s.send_to_cpu_pkt_queue.recv.msg @= s.recv_from_ctrl_ring_pkt.msg
-    #         s.send_to_cpu_pkt_queue.recv.val @= 1
 
     @update
     def update_received_msg():

--- a/controller/test/ControllerRTL_test.py
+++ b/controller/test/ControllerRTL_test.py
@@ -71,8 +71,8 @@ class TestHarness(Component):
     s.dut.send_to_tile_store_request_addr //= s.sink_to_tile_store_request_addr_en_rdy.recv
     s.dut.send_to_tile_store_request_data //= s.sink_to_tile_store_request_data_en_rdy.recv
 
-    s.src_from_noc_val_rdy.send //= s.dut.recv_from_noc
-    s.dut.send_to_noc //= s.sink_to_noc_val_rdy.recv
+    s.src_from_noc_val_rdy.send //= s.dut.recv_from_inter_cgra_noc
+    s.dut.send_to_inter_cgra_noc //= s.sink_to_noc_val_rdy.recv
 
     s.dut.recv_from_cpu_pkt.val //= 0
     s.dut.recv_from_cpu_pkt.msg //= CpuPktType()

--- a/controller/test/ControllerRTL_test.py
+++ b/controller/test/ControllerRTL_test.py
@@ -8,7 +8,6 @@ Author : Cheng Tan
   Date : Dec 15, 2024
 '''
 
-from pymtl3 import *
 from pymtl3.stdlib.test_utils import config_model_with_cmdline_opts
 
 from ..ControllerRTL import ControllerRTL

--- a/controller/test/ControllerRTL_test.py
+++ b/controller/test/ControllerRTL_test.py
@@ -27,7 +27,7 @@ import pytest
 
 class TestHarness(Component):
 
-  def construct(s, ControllerIdType, FromCpuPktType, CmdType, MsgType,
+  def construct(s, ControllerIdType, CpuPktType, CmdType, MsgType,
                 AddrType, PktType, controller_id,
                 from_tile_load_request_pkt_msgs,
                 from_tile_load_response_pkt_msgs,
@@ -55,7 +55,7 @@ class TestHarness(Component):
     s.src_from_noc_val_rdy = TestSrcRTL(PktType, from_noc_pkts)
     s.sink_to_noc_val_rdy = TestNetSinkRTL(PktType, expected_to_noc_pkts, cmp_fn = cmp_func)
 
-    s.dut = ControllerRTL(ControllerIdType, CmdType, FromCpuPktType,
+    s.dut = ControllerRTL(ControllerIdType, CmdType, CpuPktType,
                           PktType, MsgType, AddrType,
                           # Number of controllers globally (x/y dimension).
                           1, num_terminals,
@@ -77,7 +77,7 @@ class TestHarness(Component):
     s.dut.send_to_noc //= s.sink_to_noc_val_rdy.recv
 
     s.dut.recv_from_cpu_pkt.val //= 0
-    s.dut.recv_from_cpu_pkt.msg //= FromCpuPktType()
+    s.dut.recv_from_cpu_pkt.msg //= CpuPktType()
     s.dut.send_to_ctrl_ring_ctrl_pkt.rdy //= 0
 
   def done(s):
@@ -173,7 +173,7 @@ controller2addr_map = {
         3: [12, 15],
 }
 
-FromCpuPktType = mk_intra_cgra_pkt(ntiles,
+CpuPktType = mk_intra_cgra_pkt(ntiles,
                                      cgra_id_nbits,
                                      num_commands,
                                      ctrl_mem_size,
@@ -252,7 +252,7 @@ expected_to_noc_pkts = [
 def test_simple(cmdline_opts):
   print("controller2addr_map: ", controller2addr_map)
   th = TestHarness(ControllerIdType,
-                   FromCpuPktType,
+                   CpuPktType,
                    CmdType,
                    DataType,
                    AddrType,

--- a/controller/test/ControllerRTL_test.py
+++ b/controller/test/ControllerRTL_test.py
@@ -39,7 +39,8 @@ class TestHarness(Component):
                 from_noc_pkts,
                 expected_to_noc_pkts,
                 controller2addr_map,
-                idTo2d_map, num_terminals):
+                idTo2d_map, num_terminals,
+                complete_ctrl_pkt):
 
     cmp_func = lambda a, b : a == b # a.data == b.data
 
@@ -54,6 +55,7 @@ class TestHarness(Component):
 
     s.src_from_noc_val_rdy = TestSrcRTL(PktType, from_noc_pkts)
     s.sink_to_noc_val_rdy = TestNetSinkRTL(PktType, expected_to_noc_pkts, cmp_fn = cmp_func)
+    s.execution_complete_cmd = TestSinkRTL(CpuPktType, complete_ctrl_pkt)
 
     s.dut = ControllerRTL(ControllerIdType, CmdType, CpuPktType,
                           PktType, MsgType, AddrType,
@@ -79,6 +81,7 @@ class TestHarness(Component):
     s.dut.recv_from_cpu_pkt.val //= 0
     s.dut.recv_from_cpu_pkt.msg //= CpuPktType()
     s.dut.send_to_ctrl_ring_pkt.rdy //= 0
+    s.execution_complete_cmd.recv //= s.dut.send_to_cpu_pkt
 
   def done(s):
     return s.src_from_tile_load_request_pkt_en_rdy.done() and \
@@ -248,6 +251,7 @@ expected_to_noc_pkts = [
     Pkt(1,   3,  1,    0,    3,    0,    0,      0,  0, 12,  12,  1,        0,      CMD_LOAD_RESPONSE, 0,        0,      0,        0,      0,               0,              0),
     Pkt(1,   3,  1,    0,    3,    0,    0,      0,  0, 15,  150, 1,        0,      CMD_STORE_REQUEST, 0,        0,      0,        0,      0,               0,              0),
 ]
+complete_ctrl_pkt = [CpuPktType(0, 0, 0, 0, 0, ctrl_action = CMD_COMPLETE)]
 
 def test_simple(cmdline_opts):
   print("controller2addr_map: ", controller2addr_map)
@@ -272,7 +276,8 @@ def test_simple(cmdline_opts):
                    expected_to_noc_pkts,
                    controller2addr_map,
                    idTo2d_map,
-                   nterminals)
+                   nterminals,
+                   complete_ctrl_pkt)
   th.elaborate()
   th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
   run_sim(th)

--- a/controller/test/ControllerRTL_test.py
+++ b/controller/test/ControllerRTL_test.py
@@ -9,17 +9,16 @@ Author : Cheng Tan
 '''
 
 from pymtl3 import *
-from pymtl3.stdlib.test_utils import TestVectorSimulator, config_model_with_cmdline_opts
+from pymtl3.stdlib.test_utils import config_model_with_cmdline_opts
+
 from ..ControllerRTL import ControllerRTL
 from ...lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL
 from ...lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
-from ...lib.basic.val_rdy.ifcs import ValRdySendIfcRTL as SendIfcRTL
-from ...lib.basic.val_rdy.ifcs import ValRdyRecvIfcRTL as RecvIfcRTL
-from ...lib.messages import *
 from ...lib.cmd_type import *
+from ...lib.messages import *
 from ...lib.opt_type import *
 from ...noc.PyOCN.pymtl3_net.ocnlib.test.stream_sinks import NetSinkRTL as TestNetSinkRTL
-import pytest
+
 
 #-------------------------------------------------------------------------
 # TestHarness

--- a/controller/test/ControllerRTL_test.py
+++ b/controller/test/ControllerRTL_test.py
@@ -78,7 +78,7 @@ class TestHarness(Component):
 
     s.dut.recv_from_cpu_pkt.val //= 0
     s.dut.recv_from_cpu_pkt.msg //= CpuPktType()
-    s.dut.send_to_ctrl_ring_ctrl_pkt.rdy //= 0
+    s.dut.send_to_ctrl_ring_pkt.rdy //= 0
 
   def done(s):
     return s.src_from_tile_load_request_pkt_en_rdy.done() and \

--- a/lib/cmd_type.py
+++ b/lib/cmd_type.py
@@ -14,7 +14,7 @@ from pymtl3 import *
 
 # Total number of commands that are supported/recognized by controller.
 # Needs to be updated once more commands are added/supported.
-NUM_CMDS = 8
+NUM_CMDS = 9
 
 CMD_LAUNCH        = 0
 CMD_PAUSE         = 1
@@ -24,6 +24,7 @@ CMD_LOAD_REQUEST  = 4
 CMD_LOAD_RESPONSE = 5
 CMD_STORE_REQUEST = 6
 CMD_CONST         = 7
+CMD_COMPLETE      = 8
 
 CMD_SYMBOL_DICT = {
   CMD_LAUNCH:        "(LAUNCH_KERNEL)",
@@ -33,6 +34,7 @@ CMD_SYMBOL_DICT = {
   CMD_LOAD_REQUEST:  "(LOAD_REQUEST)",
   CMD_LOAD_RESPONSE: "(LOAD_RESPONSE)",
   CMD_STORE_REQUEST: "(STORE_REQUEST)",
-  CMD_CONST:         "(CONST_DATA)"
+  CMD_CONST:         "(CONST_DATA)",
+  CMD_COMPLETE:      "(COMPLETE_EXECUTION)"
 }
 

--- a/lib/messages.py
+++ b/lib/messages.py
@@ -479,7 +479,7 @@ def mk_multi_cgra_noc_pkt(ncols = 4, nrows = 4, ntiles = 16,
   IdType = mk_bits(max(clog2(ncols * nrows), 1))
   XType = mk_bits(max(clog2(ncols), 1))
   YType = mk_bits(max(clog2(nrows), 1))
-  # An additional port for Controller to receive CMD_COMPLETE signal from Ring to Cpu.
+  # An additional router for controller to receive CMD_COMPLETE signal from Ring to CPU.
   TileIdType = mk_bits(max(clog2(ntiles + 1), 1))
   OpqType = mk_bits(opaque_nbits)
   AddrType = mk_bits(addr_nbits)
@@ -565,7 +565,7 @@ def mk_intra_cgra_pkt(ntiles = 4,
                       prefix="PreloadCGRAsPacket"):
 
   CgraIdType = mk_bits(cgraId_nbits)
-  # An additional port for Controller to receive CMD_COMPLETE signal from Ring to Cpu.
+  # An additional router for controller to receive CMD_COMPLETE signal from Ring to CPU.
   TileIdType = mk_bits(clog2(ntiles + 1))
   opaque_nbits = 8
   OpqType = mk_bits(opaque_nbits)

--- a/lib/messages.py
+++ b/lib/messages.py
@@ -479,6 +479,7 @@ def mk_multi_cgra_noc_pkt(ncols = 4, nrows = 4, ntiles = 16,
   IdType = mk_bits(max(clog2(ncols * nrows), 1))
   XType = mk_bits(max(clog2(ncols), 1))
   YType = mk_bits(max(clog2(nrows), 1))
+  # An additional port for Controller to receive CMD_COMPLETE signal from Ring to Cpu.
   TileIdType = mk_bits(max(clog2(ntiles + 1), 1))
   OpqType = mk_bits(opaque_nbits)
   AddrType = mk_bits(addr_nbits)
@@ -564,6 +565,7 @@ def mk_intra_cgra_pkt(ntiles = 4,
                       prefix="PreloadCGRAsPacket"):
 
   CgraIdType = mk_bits(cgraId_nbits)
+  # An additional port for Controller to receive CMD_COMPLETE signal from Ring to Cpu.
   TileIdType = mk_bits(clog2(ntiles + 1))
   opaque_nbits = 8
   OpqType = mk_bits(opaque_nbits)

--- a/lib/messages.py
+++ b/lib/messages.py
@@ -479,7 +479,7 @@ def mk_multi_cgra_noc_pkt(ncols = 4, nrows = 4, ntiles = 16,
   IdType = mk_bits(max(clog2(ncols * nrows), 1))
   XType = mk_bits(max(clog2(ncols), 1))
   YType = mk_bits(max(clog2(nrows), 1))
-  TileIdType = mk_bits(max(clog2(ntiles), 1))
+  TileIdType = mk_bits(max(clog2(ntiles + 1), 1))
   OpqType = mk_bits(opaque_nbits)
   AddrType = mk_bits(addr_nbits)
   DataType = mk_bits(data_nbits)
@@ -564,7 +564,7 @@ def mk_intra_cgra_pkt(ntiles = 4,
                       prefix="PreloadCGRAsPacket"):
 
   CgraIdType = mk_bits(cgraId_nbits)
-  TileIdType = mk_bits(clog2(ntiles))
+  TileIdType = mk_bits(clog2(ntiles + 1))
   opaque_nbits = 8
   OpqType = mk_bits(opaque_nbits)
   CtrlActionType = mk_bits(clog2(ctrl_actions))

--- a/lib/messages.py
+++ b/lib/messages.py
@@ -653,7 +653,7 @@ def mk_intra_cgra_pkt(ntiles = 4,
         out_str += '-'
       out_str += str(int(s.ctrl_read_reg_idx[i]))
 
-    return f"{s.src}>{s.dst}:{s.opaque}:{s.ctrl_action}.{s.ctrl_addr}." \
+    return f"{s.cgra_id}:{s.src}>{s.dst}:{s.opaque}.{s.vc_id}:{s.ctrl_action}.{s.ctrl_addr}." \
            f"{out_str}"
 
   field_dict = {}

--- a/mem/ctrl/CtrlMemDynamicRTL.py
+++ b/mem/ctrl/CtrlMemDynamicRTL.py
@@ -134,9 +134,9 @@ class CtrlMemDynamicRTL(Component):
       # else:
       #   s.start_iterate_ctrl <<= 1
       if s.complete_iterate_ctrl:
-        s.send_pkt.msg <<= CtrlPktType(0, 0, 0, 0, 0, ctrl_action = CMD_COMPLETE)
+        s.send_pkt.msg <<= CtrlPktType(0, 0, 0, 0, 0, CMD_COMPLETE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
         s.send_pkt.val <<= 1
-        print(f'\n=> s.send_pkt.msg: {s.send_pkt.msg}\n')
+        # print(f'\n=> s.send_pkt.msg: {s.send_pkt.msg}\n')
 
     @update_ff
     def update_raddr():

--- a/mem/ctrl/CtrlMemDynamicRTL.py
+++ b/mem/ctrl/CtrlMemDynamicRTL.py
@@ -159,5 +159,5 @@ class CtrlMemDynamicRTL(Component):
 
   def line_trace(s):
     config_mem_str  = "|".join([str(data) for data in s.reg_file.regs])
-    return f'recv_pkt: {s.recv_pkt.msg}.recv_rdy:{s.recv_pkt.rdy} || control signal content: [{config_mem_str}] || ctrl_out: {s.send_ctrl.msg}, send_ctrl.val: {s.send_ctrl.val}, send_ctrl.rdy: {s.send_ctrl.rdy}'
+    return f'recv_pkt: {s.recv_pkt.msg}.recv_rdy:{s.recv_pkt.rdy} || control signal content: [{config_mem_str}] || ctrl_out: {s.send_ctrl.msg}, send_ctrl.val: {s.send_ctrl.val}, send_ctrl.rdy: {s.send_ctrl.rdy}, send_pkt.msg.ctrl_action: {s.send_pkt.msg.ctrl_action}, send_pkt.val: {s.send_pkt.val}'
 

--- a/mem/ctrl/CtrlMemDynamicRTL.py
+++ b/mem/ctrl/CtrlMemDynamicRTL.py
@@ -128,6 +128,10 @@ class CtrlMemDynamicRTL(Component):
           s.start_iterate_ctrl <<= 0
       # else:
       #   s.start_iterate_ctrl <<= 1
+      if s.complete_iterate_ctrl:
+        s.send_pkt.msg <<= CtrlPktType(0, 0, 0, 0, 0, ctrl_action = CMD_COMPLETE)
+        s.send_pkt.val <<= 1
+        print(f'\n=> s.send_pkt.msg: {s.send_pkt.msg}\n')
 
     @update_ff
     def update_raddr():

--- a/mem/ctrl/CtrlMemDynamicRTL.py
+++ b/mem/ctrl/CtrlMemDynamicRTL.py
@@ -23,7 +23,8 @@ class CtrlMemDynamicRTL(Component):
   def construct(s, CtrlPktType, CtrlSignalType, ctrl_mem_size,
                 num_fu_inports, num_fu_outports, num_tile_inports,
                 num_tile_outports, ctrl_count_per_iter = 4,
-                total_ctrl_steps = 4):
+                total_ctrl_steps = 4,
+                tile_id = 0):
 
     # The total_ctrl_steps indicates the number of steps the ctrl
     # signals should proceed. For example, if the number of ctrl
@@ -114,7 +115,7 @@ class CtrlMemDynamicRTL(Component):
            (s.reg_file.rdata[0].ctrl == OPT_START):
           s.send_ctrl.val @= b1(0)
           if (s.sent_complete != 1) & (total_ctrl_steps > 0) & (s.times == TimeType(total_ctrl_steps)):
-            s.send_pkt.msg @= CtrlPktType(0, 0, 0, 0, 0, CMD_COMPLETE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+            s.send_pkt.msg @= CtrlPktType(0, 0, tile_id, 0, 0, CMD_COMPLETE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
             s.send_pkt.val @= 1
         else:
           s.send_ctrl.val @= 1

--- a/mem/ctrl/CtrlMemDynamicRTL.py
+++ b/mem/ctrl/CtrlMemDynamicRTL.py
@@ -23,8 +23,8 @@ class CtrlMemDynamicRTL(Component):
 
   def construct(s, CtrlPktType, CtrlSignalType, ctrl_mem_size,
                 num_fu_inports, num_fu_outports, num_tile_inports,
-                num_tile_outports, ctrl_count_per_iter = 4,
-                total_ctrl_steps = 4):
+                num_tile_outports, num_tiles,
+                ctrl_count_per_iter = 4, total_ctrl_steps = 4):
 
     # The total_ctrl_steps indicates the number of steps the ctrl
     # signals should proceed. For example, if the number of ctrl
@@ -115,7 +115,7 @@ class CtrlMemDynamicRTL(Component):
            (s.reg_file.rdata[0].ctrl == OPT_START):
           s.send_ctrl.val @= b1(0)
           if (s.sent_complete != 1) & (total_ctrl_steps > 0) & (s.times == TimeType(total_ctrl_steps)):
-            s.send_pkt.msg @= CtrlPktType(0, 0, 0, 0, 0, CMD_COMPLETE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+            s.send_pkt.msg @= CtrlPktType(0, 0, num_tiles, 0, 0, CMD_COMPLETE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
             s.send_pkt.val @= 1
         else:
           s.send_ctrl.val @= 1

--- a/mem/ctrl/CtrlMemDynamicRTL.py
+++ b/mem/ctrl/CtrlMemDynamicRTL.py
@@ -24,8 +24,7 @@ class CtrlMemDynamicRTL(Component):
   def construct(s, CtrlPktType, CtrlSignalType, ctrl_mem_size,
                 num_fu_inports, num_fu_outports, num_tile_inports,
                 num_tile_outports, ctrl_count_per_iter = 4,
-                total_ctrl_steps = 4,
-                tile_id = 0):
+                total_ctrl_steps = 4):
 
     # The total_ctrl_steps indicates the number of steps the ctrl
     # signals should proceed. For example, if the number of ctrl
@@ -116,7 +115,7 @@ class CtrlMemDynamicRTL(Component):
            (s.reg_file.rdata[0].ctrl == OPT_START):
           s.send_ctrl.val @= b1(0)
           if (s.sent_complete != 1) & (total_ctrl_steps > 0) & (s.times == TimeType(total_ctrl_steps)):
-            s.send_pkt.msg @= CtrlPktType(0, 0, tile_id, 0, 0, CMD_COMPLETE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+            s.send_pkt.msg @= CtrlPktType(0, 0, 0, 0, 0, CMD_COMPLETE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
             s.send_pkt.val @= 1
         else:
           s.send_ctrl.val @= 1

--- a/mem/ctrl/CtrlMemDynamicRTL.py
+++ b/mem/ctrl/CtrlMemDynamicRTL.py
@@ -9,14 +9,15 @@ Author : Cheng Tan
   Date : Dec 20, 2024
 """
 
-from pymtl3 import *
 from pymtl3.stdlib.primitive import RegisterFile
+
 from ...lib.basic.en_rdy.ifcs import SendIfcRTL
 from ...lib.basic.val_rdy.ifcs import ValRdyRecvIfcRTL as RecvIfcRTL
 from ...lib.basic.val_rdy.ifcs import ValRdySendIfcRTL as SendIfcRTL
 from ...lib.basic.val_rdy.queues import NormalQueueRTL
 from ...lib.cmd_type import *
 from ...lib.opt_type import *
+
 
 class CtrlMemDynamicRTL(Component):
 

--- a/mem/ctrl/CtrlMemDynamicRTL.py
+++ b/mem/ctrl/CtrlMemDynamicRTL.py
@@ -142,7 +142,7 @@ class CtrlMemDynamicRTL(Component):
 
     @update_ff
     def issue_complete():
-      # Once COMPLETE signal is sent, we cannot send another COMPLETE signal until the next ctrl signal is launched.
+      # Once COMPLETE signal is sent, we shouldn't send another COMPLETE signal until the next ctrl signal is launched.
       if s.send_pkt_to_controller.val & s.send_pkt_to_controller.rdy:
         s.sent_complete <<= 1
       if s.recv_pkt_queue.send.msg.ctrl_action == CMD_LAUNCH:

--- a/mem/ctrl/RingMultiCtrlMemDynamicRTL.py
+++ b/mem/ctrl/RingMultiCtrlMemDynamicRTL.py
@@ -36,7 +36,7 @@ class RingMultiCtrlMemDynamicRTL(Component):
     s.ctrl_memories = [
         CtrlMemDynamicRTL(CtrlPktType, CtrlSignalType, ctrl_mem_size,
                           num_fu_inports, num_fu_outports, num_tile_inports,
-                          num_tile_outports, ctrl_count_per_iter,
+                          num_tile_outports, num_terminals, ctrl_count_per_iter,
                           total_ctrl_steps) for terminal_id in range(s.num_terminals)]
     s.ctrl_ring = RingNetworkRTL(CtrlPktType, CtrlRingPos, num_terminals + 1, 1)
 
@@ -46,8 +46,7 @@ class RingMultiCtrlMemDynamicRTL(Component):
     s.ctrl_ring.send[s.num_terminals] //= s.send_towards_controller_pkt
 
     for i in range(s.num_terminals):
-      s.ctrl_ring.recv[i].val //= 0
-      s.ctrl_ring.recv[i].msg //= CtrlPktType()
+      s.ctrl_ring.recv[i] //= s.ctrl_memories[i].send_pkt
     s.ctrl_ring.recv[s.num_terminals] //= s.recv_pkt_from_controller
 
     for i in range(s.num_terminals):

--- a/mem/ctrl/RingMultiCtrlMemDynamicRTL.py
+++ b/mem/ctrl/RingMultiCtrlMemDynamicRTL.py
@@ -30,7 +30,7 @@ class RingMultiCtrlMemDynamicRTL(Component):
     # Interface
     s.send_ctrl = [SendIfcRTL(CtrlSignalType) for _ in range(s.num_terminals)]
     s.recv_pkt_from_controller = RecvIfcRTL(CtrlPktType)
-    s.send_towards_controller_pkt = SendIfcRTL(CtrlPktType)
+    s.send_to_controller_pkt = SendIfcRTL(CtrlPktType)
 
     # Components
     s.ctrl_memories = [
@@ -42,11 +42,11 @@ class RingMultiCtrlMemDynamicRTL(Component):
 
     # Connections
     for i in range(s.num_terminals):
-      s.ctrl_ring.send[i] //= s.ctrl_memories[i].recv_pkt
-    s.ctrl_ring.send[s.num_terminals] //= s.send_towards_controller_pkt
+      s.ctrl_ring.send[i] //= s.ctrl_memories[i].recv_pkt_from_controller
+    s.ctrl_ring.send[s.num_terminals] //= s.send_to_controller_pkt
 
     for i in range(s.num_terminals):
-      s.ctrl_ring.recv[i] //= s.ctrl_memories[i].send_pkt
+      s.ctrl_ring.recv[i] //= s.ctrl_memories[i].send_pkt_to_controller
     s.ctrl_ring.recv[s.num_terminals] //= s.recv_pkt_from_controller
 
     for i in range(s.num_terminals):

--- a/mem/ctrl/RingMultiCtrlMemDynamicRTL.py
+++ b/mem/ctrl/RingMultiCtrlMemDynamicRTL.py
@@ -25,11 +25,12 @@ class RingMultiCtrlMemDynamicRTL(Component):
     # Constant
     num_terminals = width * height
     s.num_terminals = width * height
-    CtrlRingPos = mk_ring_pos(num_terminals)
+    CtrlRingPos = mk_ring_pos(num_terminals + 1)
 
     # Interface
     s.send_ctrl = [SendIfcRTL(CtrlSignalType) for _ in range(s.num_terminals)]
     s.recv_pkt_from_controller = RecvIfcRTL(CtrlPktType)
+    s.send_towards_controller_pkt = SendIfcRTL(CtrlPktType)
 
     # Components
     s.ctrl_memories = [
@@ -37,16 +38,17 @@ class RingMultiCtrlMemDynamicRTL(Component):
                           num_fu_inports, num_fu_outports, num_tile_inports,
                           num_tile_outports, ctrl_count_per_iter,
                           total_ctrl_steps) for terminal_id in range(s.num_terminals)]
-    s.ctrl_ring = RingNetworkRTL(CtrlPktType, CtrlRingPos, num_terminals, 1)
+    s.ctrl_ring = RingNetworkRTL(CtrlPktType, CtrlRingPos, num_terminals + 1, 1)
 
     # Connections
     for i in range(s.num_terminals):
       s.ctrl_ring.send[i] //= s.ctrl_memories[i].recv_pkt
+    s.ctrl_ring.send[s.num_terminals] //= s.send_towards_controller_pkt
 
-    s.ctrl_ring.recv[0] //= s.recv_pkt_from_controller
-    for i in range(1, s.num_terminals):
+    for i in range(s.num_terminals):
       s.ctrl_ring.recv[i].val //= 0
       s.ctrl_ring.recv[i].msg //= CtrlPktType()
+    s.ctrl_ring.recv[s.num_terminals] //= s.recv_pkt_from_controller
 
     for i in range(s.num_terminals):
       s.ctrl_memories[i].send_ctrl //= s.send_ctrl[i]

--- a/mem/ctrl/test/CtrlMemDynamicRTL_test.py
+++ b/mem/ctrl/test/CtrlMemDynamicRTL_test.py
@@ -7,7 +7,6 @@ Test cases for control memory with command-based action handling.
 Author : Cheng Tan
   Date : Dec 21, 2024
 """
-from pymtl3 import *
 from ..CtrlMemDynamicRTL import CtrlMemDynamicRTL
 from ....fu.single.AdderRTL import AdderRTL
 from ....lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL

--- a/mem/ctrl/test/CtrlMemDynamicRTL_test.py
+++ b/mem/ctrl/test/CtrlMemDynamicRTL_test.py
@@ -46,8 +46,8 @@ class TestHarness(Component):
                          len(ctrl_pkts), len(ctrl_pkts))
 
     s.alu.recv_opt //= s.ctrl_mem.send_ctrl
-    s.src_pkt.send //= s.ctrl_mem.recv_pkt
-    s.complete_signal_sink_out.recv //= s.ctrl_mem.send_pkt
+    s.src_pkt.send //= s.ctrl_mem.recv_pkt_from_controller
+    s.complete_signal_sink_out.recv //= s.ctrl_mem.send_pkt_to_controller
     s.src_data0.send //= s.alu.recv_in[0]
     s.src_data1.send //= s.alu.recv_in[1]
     s.alu.send_out[0] //= s.sink_out.recv
@@ -138,7 +138,8 @@ def test_Ctrl():
                   CtrlPktType(0,      0,  1,  0,     0,    CMD_LAUNCH, 0,        OPT_NAH,       0,             pick_register)]
 
   sink_out = [DataType(7, 1), DataType(4, 1), DataType(5, 1), DataType(9, 1)]
-  complete_signal_sink_out = [CtrlPktType(0,      0,  num_terminals,  0,    0, ctrl_action = CMD_COMPLETE)]
+  #                                       cgra_id, src,            dst, opaque, vc, ctrl_action
+  complete_signal_sink_out = [CtrlPktType(      0,   0,  num_terminals,      0,  0, ctrl_action = CMD_COMPLETE)]
 
   th = TestHarness(MemUnit, DataType, PredicateType, CtrlPktType, CtrlSignalType,
                    ctrl_mem_size, data_mem_size, num_fu_inports, num_fu_outports,

--- a/mem/ctrl/test/CtrlMemDynamicRTL_test.py
+++ b/mem/ctrl/test/CtrlMemDynamicRTL_test.py
@@ -7,12 +7,11 @@ Test cases for control memory with command-based action handling.
 Author : Cheng Tan
   Date : Dec 21, 2024
 """
-
 from pymtl3 import *
 from ..CtrlMemDynamicRTL import CtrlMemDynamicRTL
 from ....fu.single.AdderRTL import AdderRTL
-from ....lib.basic.val_rdy.SinkRTL import SinkRTL as ValRdyTestSinkRTL
-from ....lib.basic.val_rdy.SourceRTL import SourceRTL as ValRdyTestSrcRTL
+from ....lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL
+from ....lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
 from ....lib.cmd_type import *
 from ....lib.messages import *
 from ....lib.opt_type import *
@@ -32,13 +31,13 @@ class TestHarness(Component):
 
     AddrType = mk_bits(clog2(ctrl_mem_size))
 
-    s.src_data0 = ValRdyTestSrcRTL(DataType, src0_msgs)
-    s.src_data1 = ValRdyTestSrcRTL(DataType, src1_msgs)
+    s.src_data0 = TestSrcRTL(DataType, src0_msgs)
+    s.src_data1 = TestSrcRTL(DataType, src1_msgs)
     # s.src_waddr = TestSrcRTL(AddrType, ctrl_waddr )
     # s.src_wdata = TestSrcRTL(ConfigType, ctrl_msgs  )
-    s.src_pkt = ValRdyTestSrcRTL(CtrlPktType, ctrl_pkts)
-    s.sink_out = ValRdyTestSinkRTL(DataType, sink_msgs)
-    s.execution_complete_cmd = ValRdyTestSinkRTL(CtrlPktType, complete_ctrl_pkt)
+    s.src_pkt = TestSrcRTL(CtrlPktType, ctrl_pkts)
+    s.sink_out = TestSinkRTL(DataType, sink_msgs)
+    s.execution_complete_cmd = TestSinkRTL(CtrlPktType, complete_ctrl_pkt)
 
     s.alu = AdderRTL(DataType, PredicateType, CtrlSignalType, 2, 2,
                      data_mem_size)

--- a/mem/ctrl/test/CtrlMemDynamicRTL_test.py
+++ b/mem/ctrl/test/CtrlMemDynamicRTL_test.py
@@ -27,7 +27,7 @@ class TestHarness(Component):
                 CtrlSignalType, ctrl_mem_size, data_mem_size,
                 num_fu_inports, num_fu_outports, num_tile_inports,
                 num_tile_outports, src0_msgs, src1_msgs, ctrl_pkts,
-                sink_msgs, complete_ctrl_pkt):
+                sink_msgs, complete_signal_sink_out):
 
     AddrType = mk_bits(clog2(ctrl_mem_size))
 
@@ -37,7 +37,7 @@ class TestHarness(Component):
     # s.src_wdata = TestSrcRTL(ConfigType, ctrl_msgs  )
     s.src_pkt = TestSrcRTL(CtrlPktType, ctrl_pkts)
     s.sink_out = TestSinkRTL(DataType, sink_msgs)
-    s.execution_complete_cmd = TestSinkRTL(CtrlPktType, complete_ctrl_pkt)
+    s.complete_signal_sink_out = TestSinkRTL(CtrlPktType, complete_signal_sink_out)
 
     s.alu = AdderRTL(DataType, PredicateType, CtrlSignalType, 2, 2,
                      data_mem_size)
@@ -47,7 +47,7 @@ class TestHarness(Component):
 
     s.alu.recv_opt //= s.ctrl_mem.send_ctrl
     s.src_pkt.send //= s.ctrl_mem.recv_pkt
-    s.execution_complete_cmd.recv //= s.ctrl_mem.send_pkt
+    s.complete_signal_sink_out.recv //= s.ctrl_mem.send_pkt
     s.src_data0.send //= s.alu.recv_in[0]
     s.src_data1.send //= s.alu.recv_in[1]
     s.alu.send_out[0] //= s.sink_out.recv
@@ -138,12 +138,11 @@ def test_Ctrl():
                   CtrlPktType(0,      0,  1,  0,     0,    CMD_LAUNCH, 0,        OPT_NAH,       0,             pick_register)]
 
   sink_out = [DataType(7, 1), DataType(4, 1), DataType(5, 1), DataType(9, 1)]
-
-  complete_ctrl_pkt = [CtrlPktType(0,      0,  0,  0,    0, ctrl_action = CMD_COMPLETE)]
+  complete_signal_sink_out = [CtrlPktType(0,      0,  0,  0,    0, ctrl_action = CMD_COMPLETE)]
 
   th = TestHarness(MemUnit, DataType, PredicateType, CtrlPktType, CtrlSignalType,
                    ctrl_mem_size, data_mem_size, num_fu_inports, num_fu_outports,
                    num_tile_inports, num_tile_outports, src_data0, src_data1,
-                   src_ctrl_pkt, sink_out, complete_ctrl_pkt)
+                   src_ctrl_pkt, sink_out, complete_signal_sink_out)
   run_sim(th)
 

--- a/mem/ctrl/test/CtrlMemDynamicRTL_test.py
+++ b/mem/ctrl/test/CtrlMemDynamicRTL_test.py
@@ -26,7 +26,7 @@ class TestHarness(Component):
                 CtrlSignalType, ctrl_mem_size, data_mem_size,
                 num_fu_inports, num_fu_outports, num_tile_inports,
                 num_tile_outports, src0_msgs, src1_msgs, ctrl_pkts,
-                sink_msgs, complete_signal_sink_out):
+                sink_msgs, num_terminals, complete_signal_sink_out):
 
     AddrType = mk_bits(clog2(ctrl_mem_size))
 
@@ -42,7 +42,8 @@ class TestHarness(Component):
                      data_mem_size)
     s.ctrl_mem = MemUnit(CtrlPktType, CtrlSignalType, ctrl_mem_size,
                          num_fu_inports, num_fu_outports, num_tile_inports,
-                         num_tile_outports, len(ctrl_pkts), len(ctrl_pkts))
+                         num_tile_outports, num_terminals,
+                         len(ctrl_pkts), len(ctrl_pkts))
 
     s.alu.recv_opt //= s.ctrl_mem.send_ctrl
     s.src_pkt.send //= s.ctrl_mem.recv_pkt
@@ -53,7 +54,7 @@ class TestHarness(Component):
 
   def done(s):
     return s.src_data0.done() and s.src_data1.done() and \
-        s.src_pkt.done() and s.sink_out.done()
+        s.src_pkt.done() and s.sink_out.done() and s.complete_signal_sink_out.done()
 
   def line_trace(s):
     return s.alu.line_trace() + " || " +s.ctrl_mem.line_trace()
@@ -137,11 +138,11 @@ def test_Ctrl():
                   CtrlPktType(0,      0,  1,  0,     0,    CMD_LAUNCH, 0,        OPT_NAH,       0,             pick_register)]
 
   sink_out = [DataType(7, 1), DataType(4, 1), DataType(5, 1), DataType(9, 1)]
-  complete_signal_sink_out = [CtrlPktType(0,      0,  0,  0,    0, ctrl_action = CMD_COMPLETE)]
+  complete_signal_sink_out = [CtrlPktType(0,      0,  num_terminals,  0,    0, ctrl_action = CMD_COMPLETE)]
 
   th = TestHarness(MemUnit, DataType, PredicateType, CtrlPktType, CtrlSignalType,
                    ctrl_mem_size, data_mem_size, num_fu_inports, num_fu_outports,
                    num_tile_inports, num_tile_outports, src_data0, src_data1,
-                   src_ctrl_pkt, sink_out, complete_signal_sink_out)
+                   src_ctrl_pkt, sink_out, num_terminals, complete_signal_sink_out)
   run_sim(th)
 

--- a/mem/ctrl/test/RingCtrlMemDynamicRTL_test.py
+++ b/mem/ctrl/test/RingCtrlMemDynamicRTL_test.py
@@ -53,9 +53,7 @@ class TestHarness( Component ):
     for i in range(s.width * s.height):
       if not s.sink_out[i].done():
         return False
-    if not s.complete_signal_sink_out.done():
-        return False
-    return True
+    return s.complete_signal_sink_out.done()
 
   def line_trace(s):
     return s.dut.line_trace()
@@ -156,6 +154,8 @@ def test_Ctrl():
 
               [CtrlSignalType(OPT_SUB, 0, pickRegister),
                CtrlSignalType(OPT_ADD, 0, pickRegister)]]
+
+  # vc_id needs to be 1 due to the message might traverse across the date line via ring.
   #                                       cgra_id, src,           dst, opaque, vc, ctrl_action
   complete_signal_sink_out = [CtrlPktType(      0,   0, num_terminals,      0,  1, ctrl_action = CMD_COMPLETE)]
   th = TestHarness(MemUnit, DataType, PredicateType, CtrlPktType, CtrlSignalType,

--- a/mem/ctrl/test/RingCtrlMemDynamicRTL_test.py
+++ b/mem/ctrl/test/RingCtrlMemDynamicRTL_test.py
@@ -43,7 +43,7 @@ class TestHarness( Component ):
             len(ctrl_pkts), len(ctrl_pkts))
 
     connect(s.src_pkt.send, s.dut.recv_pkt_from_controller)
-    s.complete_signal_sink_out.recv //= s.dut.send_towards_controller_pkt
+    s.complete_signal_sink_out.recv //= s.dut.send_to_controller_pkt
     for i in range(width * height):
       connect(s.dut.send_ctrl[i], s.sink_out[i].recv)
 
@@ -156,7 +156,8 @@ def test_Ctrl():
 
               [CtrlSignalType(OPT_SUB, 0, pickRegister),
                CtrlSignalType(OPT_ADD, 0, pickRegister)]]
-  complete_signal_sink_out = [CtrlPktType(0, 0, num_terminals, 0, 1, ctrl_action = CMD_COMPLETE)]
+  #                                       cgra_id, src,           dst, opaque, vc, ctrl_action
+  complete_signal_sink_out = [CtrlPktType(      0,   0, num_terminals,      0,  1, ctrl_action = CMD_COMPLETE)]
   th = TestHarness(MemUnit, DataType, PredicateType, CtrlPktType, CtrlSignalType,
                    ctrl_mem_size, width, height, data_mem_size, num_fu_inports,
                    num_fu_outports, num_tile_inports, num_tile_outports,

--- a/scale_out/MeshMultiCgraRTL.py
+++ b/scale_out/MeshMultiCgraRTL.py
@@ -66,8 +66,8 @@ class MeshMultiCgraRTL(Component):
 
     # Connections
     for i in range(s.num_terminals):
-      s.mesh.send[i] //= s.cgra[i].recv_from_noc
-      s.mesh.recv[i] //= s.cgra[i].send_to_noc
+      s.mesh.send[i] //= s.cgra[i].recv_from_inter_cgra_noc
+      s.mesh.recv[i] //= s.cgra[i].send_to_inter_cgra_noc
 
     s.recv_from_cpu_pkt //= s.cgra[0].recv_from_cpu_pkt
     s.send_to_cpu_pkt //= s.cgra[0].send_to_cpu_pkt

--- a/scale_out/MeshMultiCgraRTL.py
+++ b/scale_out/MeshMultiCgraRTL.py
@@ -8,14 +8,13 @@ Author : Cheng Tan
   Date : Jan 8, 2025
 """
 
-from pymtl3 import *
-from pymtl3.stdlib.primitive import RegisterFile
 from ..cgra.CgraRTL import CgraRTL
 from ..lib.basic.val_rdy.ifcs import ValRdyRecvIfcRTL as RecvIfcRTL
+from ..lib.basic.val_rdy.ifcs import ValRdySendIfcRTL as SendIfcRTL
 from ..lib.opt_type import *
-from ..lib.util.common import *
-from ..noc.PyOCN.pymtl3_net.ocnlib.ifcs.positions import mk_mesh_pos
 from ..noc.PyOCN.pymtl3_net.meshnet.MeshNetworkRTL import MeshNetworkRTL
+from ..noc.PyOCN.pymtl3_net.ocnlib.ifcs.positions import mk_mesh_pos
+
 
 class MeshMultiCgraRTL(Component):
   def construct(s, CGRADataType, PredicateType, CtrlPktType,
@@ -39,6 +38,7 @@ class MeshMultiCgraRTL(Component):
     # Interface
     # Request from/to CPU.
     s.recv_from_cpu_pkt = RecvIfcRTL(CtrlPktType)
+    s.send_to_cpu_pkt = SendIfcRTL(CtrlPktType)
 
     # Components
     for cgra_row in range(cgra_rows):
@@ -70,9 +70,12 @@ class MeshMultiCgraRTL(Component):
       s.mesh.recv[i] //= s.cgra[i].send_to_noc
 
     s.recv_from_cpu_pkt //= s.cgra[0].recv_from_cpu_pkt
+    s.send_to_cpu_pkt //= s.cgra[0].send_to_cpu_pkt
+
     for i in range(1, s.num_terminals):
       s.cgra[i].recv_from_cpu_pkt.val //= 0
       s.cgra[i].recv_from_cpu_pkt.msg //= CtrlPktType()
+      s.cgra[i].send_to_cpu_pkt.rdy //= 0
 
     # Connects the tiles on the boundary of each two ajacent CGRAs.
     for cgra_row in range(cgra_rows):

--- a/scale_out/RingMultiCgraRTL.py
+++ b/scale_out/RingMultiCgraRTL.py
@@ -67,8 +67,8 @@ class RingMultiCgraRTL(Component):
     s.send_to_cpu_pkt //= s.cgra[0].send_to_cpu_pkt
 
     for i in range(s.num_terminals):
-      s.ring.send[i] //= s.cgra[i].recv_from_noc
-      s.ring.recv[i] //= s.cgra[i].send_to_noc
+      s.ring.send[i] //= s.cgra[i].recv_from_inter_cgra_noc
+      s.ring.recv[i] //= s.cgra[i].send_to_inter_cgra_noc
 
     for i in range(1, s.num_terminals):
       s.cgra[i].recv_from_cpu_pkt.val //= 0

--- a/scale_out/RingMultiCgraRTL.py
+++ b/scale_out/RingMultiCgraRTL.py
@@ -74,7 +74,6 @@ class RingMultiCgraRTL(Component):
       s.cgra[i].recv_from_cpu_pkt.val //= 0
       s.cgra[i].recv_from_cpu_pkt.msg //= CtrlPktType()
       s.cgra[i].send_to_cpu_pkt.rdy //= 0
-      # s.cgra[i].send_to_cpu_pkt.msg //= CtrlPktType()
 
     # Connects the tiles on the boundary of each two ajacent CGRAs.
     for cgra_row in range(cgra_rows):

--- a/scale_out/RingMultiCgraRTL.py
+++ b/scale_out/RingMultiCgraRTL.py
@@ -8,14 +8,13 @@ Author : Cheng Tan
   Date : Dec 23, 2024
 """
 
-from pymtl3 import *
-from pymtl3.stdlib.primitive import RegisterFile
 from ..cgra.CgraRTL import CgraRTL
 from ..lib.basic.val_rdy.ifcs import ValRdyRecvIfcRTL as RecvIfcRTL
+from ..lib.basic.val_rdy.ifcs import ValRdySendIfcRTL as SendIfcRTL
 from ..lib.opt_type import *
-from ..lib.util.common import *
 from ..noc.PyOCN.pymtl3_net.ocnlib.ifcs.positions import mk_ring_pos
 from ..noc.PyOCN.pymtl3_net.ringnet.RingNetworkRTL import RingNetworkRTL
+
 
 class RingMultiCgraRTL(Component):
   def construct(s, CGRADataType, PredicateType, CtrlPktType,
@@ -37,6 +36,7 @@ class RingMultiCgraRTL(Component):
     # Interface
     # Request from/to CPU.
     s.recv_from_cpu_pkt = RecvIfcRTL(CtrlPktType)
+    s.send_to_cpu_pkt = SendIfcRTL(CtrlPktType)
 
     # Components
     # Constructs the topology as 1d.
@@ -64,6 +64,8 @@ class RingMultiCgraRTL(Component):
       s.cgra[terminal_id].controller_id //= terminal_id
 
     s.recv_from_cpu_pkt //= s.cgra[0].recv_from_cpu_pkt
+    s.send_to_cpu_pkt //= s.cgra[0].send_to_cpu_pkt
+
     for i in range(s.num_terminals):
       s.ring.send[i] //= s.cgra[i].recv_from_noc
       s.ring.recv[i] //= s.cgra[i].send_to_noc
@@ -71,6 +73,8 @@ class RingMultiCgraRTL(Component):
     for i in range(1, s.num_terminals):
       s.cgra[i].recv_from_cpu_pkt.val //= 0
       s.cgra[i].recv_from_cpu_pkt.msg //= CtrlPktType()
+      s.cgra[i].send_to_cpu_pkt.rdy //= 0
+      # s.cgra[i].send_to_cpu_pkt.msg //= CtrlPktType()
 
     # Connects the tiles on the boundary of each two ajacent CGRAs.
     for cgra_row in range(cgra_rows):

--- a/scale_out/test/MeshMultiCgraRTL_test.py
+++ b/scale_out/test/MeshMultiCgraRTL_test.py
@@ -217,6 +217,8 @@ def test_homo_2x2_2x2(cmdline_opts):
                   [FuOutType(0), FuOutType(0), FuOutType(0), FuOutType(0),
                    FuOutType(1), FuOutType(1), FuOutType(1), FuOutType(1)], 0, 0, 0, 0, 0)
       ] for i in range(num_tiles)]
+
+  # vc_id needs to be 1 due to the message might traverse across the date line via ring.
   #                                       cgra_id, src,       dst, opaque, vc, ctrl_action
   complete_signal_sink_out = [CtrlPktType(      0,   0, num_tiles,      0,  1, ctrl_action = CMD_COMPLETE)]
 

--- a/scale_out/test/MeshMultiCgraRTL_test.py
+++ b/scale_out/test/MeshMultiCgraRTL_test.py
@@ -62,7 +62,7 @@ class TestHarness(Component):
     s.complete_signal_sink_out.recv //= s.dut.send_to_cpu_pkt
 
   def done(s):
-    return s.src_ctrl_pkt.done()
+    return s.src_ctrl_pkt.done() and s.complete_signal_sink_out.done()
 
   def line_trace(s):
     return s.dut.line_trace()
@@ -217,7 +217,7 @@ def test_homo_2x2_2x2(cmdline_opts):
                   [FuOutType(0), FuOutType(0), FuOutType(0), FuOutType(0),
                    FuOutType(1), FuOutType(1), FuOutType(1), FuOutType(1)], 0, 0, 0, 0, 0)
       ] for i in range(num_tiles)]
-  complete_signal_sink_out = [CtrlPktType(0, 0, 0, 0, 0, ctrl_action = CMD_COMPLETE)]
+  complete_signal_sink_out = [CtrlPktType(0, 0, num_tiles, 0, 1, ctrl_action = CMD_COMPLETE)]
 
   src_ctrl_pkt = []
   for opt_per_tile in src_opt_per_tile:

--- a/scale_out/test/MeshMultiCgraRTL_test.py
+++ b/scale_out/test/MeshMultiCgraRTL_test.py
@@ -217,7 +217,8 @@ def test_homo_2x2_2x2(cmdline_opts):
                   [FuOutType(0), FuOutType(0), FuOutType(0), FuOutType(0),
                    FuOutType(1), FuOutType(1), FuOutType(1), FuOutType(1)], 0, 0, 0, 0, 0)
       ] for i in range(num_tiles)]
-  complete_signal_sink_out = [CtrlPktType(0, 0, num_tiles, 0, 1, ctrl_action = CMD_COMPLETE)]
+  #                                       cgra_id, src,       dst, opaque, vc, ctrl_action
+  complete_signal_sink_out = [CtrlPktType(      0,   0, num_tiles,      0,  1, ctrl_action = CMD_COMPLETE)]
 
   src_ctrl_pkt = []
   for opt_per_tile in src_opt_per_tile:

--- a/scale_out/test/RingMultiCgraRTL_test.py
+++ b/scale_out/test/RingMultiCgraRTL_test.py
@@ -8,20 +8,20 @@ Author : Cheng Tan
   Date : Dec 23, 2024
 """
 
-from pymtl3 import *
+from pymtl3.passes.backends.verilog import (VerilogVerilatorImportPass)
 from pymtl3.stdlib.test_utils import (run_sim,
                                       config_model_with_cmdline_opts)
-from pymtl3.passes.backends.verilog import (VerilogTranslationPass,
-                                            VerilogVerilatorImportPass)
+
 from ..RingMultiCgraRTL import RingMultiCgraRTL
 from ...fu.flexible.FlexibleFuRTL import FlexibleFuRTL
 from ...fu.single.AdderRTL import AdderRTL
 from ...fu.single.MemUnitRTL import MemUnitRTL
-from ...fu.single.ShifterRTL import ShifterRTL
+from ...lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL
+from ...lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
+from ...lib.cmd_type import *
 from ...lib.messages import *
 from ...lib.opt_type import *
-from ...lib.cmd_type import *
-from ...lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
+
 
 #-------------------------------------------------------------------------
 # Test harness
@@ -33,12 +33,13 @@ class TestHarness(Component):
                 cgra_rows, cgra_columns, width, height, ctrl_mem_size,
                 data_mem_size_global, data_mem_size_per_bank,
                 num_banks_per_cgra, num_registers_per_reg_bank,
-                src_ctrl_pkt, ctrl_steps, controller2addr_map):
+                src_ctrl_pkt, ctrl_steps, controller2addr_map, complete_signal_sink_out):
 
     s.num_terminals = cgra_rows * cgra_columns
     s.num_tiles = width * height
 
     s.src_ctrl_pkt = TestSrcRTL(CtrlPktType, src_ctrl_pkt)
+    s.complete_signal_sink_out = TestSinkRTL(CtrlPktType, complete_signal_sink_out)
 
     s.dut = DUT(DataType, PredicateType, CtrlPktType, CtrlSignalType,
                 NocPktType, CmdType, cgra_rows, cgra_columns, height,
@@ -49,6 +50,7 @@ class TestHarness(Component):
 
     # Connections
     s.src_ctrl_pkt.send //= s.dut.recv_from_cpu_pkt
+    s.complete_signal_sink_out.recv //= s.dut.send_to_cpu_pkt
 
   def done(s):
     return s.src_ctrl_pkt.done()
@@ -199,7 +201,7 @@ def test_homo_2x2(cmdline_opts):
                        [FuOutType(0), FuOutType(0), FuOutType(0), FuOutType(0),
                         FuOutType(1), FuOutType(1), FuOutType(1), FuOutType(1)])
       ] for i in range(num_tiles)]
-
+  complete_signal_sink_out = [CtrlPktType(0, 0, 0, 0, 0, ctrl_action = CMD_COMPLETE)]
 
   src_ctrl_pkt = []
   for opt_per_tile in src_opt_per_tile:
@@ -210,7 +212,7 @@ def test_homo_2x2(cmdline_opts):
                    width, height, ctrl_mem_size, data_mem_size_global,
                    data_mem_size_per_bank, num_banks_per_cgra,
                    num_registers_per_reg_bank, src_ctrl_pkt,
-                   ctrl_mem_size, controller2addr_map)
+                   ctrl_mem_size, controller2addr_map, complete_signal_sink_out)
   th.elaborate()
   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',

--- a/scale_out/test/RingMultiCgraRTL_test.py
+++ b/scale_out/test/RingMultiCgraRTL_test.py
@@ -53,7 +53,7 @@ class TestHarness(Component):
     s.complete_signal_sink_out.recv //= s.dut.send_to_cpu_pkt
 
   def done(s):
-    return s.src_ctrl_pkt.done()
+    return s.src_ctrl_pkt.done() and s.complete_signal_sink_out.done()
 
   def line_trace(s):
     return s.dut.line_trace()
@@ -104,7 +104,7 @@ def test_homo_2x2(cmdline_opts):
   predicate_nbits = 1
 
   CtrlPktType = \
-        mk_intra_cgra_pkt(width * height,
+        mk_intra_cgra_pkt(num_tiles,
                         cgra_id_nbits,
                         num_commands,
                         ctrl_mem_size,
@@ -128,7 +128,7 @@ def test_homo_2x2(cmdline_opts):
 
   NocPktType = mk_multi_cgra_noc_pkt(ncols = num_terminals,
                                      nrows = 1,
-                                     ntiles = width * height,
+                                     ntiles = num_tiles,
                                      addr_nbits = data_addr_nbits,
                                      data_nbits = 32,
                                      predicate_nbits = 1,
@@ -201,7 +201,7 @@ def test_homo_2x2(cmdline_opts):
                        [FuOutType(0), FuOutType(0), FuOutType(0), FuOutType(0),
                         FuOutType(1), FuOutType(1), FuOutType(1), FuOutType(1)])
       ] for i in range(num_tiles)]
-  complete_signal_sink_out = [CtrlPktType(0, 0, 0, 0, 0, ctrl_action = CMD_COMPLETE)]
+  complete_signal_sink_out = [CtrlPktType(0, 0, num_tiles, 0, 1, ctrl_action = CMD_COMPLETE)]
 
   src_ctrl_pkt = []
   for opt_per_tile in src_opt_per_tile:

--- a/scale_out/test/RingMultiCgraRTL_test.py
+++ b/scale_out/test/RingMultiCgraRTL_test.py
@@ -201,6 +201,8 @@ def test_homo_2x2(cmdline_opts):
                        [FuOutType(0), FuOutType(0), FuOutType(0), FuOutType(0),
                         FuOutType(1), FuOutType(1), FuOutType(1), FuOutType(1)])
       ] for i in range(num_tiles)]
+
+  # vc_id needs to be 1 due to the message might traverse across the date line via ring.
   #                                       cgra_id, src,       dst, opaque, vc, ctrl_action
   complete_signal_sink_out = [CtrlPktType(      0,   0, num_tiles,      0,  1, ctrl_action = CMD_COMPLETE)]
 

--- a/scale_out/test/RingMultiCgraRTL_test.py
+++ b/scale_out/test/RingMultiCgraRTL_test.py
@@ -201,7 +201,8 @@ def test_homo_2x2(cmdline_opts):
                        [FuOutType(0), FuOutType(0), FuOutType(0), FuOutType(0),
                         FuOutType(1), FuOutType(1), FuOutType(1), FuOutType(1)])
       ] for i in range(num_tiles)]
-  complete_signal_sink_out = [CtrlPktType(0, 0, num_tiles, 0, 1, ctrl_action = CMD_COMPLETE)]
+  #                                       cgra_id, src,       dst, opaque, vc, ctrl_action
+  complete_signal_sink_out = [CtrlPktType(      0,   0, num_tiles,      0,  1, ctrl_action = CMD_COMPLETE)]
 
   src_ctrl_pkt = []
   for opt_per_tile in src_opt_per_tile:

--- a/systolic/CgraSystolicArrayRTL.py
+++ b/systolic/CgraSystolicArrayRTL.py
@@ -65,9 +65,8 @@ class CgraSystolicArrayRTL(Component):
                       data_mem_size_global, num_ctrl,
                       total_steps, 4, 2, s.num_mesh_ports,
                       s.num_mesh_ports, num_registers_per_reg_bank,
-                      FuList = FuList,
-                      tile_id = i)
-              for i in range(s.num_tiles)]
+                      FuList = FuList)
+               for i in range(s.num_tiles)]
     s.data_mem = DataMemWithCrossbarRTL(NocPktType, DataType,
                                         data_mem_size_global,
                                         data_mem_size_per_bank,

--- a/systolic/CgraSystolicArrayRTL.py
+++ b/systolic/CgraSystolicArrayRTL.py
@@ -36,7 +36,7 @@ class CgraSystolicArrayRTL(Component):
     assert(height == 3)
     assert(num_banks_per_cgra == 4)
     s.num_tiles = width * height
-    # An additional port for Controller to receive CMD_COMPLETE signal from Ring to Cpu.
+    # An additional router for controller to receive CMD_COMPLETE signal from Ring to CPU.
     CtrlRingPos = mk_ring_pos(s.num_tiles + 1)
     CtrlAddrType = mk_bits(clog2(ctrl_mem_size))
     DataAddrType = mk_bits(clog2(data_mem_size_global))
@@ -82,8 +82,8 @@ class CgraSystolicArrayRTL(Component):
                                  1, 1,
                                  controller2addr_map,
                                  idTo2d_map)
-    # An additional port for Controller to receive CMD_COMPLETE signal from Ring to Cpu.
-    #                                                                             For latency per hop.
+    # An additional router for controller to receive CMD_COMPLETE signal from Ring to CPU.
+    # The last argument of 1 is for the latency per hop.
     s.ctrl_ring = RingNetworkRTL(CtrlPktType, CtrlRingPos, s.num_tiles + 1, 1)
 
     # Connections

--- a/systolic/CgraSystolicArrayRTL.py
+++ b/systolic/CgraSystolicArrayRTL.py
@@ -107,7 +107,7 @@ class CgraSystolicArrayRTL(Component):
     for i in range(s.num_tiles):
       s.ctrl_ring.send[i] //= s.tile[i].recv_ctrl_pkt
 
-    s.ctrl_ring.recv[0] //= s.controller.send_to_ctrl_ring_ctrl_pkt
+    s.ctrl_ring.recv[0] //= s.controller.send_to_ctrl_ring_pkt
     for i in range(1, s.num_tiles):
       s.ctrl_ring.recv[i].val //= 0
       s.ctrl_ring.recv[i].msg //= CtrlPktType()

--- a/systolic/CgraSystolicArrayRTL.py
+++ b/systolic/CgraSystolicArrayRTL.py
@@ -7,19 +7,16 @@ Author : Cheng Tan
   Date : Dec 22, 2024
 """
 
-from pymtl3 import *
 from ..controller.ControllerRTL import ControllerRTL
-from ..fu.flexible.FlexibleFuRTL import FlexibleFuRTL
-from ..fu.single.MemUnitRTL import MemUnitRTL
-from ..fu.single.AdderRTL import AdderRTL
-from ..lib.util.common import *
 from ..lib.basic.val_rdy.ifcs import ValRdyRecvIfcRTL as RecvIfcRTL
 from ..lib.basic.val_rdy.ifcs import ValRdySendIfcRTL as SendIfcRTL
 from ..lib.opt_type import *
+from ..lib.util.common import *
 from ..mem.data.DataMemWithCrossbarRTL import DataMemWithCrossbarRTL
 from ..noc.PyOCN.pymtl3_net.ocnlib.ifcs.positions import mk_ring_pos
 from ..noc.PyOCN.pymtl3_net.ringnet.RingNetworkRTL import RingNetworkRTL
 from ..tile.TileRTL import TileRTL
+
 
 class CgraSystolicArrayRTL(Component):
 
@@ -39,7 +36,7 @@ class CgraSystolicArrayRTL(Component):
     assert(height == 3)
     assert(num_banks_per_cgra == 4)
     s.num_tiles = width * height
-    CtrlRingPos = mk_ring_pos(s.num_tiles)
+    CtrlRingPos = mk_ring_pos(s.num_tiles + 1)
     CtrlAddrType = mk_bits(clog2(ctrl_mem_size))
     DataAddrType = mk_bits(clog2(data_mem_size_global))
     assert(data_mem_size_per_bank * num_banks_per_cgra <= \
@@ -47,6 +44,7 @@ class CgraSystolicArrayRTL(Component):
 
     # Interfaces
     s.recv_from_cpu_pkt = RecvIfcRTL(CtrlPktType)
+    s.send_to_cpu_pkt = SendIfcRTL(CtrlPktType)
     s.recv_from_noc = RecvIfcRTL(NocPktType)
     s.send_to_noc = SendIfcRTL(NocPktType)
 
@@ -67,7 +65,8 @@ class CgraSystolicArrayRTL(Component):
                       data_mem_size_global, num_ctrl,
                       total_steps, 4, 2, s.num_mesh_ports,
                       s.num_mesh_ports, num_registers_per_reg_bank,
-                      FuList = FuList)
+                      FuList = FuList,
+                      tile_id = i)
               for i in range(s.num_tiles)]
     s.data_mem = DataMemWithCrossbarRTL(NocPktType, DataType,
                                         data_mem_size_global,
@@ -82,7 +81,7 @@ class CgraSystolicArrayRTL(Component):
                                  1, 1,
                                  controller2addr_map,
                                  idTo2d_map)
-    s.ctrl_ring = RingNetworkRTL(CtrlPktType, CtrlRingPos, s.num_tiles, 1)
+    s.ctrl_ring = RingNetworkRTL(CtrlPktType, CtrlRingPos, s.num_tiles + 1, 1)
 
     # Connections
     # Connects controller id.
@@ -102,15 +101,16 @@ class CgraSystolicArrayRTL(Component):
 
     # Connects the ctrl interface between CPU and controller.
     s.recv_from_cpu_pkt //= s.controller.recv_from_cpu_pkt
+    s.send_to_cpu_pkt //= s.controller.send_to_cpu_pkt
 
     # Connects ring with each control memory.
     for i in range(s.num_tiles):
       s.ctrl_ring.send[i] //= s.tile[i].recv_ctrl_pkt
+    s.ctrl_ring.send[s.num_tiles] //= s.controller.recv_from_ctrl_ring_pkt
 
-    s.ctrl_ring.recv[0] //= s.controller.send_to_ctrl_ring_pkt
-    for i in range(1, s.num_tiles):
-      s.ctrl_ring.recv[i].val //= 0
-      s.ctrl_ring.recv[i].msg //= CtrlPktType()
+    for i in range(s.num_tiles):
+      s.ctrl_ring.recv[i] //= s.tile[i].send_towards_controller_pkt
+    s.ctrl_ring.recv[s.num_tiles] //= s.controller.send_to_ctrl_ring_pkt
 
     for i in range(s.num_tiles):
 

--- a/systolic/CgraSystolicArrayRTL.py
+++ b/systolic/CgraSystolicArrayRTL.py
@@ -64,7 +64,8 @@ class CgraSystolicArrayRTL(Component):
                       CtrlSignalType, ctrl_mem_size,
                       data_mem_size_global, num_ctrl,
                       total_steps, 4, 2, s.num_mesh_ports,
-                      s.num_mesh_ports, num_registers_per_reg_bank,
+                      s.num_mesh_ports, s.num_tiles,
+                      num_registers_per_reg_bank,
                       FuList = FuList)
                for i in range(s.num_tiles)]
     s.data_mem = DataMemWithCrossbarRTL(NocPktType, DataType,

--- a/systolic/test/Cgra3x3MemRightAndBottomRTL_matmul_2x2_test.py
+++ b/systolic/test/Cgra3x3MemRightAndBottomRTL_matmul_2x2_test.py
@@ -159,6 +159,7 @@ def test_CGRA_systolic(cmdline_opts):
   num_banks_per_cgra = 4
   width = 3
   height = 3
+  num_tiles = width * height
   num_terminals = 1
   num_commands = NUM_CMDS
   num_ctrl_operations = NUM_OPTS
@@ -194,7 +195,7 @@ def test_CGRA_systolic(cmdline_opts):
   predicate_nbits = 1
 
   CtrlPktType = \
-        mk_intra_cgra_pkt(width * height,
+        mk_intra_cgra_pkt(num_tiles,
                         cgra_id_nbits,
                         num_commands,
                         ctrl_mem_size,
@@ -218,7 +219,7 @@ def test_CGRA_systolic(cmdline_opts):
 
   NocPktType = mk_multi_cgra_noc_pkt(ncols = cgra_columns,
                                      nrows = cgra_rows,
-                                     ntiles = width * height,
+                                     ntiles = num_tiles,
                                      addr_nbits = addr_nbits,
                                      data_nbits = data_nbits,
                                      predicate_nbits = 1,
@@ -451,7 +452,7 @@ def test_CGRA_systolic(cmdline_opts):
   expected_out = [[DataType(14, 1), DataType(20, 1)],
                   [DataType(30, 1), DataType(44, 1)]]
 
-  complete_signal_sink_out = [CtrlPktType(0, 0, 0, 0, 1, CMD_COMPLETE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)]
+  complete_signal_sink_out = [CtrlPktType(0, 0, num_tiles, 0, 1, ctrl_action = CMD_COMPLETE)]
 
   # When the max iterations are larger than the number of control signals,
   # enough ctrl_waddr needs to be provided to make execution (i.e., ctrl

--- a/systolic/test/Cgra3x3MemRightAndBottomRTL_matmul_2x2_test.py
+++ b/systolic/test/Cgra3x3MemRightAndBottomRTL_matmul_2x2_test.py
@@ -104,8 +104,7 @@ class TestHarness(Component):
     return True
 
   def done(s):
-    print(f"s.dut.send_to_cpu_pkt: {s.dut.send_to_cpu_pkt}")
-    return s.check_parity() #and s.complete_signal_sink_out.done()
+    return s.check_parity() and s.complete_signal_sink_out.done()
 
   def line_trace(s):
     return s.dut.line_trace()
@@ -128,7 +127,7 @@ def run_sim(test_harness, enable_verification_pymtl,
       test_harness.sim_tick()
       ncycles += 1
       print("----------------------------------------------------")
-      print("xxxxxxxxxcycle{}:{}".format( ncycles, test_harness.line_trace()))
+      print("cycle{}:{}".format( ncycles, test_harness.line_trace()))
     # Checks the output parity.
     assert test_harness.check_parity()
 
@@ -139,7 +138,7 @@ def run_sim(test_harness, enable_verification_pymtl,
       test_harness.sim_tick()
       ncycles += 1
       print("----------------------------------------------------")
-      print(".......cycle{}:{}".format( ncycles, test_harness.line_trace()))
+      print("cycle{}:{}".format( ncycles, test_harness.line_trace()))
 
   test_harness.sim_tick()
   test_harness.sim_tick()
@@ -453,6 +452,8 @@ def test_CGRA_systolic(cmdline_opts):
   """
   expected_out = [[DataType(14, 1), DataType(20, 1)],
                   [DataType(30, 1), DataType(44, 1)]]
+
+  # vc_id needs to be 1 due to the message might traverse across the date line via ring.
   #                                       cgra_id, src,       dst, opaque, vc, ctrl_action
   complete_signal_sink_out = [CtrlPktType(      0,   0, num_tiles,      0,  1, ctrl_action = CMD_COMPLETE)]
 

--- a/systolic/test/Cgra3x3MemRightAndBottomRTL_matmul_2x2_test.py
+++ b/systolic/test/Cgra3x3MemRightAndBottomRTL_matmul_2x2_test.py
@@ -9,11 +9,12 @@ Author : Cheng Tan
   Date : Nov 19, 2024
 """
 
-from pymtl3 import *
 from pymtl3.passes.backends.verilog import VerilogTranslationPass
 from pymtl3.stdlib.test_utils import (run_sim,
                                       config_model_with_cmdline_opts)
+
 from ..CgraSystolicArrayRTL import CgraSystolicArrayRTL
+from ...fu.double.SeqMulAdderRTL import SeqMulAdderRTL
 from ...fu.flexible.FlexibleFuRTL import FlexibleFuRTL
 from ...fu.single.AdderRTL import AdderRTL
 from ...fu.single.BranchRTL import BranchRTL
@@ -22,9 +23,8 @@ from ...fu.single.LogicRTL import LogicRTL
 from ...fu.single.MemUnitRTL import MemUnitRTL
 from ...fu.single.MulRTL import MulRTL
 from ...fu.single.PhiRTL import PhiRTL
-from ...fu.single.SelRTL import SelRTL
-from ...fu.double.SeqMulAdderRTL import SeqMulAdderRTL
 from ...fu.single.ShifterRTL import ShifterRTL
+from ...lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL
 from ...lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
 from ...lib.basic.val_rdy.queues import BypassQueueRTL
 from ...lib.cmd_type import *
@@ -45,12 +45,13 @@ class TestHarness(Component):
                 data_mem_size_per_bank, num_banks_per_cgra,
                 num_registers_per_reg_bank,
                 src_ctrl_pkt, ctrl_steps, controller2addr_map,
-                preload_data, expected_out):
+                preload_data, expected_out, complete_signal_sink_out):
 
     s.DataType = DataType
     s.num_tiles = width * height
     s.src_ctrl_pkt = TestSrcRTL(CtrlPktType, src_ctrl_pkt)
     s.expected_out = expected_out
+    s.complete_signal_sink_out = TestSinkRTL(CtrlPktType, complete_signal_sink_out)
 
     s.dut = DUT(DataType, PredicateType, CtrlPktType, CtrlSignalType,
                 NocPktType, CmdType, ControllerIdType, controller_id,
@@ -71,6 +72,7 @@ class TestHarness(Component):
     # we have to connect from_noc and to_noc in testbench.
     s.dut.send_to_noc //= s.bypass_queue.recv
     s.bypass_queue.send //= s.dut.recv_from_noc
+    s.complete_signal_sink_out.recv //= s.dut.send_to_cpu_pkt
 
     for tile_col in range(width):
       s.dut.send_data_on_boundary_north[tile_col].rdy //= 0
@@ -100,7 +102,7 @@ class TestHarness(Component):
     return True
 
   def done(s):
-    return s.check_parity()
+    return s.check_parity() and s.complete_signal_sink_out.done()
 
   def line_trace(s):
     return s.dut.line_trace()
@@ -449,6 +451,9 @@ def test_CGRA_systolic(cmdline_opts):
   expected_out = [[DataType(14, 1), DataType(20, 1)],
                   [DataType(30, 1), DataType(44, 1)]]
 
+  #
+  complete_signal_sink_out = [CtrlPktType(0, 0, 9, 0, 1, CMD_COMPLETE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)]
+
   # When the max iterations are larger than the number of control signals,
   # enough ctrl_waddr needs to be provided to make execution (i.e., ctrl
   # read) continue.
@@ -460,7 +465,8 @@ def test_CGRA_systolic(cmdline_opts):
                    num_registers_per_reg_bank,
                    src_ctrl_pkt, ctrl_steps,
                    controller2addr_map, None,
-                   expected_out)
+                   expected_out,
+                   complete_signal_sink_out)
 
   th.elaborate()
   th.dut.set_metadata(VerilogTranslationPass.explicit_module_name,

--- a/systolic/test/Cgra3x3MemRightAndBottomRTL_matmul_2x2_test.py
+++ b/systolic/test/Cgra3x3MemRightAndBottomRTL_matmul_2x2_test.py
@@ -51,7 +51,9 @@ class TestHarness(Component):
     s.num_tiles = width * height
     s.src_ctrl_pkt = TestSrcRTL(CtrlPktType, src_ctrl_pkt)
     s.expected_out = expected_out
-    s.complete_signal_sink_out = TestSinkRTL(CtrlPktType, complete_signal_sink_out)
+
+    cmp_fn = lambda a, b: a.dst == b.dst and a.ctrl_action == b.ctrl_action
+    s.complete_signal_sink_out = TestSinkRTL(CtrlPktType, complete_signal_sink_out, cmp_fn = cmp_fn)
 
     s.dut = DUT(DataType, PredicateType, CtrlPktType, CtrlSignalType,
                 NocPktType, CmdType, ControllerIdType, controller_id,

--- a/systolic/test/Cgra3x3MemRightAndBottomRTL_matmul_2x2_test.py
+++ b/systolic/test/Cgra3x3MemRightAndBottomRTL_matmul_2x2_test.py
@@ -35,7 +35,7 @@ from ...lib.opt_type import *
 # Test harness
 #-------------------------------------------------------------------------
 
-kMaxCycles = 200
+kMaxCycles = 100
 
 class TestHarness(Component):
   def construct(s, DUT, FunctionUnit, FuList, DataType, PredicateType,
@@ -102,7 +102,8 @@ class TestHarness(Component):
     return True
 
   def done(s):
-    return s.check_parity() and s.complete_signal_sink_out.done()
+    print(f"s.dut.send_to_cpu_pkt: {s.dut.send_to_cpu_pkt}")
+    return s.check_parity() #and s.complete_signal_sink_out.done()
 
   def line_trace(s):
     return s.dut.line_trace()
@@ -125,8 +126,7 @@ def run_sim(test_harness, enable_verification_pymtl,
       test_harness.sim_tick()
       ncycles += 1
       print("----------------------------------------------------")
-      print("cycle{}:{}".format( ncycles, test_harness.line_trace()))
-
+      print("xxxxxxxxxcycle{}:{}".format( ncycles, test_harness.line_trace()))
     # Checks the output parity.
     assert test_harness.check_parity()
 
@@ -137,7 +137,7 @@ def run_sim(test_harness, enable_verification_pymtl,
       test_harness.sim_tick()
       ncycles += 1
       print("----------------------------------------------------")
-      print("cycle{}:{}".format( ncycles, test_harness.line_trace()))
+      print(".......cycle{}:{}".format( ncycles, test_harness.line_trace()))
 
   test_harness.sim_tick()
   test_harness.sim_tick()
@@ -451,8 +451,7 @@ def test_CGRA_systolic(cmdline_opts):
   expected_out = [[DataType(14, 1), DataType(20, 1)],
                   [DataType(30, 1), DataType(44, 1)]]
 
-  #
-  complete_signal_sink_out = [CtrlPktType(0, 0, 9, 0, 1, CMD_COMPLETE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)]
+  complete_signal_sink_out = [CtrlPktType(0, 0, 0, 0, 1, CMD_COMPLETE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)]
 
   # When the max iterations are larger than the number of control signals,
   # enough ctrl_waddr needs to be provided to make execution (i.e., ctrl

--- a/systolic/test/Cgra3x3MemRightAndBottomRTL_matmul_2x2_test.py
+++ b/systolic/test/Cgra3x3MemRightAndBottomRTL_matmul_2x2_test.py
@@ -70,8 +70,8 @@ class TestHarness(Component):
     # As we always first issue request pkt from CPU to NoC,
     # when there is no NoC for single CGRA test,
     # we have to connect from_noc and to_noc in testbench.
-    s.dut.send_to_noc //= s.bypass_queue.recv
-    s.bypass_queue.send //= s.dut.recv_from_noc
+    s.dut.send_to_inter_cgra_noc //= s.bypass_queue.recv
+    s.bypass_queue.send //= s.dut.recv_from_inter_cgra_noc
     s.complete_signal_sink_out.recv //= s.dut.send_to_cpu_pkt
 
     for tile_col in range(width):
@@ -451,8 +451,8 @@ def test_CGRA_systolic(cmdline_opts):
   """
   expected_out = [[DataType(14, 1), DataType(20, 1)],
                   [DataType(30, 1), DataType(44, 1)]]
-
-  complete_signal_sink_out = [CtrlPktType(0, 0, num_tiles, 0, 1, ctrl_action = CMD_COMPLETE)]
+  #                                       cgra_id, src,       dst, opaque, vc, ctrl_action
+  complete_signal_sink_out = [CtrlPktType(      0,   0, num_tiles,      0,  1, ctrl_action = CMD_COMPLETE)]
 
   # When the max iterations are larger than the number of control signals,
   # enough ctrl_waddr needs to be provided to make execution (i.e., ctrl

--- a/tile/TileRTL.py
+++ b/tile/TileRTL.py
@@ -40,8 +40,7 @@ class TileRTL(Component):
                 num_fu_inports, num_fu_outports, num_tile_inports,
                 num_tile_outports, num_registers_per_reg_bank = 16,
                 Fu = FlexibleFuRTL,
-                FuList = [PhiRTL, AdderRTL, CompRTL, MulRTL, BranchRTL, MemUnitRTL],
-                tile_id = 0):
+                FuList = [PhiRTL, AdderRTL, CompRTL, MulRTL, BranchRTL, MemUnitRTL]):
 
     # Constants.
     num_routing_xbar_inports = num_tile_inports
@@ -90,7 +89,7 @@ class TileRTL(Component):
                                    ctrl_mem_size,
                                    num_fu_inports, num_fu_outports,
                                    num_tile_inports, num_tile_outports,
-                                   num_ctrl, total_steps, tile_id)
+                                   num_ctrl, total_steps)
 
     # The `tile_in_channel` indicates the outport channels that are
     # connected to the next tiles.

--- a/tile/TileRTL.py
+++ b/tile/TileRTL.py
@@ -38,7 +38,8 @@ class TileRTL(Component):
   def construct(s, DataType, PredicateType, CtrlPktType, CtrlSignalType,
                 ctrl_mem_size, data_mem_size, num_ctrl, total_steps,
                 num_fu_inports, num_fu_outports, num_tile_inports,
-                num_tile_outports, num_registers_per_reg_bank = 16,
+                num_tile_outports, num_tiles,
+                num_registers_per_reg_bank = 16,
                 Fu = FlexibleFuRTL,
                 FuList = [PhiRTL, AdderRTL, CompRTL, MulRTL, BranchRTL, MemUnitRTL]):
 
@@ -89,6 +90,7 @@ class TileRTL(Component):
                                    ctrl_mem_size,
                                    num_fu_inports, num_fu_outports,
                                    num_tile_inports, num_tile_outports,
+                                   num_tiles,
                                    num_ctrl, total_steps)
 
     # The `tile_in_channel` indicates the outport channels that are

--- a/tile/TileRTL.py
+++ b/tile/TileRTL.py
@@ -61,7 +61,7 @@ class TileRTL(Component):
     # Ctrl.
     s.recv_ctrl_pkt = RecvIfcRTL(CtrlPktType)
     # Sends the ctrl packets to ctrl ring.
-    s.send_pkt = SendIfcRTL(CtrlPktType)
+    s.send_towards_controller_pkt = SendIfcRTL(CtrlPktType)
 
     # Data.
     s.to_mem_raddr = SendIfcRTL(DataAddrType)
@@ -194,10 +194,10 @@ class TileRTL(Component):
 
     @update
     def update_send_out_signal():
-        s.send_pkt.val @= 0
+        s.send_towards_controller_pkt.val @= 0
         if s.ctrl_mem.send_pkt.val:
-            s.send_pkt.val @= 1
-            s.send_pkt.msg @= s.ctrl_mem.send_pkt.msg
+            s.send_towards_controller_pkt.val @= 1
+            s.send_towards_controller_pkt.msg @= s.ctrl_mem.send_pkt.msg
 
     # Updates the configuration memory related signals.
     @update

--- a/tile/TileRTL.py
+++ b/tile/TileRTL.py
@@ -40,7 +40,8 @@ class TileRTL(Component):
                 num_fu_inports, num_fu_outports, num_tile_inports,
                 num_tile_outports, num_registers_per_reg_bank = 16,
                 Fu = FlexibleFuRTL,
-                FuList = [PhiRTL, AdderRTL, CompRTL, MulRTL, BranchRTL, MemUnitRTL]):
+                FuList = [PhiRTL, AdderRTL, CompRTL, MulRTL, BranchRTL, MemUnitRTL],
+                tile_id = 0):
 
     # Constants.
     num_routing_xbar_inports = num_tile_inports
@@ -89,7 +90,7 @@ class TileRTL(Component):
                                    ctrl_mem_size,
                                    num_fu_inports, num_fu_outports,
                                    num_tile_inports, num_tile_outports,
-                                   num_ctrl, total_steps)
+                                   num_ctrl, total_steps, tile_id)
 
     # The `tile_in_channel` indicates the outport channels that are
     # connected to the next tiles.

--- a/tile/TileRTL.py
+++ b/tile/TileRTL.py
@@ -60,6 +60,8 @@ class TileRTL(Component):
 
     # Ctrl.
     s.recv_ctrl_pkt = RecvIfcRTL(CtrlPktType)
+    # Sends the ctrl packets to ctrl ring.
+    s.send_pkt = SendIfcRTL(CtrlPktType)
 
     # Data.
     s.to_mem_raddr = SendIfcRTL(DataAddrType)
@@ -190,10 +192,16 @@ class TileRTL(Component):
             s.const_mem.recv_const.msg.predicate @= 1
             s.recv_ctrl_pkt.rdy @= s.const_mem.recv_const.rdy
 
+    @update
+    def update_send_out_signal():
+        s.send_pkt.val @= 0
+        if s.ctrl_mem.send_pkt.val:
+            s.send_pkt.val @= 1
+            s.send_pkt.msg @= s.ctrl_mem.send_pkt.msg
+
     # Updates the configuration memory related signals.
     @update
     def update_opt():
-
       s.element.recv_opt.msg @= s.ctrl_mem.send_ctrl.msg
       s.routing_crossbar.recv_opt.msg @= s.ctrl_mem.send_ctrl.msg
       s.fu_crossbar.recv_opt.msg @= s.ctrl_mem.send_ctrl.msg

--- a/tile/TileRTL.py
+++ b/tile/TileRTL.py
@@ -60,9 +60,9 @@ class TileRTL(Component):
                    for _ in range (num_tile_outports)]
 
     # Ctrl.
-    s.recv_ctrl_pkt = RecvIfcRTL(CtrlPktType)
+    s.recv_from_controller_pkt = RecvIfcRTL(CtrlPktType)
     # Sends the ctrl packets to ctrl ring.
-    s.send_towards_controller_pkt = SendIfcRTL(CtrlPktType)
+    s.send_to_controller_pkt = SendIfcRTL(CtrlPktType)
 
     # Data.
     s.to_mem_raddr = SendIfcRTL(DataAddrType)
@@ -178,28 +178,28 @@ class TileRTL(Component):
 
     @update
     def feed_pkt():
-        s.ctrl_mem.recv_pkt.msg @= CtrlPktType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        s.ctrl_mem.recv_pkt_from_controller.msg @= CtrlPktType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
         s.const_mem.recv_const.msg @= DataType(0, 0, 0, 0)
-        s.ctrl_mem.recv_pkt.val @= 0
+        s.ctrl_mem.recv_pkt_from_controller.val @= 0
         s.const_mem.recv_const.val @= 0
-        s.recv_ctrl_pkt.rdy @= 0
+        s.recv_from_controller_pkt.rdy @= 0
 
-        if s.recv_ctrl_pkt.val & ((s.recv_ctrl_pkt.msg.ctrl_action == CMD_CONFIG) | (s.recv_ctrl_pkt.msg.ctrl_action == CMD_LAUNCH)):
-            s.ctrl_mem.recv_pkt.val @= 1
-            s.ctrl_mem.recv_pkt.msg @= s.recv_ctrl_pkt.msg
-            s.recv_ctrl_pkt.rdy @= s.ctrl_mem.recv_pkt.rdy
-        elif s.recv_ctrl_pkt.val & (s.recv_ctrl_pkt.msg.ctrl_action == CMD_CONST):
+        if s.recv_from_controller_pkt.val & ((s.recv_from_controller_pkt.msg.ctrl_action == CMD_CONFIG) | (s.recv_from_controller_pkt.msg.ctrl_action == CMD_LAUNCH)):
+            s.ctrl_mem.recv_pkt_from_controller.val @= 1
+            s.ctrl_mem.recv_pkt_from_controller.msg @= s.recv_from_controller_pkt.msg
+            s.recv_from_controller_pkt.rdy @= s.ctrl_mem.recv_pkt_from_controller.rdy
+        elif s.recv_from_controller_pkt.val & (s.recv_from_controller_pkt.msg.ctrl_action == CMD_CONST):
             s.const_mem.recv_const.val @= 1
-            s.const_mem.recv_const.msg.payload @= s.recv_ctrl_pkt.msg.data
+            s.const_mem.recv_const.msg.payload @= s.recv_from_controller_pkt.msg.data
             s.const_mem.recv_const.msg.predicate @= 1
-            s.recv_ctrl_pkt.rdy @= s.const_mem.recv_const.rdy
+            s.recv_from_controller_pkt.rdy @= s.const_mem.recv_const.rdy
 
     @update
     def update_send_out_signal():
-        s.send_towards_controller_pkt.val @= 0
-        if s.ctrl_mem.send_pkt.val:
-            s.send_towards_controller_pkt.val @= 1
-            s.send_towards_controller_pkt.msg @= s.ctrl_mem.send_pkt.msg
+        s.send_to_controller_pkt.val @= 0
+        if s.ctrl_mem.send_pkt_to_controller.val:
+            s.send_to_controller_pkt.val @= 1
+            s.send_to_controller_pkt.msg @= s.ctrl_mem.send_pkt_to_controller.msg
 
     # Updates the configuration memory related signals.
     @update

--- a/tile/test/TileRTL_test.py
+++ b/tile/test/TileRTL_test.py
@@ -64,8 +64,8 @@ class TestHarness(Component):
                 num_registers_per_reg_bank,
                 FunctionUnit, FuList)
 
-    connect(s.src_ctrl_pkt.send, s.dut.recv_ctrl_pkt)
-    s.complete_signal_sink_out.recv //= s.dut.send_towards_controller_pkt
+    connect(s.src_ctrl_pkt.send, s.dut.recv_from_controller_pkt)
+    s.complete_signal_sink_out.recv //= s.dut.send_to_controller_pkt
 
     for i in range(num_tile_inports):
       connect(s.src_data[i].send, s.dut.recv_data[i])
@@ -86,6 +86,9 @@ class TestHarness(Component):
 
     for i in range(s.num_tile_outports):
       if not s.sink_out[i].done():
+        return False
+
+    if not s.complete_signal_sink_out.done():
         return False
 
     return True
@@ -223,7 +226,8 @@ def test_tile_alu(cmdline_opts):
               [],
               # 5 + 4 = 9; 7 - 3 = 4.
               [DataType(9, 1), DataType(4, 1)]]
-  complete_signal_sink_out = [CtrlPktType(0, 0, num_terminals, 0, 0, ctrl_action = CMD_COMPLETE)]
+  #                                       cgra_id, src,           dst, opaque, vc, ctrl_action
+  complete_signal_sink_out = [CtrlPktType(      0,   0, num_terminals,      0,  0, ctrl_action = CMD_COMPLETE)]
 
   th = TestHarness(DUT, FunctionUnit, FuList, DataType, PredicateType,
                    CtrlPktType, CtrlSignalType, ctrl_mem_size,

--- a/tile/test/TileRTL_test.py
+++ b/tile/test/TileRTL_test.py
@@ -45,7 +45,7 @@ class TestHarness(Component):
                 CtrlPktType, CtrlSignalType, ctrl_mem_size, data_mem_size,
                 num_fu_inports, num_fu_outports, num_tile_inports,
                 num_tile_outports, num_registers_per_reg_bank, src_data,
-                src_ctrl_pkt, sink_out, complete_signal_sink_out):
+                src_ctrl_pkt, sink_out, num_terminals, complete_signal_sink_out):
 
     s.num_tile_inports = num_tile_inports
     s.num_tile_outports = num_tile_outports
@@ -60,7 +60,8 @@ class TestHarness(Component):
     s.dut = DUT(DataType, PredicateType, CtrlPktType, CtrlSignalType,
                 ctrl_mem_size, data_mem_size, 3, 3, # 3 opts
                 num_fu_inports, num_fu_outports, num_tile_inports,
-                num_tile_outports, num_registers_per_reg_bank,
+                num_tile_outports, num_terminals,
+                num_registers_per_reg_bank,
                 FunctionUnit, FuList)
 
     connect(s.src_ctrl_pkt.send, s.dut.recv_ctrl_pkt)
@@ -222,14 +223,14 @@ def test_tile_alu(cmdline_opts):
               [],
               # 5 + 4 = 9; 7 - 3 = 4.
               [DataType(9, 1), DataType(4, 1)]]
-  complete_signal_sink_out = [CtrlPktType(0, 0, 0, 0, 0, ctrl_action = CMD_COMPLETE)]
+  complete_signal_sink_out = [CtrlPktType(0, 0, num_terminals, 0, 0, ctrl_action = CMD_COMPLETE)]
 
   th = TestHarness(DUT, FunctionUnit, FuList, DataType, PredicateType,
                    CtrlPktType, CtrlSignalType, ctrl_mem_size,
                    data_mem_size, num_fu_inports, num_fu_outports,
                    num_tile_inports, num_tile_outports,
                    num_registers_per_reg_bank, src_data,
-                   src_ctrl_pkt, sink_out, complete_signal_sink_out)
+                   src_ctrl_pkt, sink_out, num_terminals, complete_signal_sink_out)
   th.elaborate()
   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',

--- a/tile/test/TileRTL_test.py
+++ b/tile/test/TileRTL_test.py
@@ -45,7 +45,7 @@ class TestHarness(Component):
                 CtrlPktType, CtrlSignalType, ctrl_mem_size, data_mem_size,
                 num_fu_inports, num_fu_outports, num_tile_inports,
                 num_tile_outports, num_registers_per_reg_bank, src_data,
-                src_ctrl_pkt, sink_out, complete_ctrl_pkt):
+                src_ctrl_pkt, sink_out, complete_signal_sink_out):
 
     s.num_tile_inports = num_tile_inports
     s.num_tile_outports = num_tile_outports
@@ -55,7 +55,7 @@ class TestHarness(Component):
                   for i in range(num_tile_inports)]
     s.sink_out = [TestSinkRTL(DataType, sink_out[i])
                   for i in range(num_tile_outports)]
-    s.execution_complete_cmd = TestSinkRTL(CtrlPktType, complete_ctrl_pkt)
+    s.complete_signal_sink_out = TestSinkRTL(CtrlPktType, complete_signal_sink_out)
 
     s.dut = DUT(DataType, PredicateType, CtrlPktType, CtrlSignalType,
                 ctrl_mem_size, data_mem_size, 3, 3, # 3 opts
@@ -64,7 +64,7 @@ class TestHarness(Component):
                 FunctionUnit, FuList)
 
     connect(s.src_ctrl_pkt.send, s.dut.recv_ctrl_pkt)
-    s.execution_complete_cmd.recv //= s.dut.send_towards_controller_pkt
+    s.complete_signal_sink_out.recv //= s.dut.send_towards_controller_pkt
 
     for i in range(num_tile_inports):
       connect(s.src_data[i].send, s.dut.recv_data[i])
@@ -222,14 +222,14 @@ def test_tile_alu(cmdline_opts):
               [],
               # 5 + 4 = 9; 7 - 3 = 4.
               [DataType(9, 1), DataType(4, 1)]]
-  complete_ctrl_pkt = [CtrlPktType(0, 0, 0, 0, 0, ctrl_action = CMD_COMPLETE)]
+  complete_signal_sink_out = [CtrlPktType(0, 0, 0, 0, 0, ctrl_action = CMD_COMPLETE)]
 
   th = TestHarness(DUT, FunctionUnit, FuList, DataType, PredicateType,
                    CtrlPktType, CtrlSignalType, ctrl_mem_size,
                    data_mem_size, num_fu_inports, num_fu_outports,
                    num_tile_inports, num_tile_outports,
                    num_registers_per_reg_bank, src_data,
-                   src_ctrl_pkt, sink_out, complete_ctrl_pkt)
+                   src_ctrl_pkt, sink_out, complete_signal_sink_out)
   th.elaborate()
   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',

--- a/tile/test/TileRTL_test.py
+++ b/tile/test/TileRTL_test.py
@@ -28,8 +28,8 @@ from ...fu.single.ShifterRTL import ShifterRTL
 from ...fu.triple.ThreeMulAdderShifterRTL import ThreeMulAdderShifterRTL
 from ...fu.vector.VectorAdderComboRTL import VectorAdderComboRTL
 from ...fu.vector.VectorMulComboRTL import VectorMulComboRTL
-from ...lib.basic.val_rdy.SinkRTL import SinkRTL as ValRdyTestSinkRTL
-from ...lib.basic.val_rdy.SourceRTL import SourceRTL as ValRdyTestSrcRTL
+from ...lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL
+from ...lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
 from ...lib.cmd_type import *
 from ...lib.messages import *
 from ...lib.opt_type import *
@@ -50,12 +50,12 @@ class TestHarness(Component):
     s.num_tile_inports = num_tile_inports
     s.num_tile_outports = num_tile_outports
 
-    s.src_ctrl_pkt = ValRdyTestSrcRTL(CtrlPktType, src_ctrl_pkt)
-    s.src_data = [ValRdyTestSrcRTL(DataType, src_data[i])
+    s.src_ctrl_pkt = TestSrcRTL(CtrlPktType, src_ctrl_pkt)
+    s.src_data = [TestSrcRTL(DataType, src_data[i])
                   for i in range(num_tile_inports)]
-    s.sink_out = [ValRdyTestSinkRTL(DataType, sink_out[i])
+    s.sink_out = [TestSinkRTL(DataType, sink_out[i])
                   for i in range(num_tile_outports)]
-    s.execution_complete_cmd = ValRdyTestSinkRTL(CtrlPktType, complete_ctrl_pkt)
+    s.execution_complete_cmd = TestSinkRTL(CtrlPktType, complete_ctrl_pkt)
 
     s.dut = DUT(DataType, PredicateType, CtrlPktType, CtrlSignalType,
                 ctrl_mem_size, data_mem_size, 3, 3, # 3 opts
@@ -64,7 +64,7 @@ class TestHarness(Component):
                 FunctionUnit, FuList)
 
     connect(s.src_ctrl_pkt.send, s.dut.recv_ctrl_pkt)
-    s.execution_complete_cmd.recv //= s.dut.send_pkt
+    s.execution_complete_cmd.recv //= s.dut.send_towards_controller_pkt
 
     for i in range(num_tile_inports):
       connect(s.src_data[i].send, s.dut.recv_data[i])


### PR DESCRIPTION
[P0] Allow tile issue COMPLETE signals on ring (within one CGRA) towards controller #48

Hi @tancheng ,

Just pushed the 1st version, add an interface to send 'COMPLETE' signal out and validate in `_test`, could you help take a look if I'm on the right way?

Next, need to add interface in all TileRTL, RingNetworkRTL, CgraRTL, ControllerRTL to transfer 'COMPLETE' signal to CPU right?
Maybe rename [`FromCpuPktType`](https://github.com/tancheng/VectorCGRA/blob/2ddc8df97906e71f14cea07d8af7f29853c9d997/controller/ControllerRTL.py#L42) to `CpuPktType`.

Thanks,
