### PR TITLE
X-prop and inferred latch fix proposal.

### DIFF
--- a/mem/const/ConstQueueDynamicRTL.py
+++ b/mem/const/ConstQueueDynamicRTL.py
@@ -53,8 +53,8 @@ class ConstQueueDynamicRTL(Component):
     @update
     def load_const():
       # Initializes signals.
-      s.reg_file.waddr[0] @= 0
-      s.reg_file.wdata[0] @= 0
+      s.reg_file.waddr[0] @= AddrType()
+      s.reg_file.wdata[0] @= DataType()
       s.reg_file.wen[0] @= 0
 
       not_full = s.wr_cur < const_mem_size

--- a/mem/const/ConstQueueDynamicRTL.py
+++ b/mem/const/ConstQueueDynamicRTL.py
@@ -52,16 +52,18 @@ class ConstQueueDynamicRTL(Component):
 
     @update
     def load_const():
+      # Initializes signals.
+      s.reg_file.waddr[0] @= 0
+      s.reg_file.wdata[0] @= 0
+      s.reg_file.wen[0] @= 0
+
       not_full = s.wr_cur < const_mem_size
       s.recv_const.rdy @= not_full
+
       if s.recv_const.val & not_full:
         s.reg_file.waddr[0] @= trunc(s.wr_cur, AddrType)
         s.reg_file.wdata[0] @= s.recv_const.msg
         s.reg_file.wen[0] @= 1
-      else:
-        s.reg_file.waddr[0] @= trunc(s.wr_cur, AddrType)
-        s.reg_file.wdata[0] @= s.recv_const.msg
-        s.reg_file.wen[0] @= 0
 
 
     @update_ff


### PR DESCRIPTION
The reset issue was found by not being able to write values into the const memories from a custom SystemVerilog test bench. This led to observing the ready signal from the constant memory as always undefined (X). It could be traced back to the wr_cur DFF.

The other DFF's missing reset and the incomplete if-statement were found by subsequently reviewing the rest of the mem/const/ConstQueueDynamicRTL.py file.

We should think about reviewing the whole code base for similar potential issues.
