### PR TITLE
init_mem_done/addr reset insertion.

### DIFF
--- a/mem/data/DataMemWithCrossbarRTL.py
+++ b/mem/data/DataMemWithCrossbarRTL.py
@@ -315,18 +315,26 @@ class DataMemWithCrossbarRTL(Component):
       # Preloads data.
       @update_ff
       def update_init_index_increment():
-        if (s.init_mem_done == b1(0)) & (s.init_mem_addr < data_mem_size_per_bank - 1):
-          s.init_mem_addr <<= s.init_mem_addr + PerBankAddrType(1)
-        else:
-          s.init_mem_done <<= b1(1)
+        if (reset):
+          s.init_mem_done <<= b1(0)
           s.init_mem_addr <<= PerBankAddrType(0)
+        else:
+          if (s.init_mem_done == b1(0)) & (s.init_mem_addr < data_mem_size_per_bank - 1):
+            s.init_mem_addr <<= s.init_mem_addr + PerBankAddrType(1)
+          else:
+            s.init_mem_done <<= b1(1)
+            s.init_mem_addr <<= PerBankAddrType(0)
 
     else:
       @update_ff
       def update_init_index_once():
-          if s.init_mem_done == b1(0):
-            s.init_mem_done <<= b1(1)
+          if (reset):
+            s.init_mem_done <<= b1(0)
             s.init_mem_addr <<= PerBankAddrType(0)
+          else:
+            if s.init_mem_done == b1(0):
+              s.init_mem_done <<= b1(1)
+              s.init_mem_addr <<= PerBankAddrType(0)
 
     # Indicates whether the remote (towards others via NoC) load is pending on response.
     @update_ff

--- a/mem/data/DataMemWithCrossbarRTL.py
+++ b/mem/data/DataMemWithCrossbarRTL.py
@@ -315,7 +315,7 @@ class DataMemWithCrossbarRTL(Component):
       # Preloads data.
       @update_ff
       def update_init_index_increment():
-        if (reset):
+        if (s.reset):
           s.init_mem_done <<= b1(0)
           s.init_mem_addr <<= PerBankAddrType(0)
         else:
@@ -328,7 +328,7 @@ class DataMemWithCrossbarRTL(Component):
     else:
       @update_ff
       def update_init_index_once():
-          if (reset):
+          if (s.reset):
             s.init_mem_done <<= b1(0)
             s.init_mem_addr <<= PerBankAddrType(0)
           else:

--- a/mem/data/DataMemWithCrossbarRTL.py
+++ b/mem/data/DataMemWithCrossbarRTL.py
@@ -315,25 +315,25 @@ class DataMemWithCrossbarRTL(Component):
       # Preloads data.
       @update_ff
       def update_init_index_increment():
-        if (s.reset):
-          s.init_mem_done <<= b1(0)
+        if s.reset:
+          s.init_mem_done <<= 0
           s.init_mem_addr <<= PerBankAddrType(0)
         else:
-          if (s.init_mem_done == b1(0)) & (s.init_mem_addr < data_mem_size_per_bank - 1):
+          if (s.init_mem_done == 0) & (s.init_mem_addr < data_mem_size_per_bank - 1):
             s.init_mem_addr <<= s.init_mem_addr + PerBankAddrType(1)
           else:
-            s.init_mem_done <<= b1(1)
+            s.init_mem_done <<= 1
             s.init_mem_addr <<= PerBankAddrType(0)
 
     else:
       @update_ff
       def update_init_index_once():
-          if (s.reset):
-            s.init_mem_done <<= b1(0)
+          if s.reset:
+            s.init_mem_done <<= 0
             s.init_mem_addr <<= PerBankAddrType(0)
           else:
-            if s.init_mem_done == b1(0):
-              s.init_mem_done <<= b1(1)
+            if s.init_mem_done == 0:
+              s.init_mem_done <<= 1
               s.init_mem_addr <<= PerBankAddrType(0)
 
     # Indicates whether the remote (towards others via NoC) load is pending on response.


### PR DESCRIPTION
Fixes failing stores into the CGRA's register file. The logic was stuck trying to initialize the register file; I could trace this back to this missing reset.
