### PR TITLE
Avoid val depend on rdy in FpAddRTL.py

### DIFF
--- a/fu/float/FpAddRTL.py
+++ b/fu/float/FpAddRTL.py
@@ -80,7 +80,7 @@ class FpAddRTL(Fu):
       s.recv_predicate.rdy @= b1(0)
       s.recv_opt.rdy @= 0
 
-      if s.recv_opt.val & s.send_out[0].rdy:
+      if s.recv_opt.val:
         if s.recv_opt.msg.fu_in[0] != 0:
           s.in0 @= zext(s.recv_opt.msg.fu_in[0] - 1, FuInType)
         if s.recv_opt.msg.fu_in[1] != 0:

--- a/fu/float/FpMulRTL.py
+++ b/fu/float/FpMulRTL.py
@@ -76,7 +76,7 @@ class FpMulRTL(Fu):
       s.recv_predicate.rdy @= b1(0)
       s.recv_opt.rdy @= 0
 
-      if s.recv_opt.val & s.send_out[0].rdy:
+      if s.recv_opt.val:
         if s.recv_opt.msg.fu_in[0] != 0:
           s.in0 @= zext(s.recv_opt.msg.fu_in[0] - 1, FuInType)
         if s.recv_opt.msg.fu_in[1] != 0:


### PR DESCRIPTION
Avoid val depend on rdy in:
 - FpAddRTL.py
 - FpMulRTL.py