### PR TITLE
[feature] Optional execute/route based on prologue count that is pre-…

### DIFF
--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -105,6 +105,10 @@ class CgraRTL(Component):
     s.recv_from_cpu_pkt //= s.controller.recv_from_cpu_pkt
     s.send_to_cpu_pkt //=  s.controller.send_to_cpu_pkt
 
+    # Assigns tile id.
+    for i in range(s.num_tiles):
+      s.tile[i].tile_id //= i
+
     # Connects ring with each control memory.
     for i in range(s.num_tiles):
       s.ctrl_ring.send[i] //= s.tile[i].recv_from_controller_pkt

--- a/cgra/CgraTemplateRTL.py
+++ b/cgra/CgraTemplateRTL.py
@@ -103,6 +103,10 @@ class CgraTemplateRTL(Component):
     s.recv_from_cpu_pkt //= s.controller.recv_from_cpu_pkt
     s.send_to_cpu_pkt //= s.controller.send_to_cpu_pkt
 
+    # Assigns tile id.
+    for i in range(s.num_tiles):
+      s.tile[i].tile_id //= i
+
     # Connects ring with each control memory.
     for i in range(s.num_tiles):
       s.ctrl_ring.send[i] //= s.tile[i].recv_from_controller_pkt

--- a/controller/ControllerRTL.py
+++ b/controller/ControllerRTL.py
@@ -289,7 +289,12 @@ class ControllerRTL(Component):
                 CGRADataType(received_pkt.data, received_pkt.predicate, 0, 0)
             s.send_to_tile_load_response_data_queue.recv.val @= 1
 
-        elif (s.recv_from_inter_cgra_noc.msg.ctrl_action == CMD_CONFIG) | (s.recv_from_inter_cgra_noc.msg.ctrl_action == CMD_CONST) | (s.recv_from_inter_cgra_noc.msg.ctrl_action == CMD_LAUNCH):
+        elif (s.recv_from_inter_cgra_noc.msg.ctrl_action == CMD_CONFIG) | \
+             (s.recv_from_inter_cgra_noc.msg.ctrl_action == CMD_CONFIG_PROLOGUE_FU) | \
+             (s.recv_from_inter_cgra_noc.msg.ctrl_action == CMD_CONFIG_PROLOGUE_FU_CROSSBAR) | \
+             (s.recv_from_inter_cgra_noc.msg.ctrl_action == CMD_CONFIG_PROLOGUE_ROUTING_CROSSBAR) | \
+             (s.recv_from_inter_cgra_noc.msg.ctrl_action == CMD_CONST) | \
+             (s.recv_from_inter_cgra_noc.msg.ctrl_action == CMD_LAUNCH):
           s.recv_from_inter_cgra_noc.rdy @= s.send_to_ctrl_ring_pkt.rdy
           s.send_to_ctrl_ring_pkt.val @= s.recv_from_inter_cgra_noc.val
           s.send_to_ctrl_ring_pkt.msg @= CpuPktType(s.recv_from_inter_cgra_noc.msg.dst,  # cgra_id
@@ -313,7 +318,7 @@ class ControllerRTL(Component):
                                                     0,  # ctrl_write_reg_from
                                                     0,  # ctrl_write_reg_idx
                                                     0,  # ctrl_read_reg_from
-                                                    0) # ctrl_read_reg_idx
+                                                    0)  # ctrl_read_reg_idx
 
         # else:
         #   # TODO: Handle other cmd types.

--- a/fu/flexible/FlexibleFuRTL.py
+++ b/fu/flexible/FlexibleFuRTL.py
@@ -22,7 +22,8 @@ from ...lib.util.common import *
 class FlexibleFuRTL(Component):
 
   def construct(s, DataType, PredicateType, CtrlType,
-                num_inports, num_outports, data_mem_size, FuList):
+                num_inports, num_outports, data_mem_size,
+                num_tiles, FuList):
 
     # Constant
     num_entries = 2
@@ -46,6 +47,7 @@ class FlexibleFuRTL(Component):
     s.to_mem_wdata = [SendIfcRTL(DataType) for _ in range(s.fu_list_size)]
 
     s.prologue_count_inport = InPort(PrologueCountType)
+    s.tile_id = InPort(mk_bits(clog2(num_tiles + 1)))
 
     # Components
     s.fu = [FuList[i](DataType, PredicateType, CtrlType, num_inports, num_outports,

--- a/fu/flexible/FlexibleFuRTL.py
+++ b/fu/flexible/FlexibleFuRTL.py
@@ -16,6 +16,7 @@ from ...fu.single.NahRTL  import NahRTL
 from ...lib.basic.val_rdy.ifcs import ValRdyRecvIfcRTL as RecvIfcRTL
 from ...lib.basic.val_rdy.ifcs import ValRdySendIfcRTL as SendIfcRTL
 from ...lib.opt_type import *
+from ...lib.util.common import *
 
 
 class FlexibleFuRTL(Component):
@@ -30,6 +31,7 @@ class FlexibleFuRTL(Component):
     s.fu_list_size = len(FuList)
     CountType = mk_bits(clog2(num_entries + 1))
     AddrType = mk_bits(clog2(data_mem_size))
+    PrologueCountType = mk_bits(clog2(PROLOGUE_MAX_COUNT + 1))
 
     # Interface
     s.recv_in = [RecvIfcRTL(DataType) for _ in range(num_inports)]
@@ -42,6 +44,8 @@ class FlexibleFuRTL(Component):
     s.from_mem_rdata = [RecvIfcRTL(DataType) for _ in range(s.fu_list_size)]
     s.to_mem_waddr = [SendIfcRTL(AddrType) for _ in range(s.fu_list_size)]
     s.to_mem_wdata = [SendIfcRTL(DataType) for _ in range(s.fu_list_size)]
+
+    s.prologue_count_inport = InPort(PrologueCountType)
 
     # Components
     s.fu = [FuList[i](DataType, PredicateType, CtrlType, num_inports, num_outports,
@@ -98,7 +102,7 @@ class FlexibleFuRTL(Component):
       # Operation (especially mem access) won't perform more than once, because once the
       # operation is performance (i.e., the recv_opt.rdy would be set), the `element_done`
       # register would be set and be respected.
-      s.recv_opt.rdy @= reduce_or(s.fu_recv_opt_rdy_vector)
+      s.recv_opt.rdy @= reduce_or(s.fu_recv_opt_rdy_vector) | (s.prologue_count_inport != 0)
 
       for j in range(num_inports):
         s.recv_in[j].rdy @= b1(0)

--- a/fu/flexible/test/FlexibleFuRTL_hypothesis_test.py
+++ b/fu/flexible/test/FlexibleFuRTL_hypothesis_test.py
@@ -40,55 +40,56 @@ class TestHarness( Component ):
     num_inports   = 2
     num_outports  = 2
 
-    s.src_in0       = TestSrcRTL( DataType,      src0_msgs     )
-    s.src_in1       = TestSrcRTL( DataType,      src1_msgs     )
-    s.src_predicate = TestSrcRTL( PredicateType, src_predicate )
-    s.src_const     = TestSrcRTL( DataType,      src1_msgs     )
-    s.src_opt       = TestSrcRTL( CtrlType,      ctrl_msgs     )
-    s.sink_out0     = TestSinkRTL( DataType,      sink0_msgs    )
+    s.src_in0       = TestSrcRTL (DataType,      src0_msgs    )
+    s.src_in1       = TestSrcRTL (DataType,      src1_msgs    )
+    s.src_predicate = TestSrcRTL (PredicateType, src_predicate)
+    s.src_const     = TestSrcRTL (DataType,      src1_msgs    )
+    s.src_opt       = TestSrcRTL (CtrlType,      ctrl_msgs    )
+    s.sink_out0     = TestSinkRTL(DataType,      sink0_msgs   )
 
-    s.dut = FunctionUnit( DataType, PredicateType, CtrlType,
-                          num_inports, num_outports, data_mem_size, FuList )
+    s.dut = FunctionUnit(DataType, PredicateType, CtrlType,
+                         num_inports, num_outports, data_mem_size,
+                         1, FuList )
 
-    connect( s.src_const.send,     s.dut.recv_const     )
-    connect( s.src_in0.send,       s.dut.recv_in[0]     )
-    connect( s.src_in1.send,       s.dut.recv_in[1]     )
-    connect( s.src_predicate.send, s.dut.recv_predicate )
-    connect( s.src_opt.send,       s.dut.recv_opt       )
-    connect( s.dut.send_out[0],    s.sink_out0.recv     )
+    connect(s.src_const.send,     s.dut.recv_const    )
+    connect(s.src_in0.send,       s.dut.recv_in[0]    )
+    connect(s.src_in1.send,       s.dut.recv_in[1]    )
+    connect(s.src_predicate.send, s.dut.recv_predicate)
+    connect(s.src_opt.send,       s.dut.recv_opt      )
+    connect(s.dut.send_out[0],    s.sink_out0.recv    )
 
-    AddrType = mk_bits( clog2( data_mem_size ) )
-    s.to_mem_raddr   = [ TestSinkRTL( AddrType, [] ) for _ in FuList ]
-    s.from_mem_rdata = [ TestSrcRTL( DataType, [] ) for _ in FuList ]
-    s.to_mem_waddr   = [ TestSinkRTL( AddrType, [] ) for _ in FuList ]
-    s.to_mem_wdata   = [ TestSinkRTL( DataType, [] ) for _ in FuList ]
+    AddrType = mk_bits(clog2(data_mem_size))
+    s.to_mem_raddr   = [TestSinkRTL(AddrType, []) for _ in FuList]
+    s.from_mem_rdata = [TestSrcRTL (DataType, []) for _ in FuList]
+    s.to_mem_waddr   = [TestSinkRTL(AddrType, []) for _ in FuList]
+    s.to_mem_wdata   = [TestSinkRTL(DataType, []) for _ in FuList]
 
-    for i in range( s.dut.fu_list_size ):
+    for i in range(s.dut.fu_list_size):
       s.to_mem_raddr[i].recv   //= s.dut.to_mem_raddr[i]
       s.from_mem_rdata[i].send //= s.dut.from_mem_rdata[i]
       s.to_mem_waddr[i].recv   //= s.dut.to_mem_waddr[i]
       s.to_mem_wdata[i].recv   //= s.dut.to_mem_wdata[i]
 
-  def done( s ):
-    return s.src_in0.done() and s.src_in1.done()   and \
+  def done(s):
+    return s.src_in0.done() and s.src_in1.done() and \
            s.src_opt.done() and s.sink_out0.done()
 
-  def line_trace( s ):
+  def line_trace(s):
     return s.dut.line_trace()
 
-def run_sim( test_harness, max_cycles=20 ):
+def run_sim(test_harness, max_cycles = 20):
   test_harness.elaborate()
-  test_harness.apply( DefaultPassGroup() )
+  test_harness.apply(DefaultPassGroup())
   test_harness.sim_reset()
 
   # Run simulation
   ncycles = 0
   print()
-  print( "{}:{}".format( ncycles, test_harness.line_trace() ))
+  print("{}:{}".format(ncycles, test_harness.line_trace()))
   while not test_harness.done() and ncycles < max_cycles:
     test_harness.sim_tick()
     ncycles += 1
-    print( "{}:{}".format( ncycles, test_harness.line_trace() ))
+    print("{}:{}".format(ncycles, test_harness.line_trace()))
 
   # Check timeout
   assert ncycles < max_cycles
@@ -98,42 +99,42 @@ def run_sim( test_harness, max_cycles=20 ):
   test_harness.sim_tick()
 
 
-func_opt = { AdderRTL : OPT_ADD,
-             NahRTL   : OPT_ADD,
-             MulRTL   : OPT_MUL }
+func_opt = {AdderRTL : OPT_ADD,
+            NahRTL   : OPT_ADD,
+            MulRTL   : OPT_MUL}
 
 @st.composite
-def inputs_strat( draw, functions ):
-  input_a  = draw( st.integers(0, 8), label="input_a" )
-  input_b  = draw( st.integers(0, 8), label="input_b" )
-  opt = draw( st.sampled_from( [ func_opt[function] for function in functions ] ) )
+def inputs_strat(draw, functions):
+  input_a = draw(st.integers(0, 8), label="input_a")
+  input_b = draw(st.integers(0, 8), label="input_b")
+  opt = draw(st.sampled_from([func_opt[function] for function in functions]))
   return input_a, input_b, opt
 
-@hypothesis.settings( deadline=None, max_examples=50 )
+@hypothesis.settings(deadline=None, max_examples = 50)
 @hypothesis.given(
-  functions = st.sampled_from( [ [ AdderRTL], [ AdderRTL, MulRTL ]] ),
+  functions = st.sampled_from([[AdderRTL], [AdderRTL, MulRTL]]),
   inputs = st.data(),
 )
-def test_hypothesis( functions, inputs ):
+def test_hypothesis(functions, inputs):
   FU = FlexibleFuRTL
   input_list = inputs.draw(
-    st.lists( inputs_strat(functions), max_size=4 ),
+    st.lists(inputs_strat(functions), max_size = 4),
     label = "functions"
   )
-  src_a, src_b, src_opt  = [], [], []
-  DataType      = mk_data( 16, 1 )
-  PredicateType = mk_predicate( 1, 1 )
+  src_a, src_b, src_opt = [], [], []
+  DataType      = mk_data(16, 1)
+  PredicateType = mk_predicate(1, 1)
   CtrlType      = mk_ctrl()
   num_inports   = 2
-  FuInType      = mk_bits( clog2( num_inports + 1 ) )
-  pickRegister  = [ FuInType( x+1 ) for x in range( num_inports ) ]
+  FuInType      = mk_bits(clog2(num_inports + 1))
+  pickRegister  = [FuInType(x + 1) for x in range(num_inports)]
   for value in input_list:
-    src_a.append  ( DataType(value[0]) )
-    src_b.append  ( DataType(value[1]) )
-    src_opt.append( CtrlType(value[2], b1( 0 ), pickRegister) )
-  src_predicate = [ PredicateType(1, 0) ]
-  sink_out      = FuFL( DataType, src_a, src_b, src_opt )
-  th = TestHarness( FU, functions, DataType, PredicateType, CtrlType,
-                    src_a, src_b, src_predicate, src_opt, sink_out )
-  run_sim( th )
+    src_a.append  (DataType(value[0]))
+    src_b.append  (DataType(value[1]))
+    src_opt.append(CtrlType(value[2], b1( 0 ), pickRegister))
+  src_predicate = [PredicateType(1, 0)]
+  sink_out      = FuFL(DataType, src_a, src_b, src_opt)
+  th = TestHarness(FU, functions, DataType, PredicateType, CtrlType,
+                   src_a, src_b, src_predicate, src_opt, sink_out)
+  run_sim(th)
 

--- a/fu/flexible/test/FlexibleFuRTL_test.py
+++ b/fu/flexible/test/FlexibleFuRTL_test.py
@@ -43,7 +43,7 @@ class TestHarness( Component ):
     s.sink_out1 = TestSinkRTL( DataType, sink1_msgs)
 
     s.dut = FunctionUnit(DataType, PredicateType, CtrlType, num_inports,
-                         num_outports, data_mem_size, FuList)
+                         num_outports, data_mem_size, 1, FuList)
 
     connect(s.src_const.send, s.dut.recv_const)
     connect(s.src_in0.send, s.dut.recv_in[0])

--- a/lib/cmd_type.py
+++ b/lib/cmd_type.py
@@ -40,7 +40,7 @@ CMD_SYMBOL_DICT = {
   CMD_LOAD_REQUEST:                     "(LOAD_REQUEST)",
   CMD_LOAD_RESPONSE:                    "(LOAD_RESPONSE)",
   CMD_STORE_REQUEST:                    "(STORE_REQUEST)",
-  CMD_CONST:                            "(CONST_DATA)"
+  CMD_CONST:                            "(CONST_DATA)",
   CMD_COMPLETE:                         "(COMPLETE_EXECUTION)"
 }
 

--- a/lib/cmd_type.py
+++ b/lib/cmd_type.py
@@ -14,25 +14,31 @@ from pymtl3 import *
 
 # Total number of commands that are supported/recognized by controller.
 # Needs to be updated once more commands are added/supported.
-NUM_CMDS = 8
+NUM_CMDS = 11
 
-CMD_LAUNCH        = 0
-CMD_PAUSE         = 1
-CMD_TERMINATE     = 2
-CMD_CONFIG        = 3
-CMD_LOAD_REQUEST  = 4
-CMD_LOAD_RESPONSE = 5
-CMD_STORE_REQUEST = 6
-CMD_CONST         = 7
+CMD_LAUNCH                           = 0
+CMD_PAUSE                            = 1
+CMD_TERMINATE                        = 2
+CMD_CONFIG                           = 3
+CMD_CONFIG_PROLOGUE_FU               = 4
+CMD_CONFIG_PROLOGUE_FU_CROSSBAR      = 5
+CMD_CONFIG_PROLOGUE_ROUTING_CROSSBAR = 6
+CMD_LOAD_REQUEST                     = 7
+CMD_LOAD_RESPONSE                    = 8
+CMD_STORE_REQUEST                    = 9
+CMD_CONST                            = 10
 
 CMD_SYMBOL_DICT = {
-  CMD_LAUNCH:        "(LAUNCH_KERNEL)",
-  CMD_PAUSE:         "(PAUSE_EXECUTION)",
-  CMD_TERMINATE:     "(TERMINATE_EXECUTION)",
-  CMD_CONFIG:        "(PRELOADING_KERNEL_CONFIG)",
-  CMD_LOAD_REQUEST:  "(LOAD_REQUEST)",
-  CMD_LOAD_RESPONSE: "(LOAD_RESPONSE)",
-  CMD_STORE_REQUEST: "(STORE_REQUEST)",
-  CMD_CONST:         "(CONST_DATA)"
+  CMD_LAUNCH:                           "(LAUNCH_KERNEL)",
+  CMD_PAUSE:                            "(PAUSE_EXECUTION)",
+  CMD_TERMINATE:                        "(TERMINATE_EXECUTION)",
+  CMD_CONFIG:                           "(PRELOADING_KERNEL_CONFIG)",
+  CMD_CONFIG_PROLOGUE_FU:               "(PRELOADING_PROLOGUE_FU)",
+  CMD_CONFIG_PROLOGUE_FU_CROSSBAR:      "(PRELOADING_PROLOGUE_FU_CROSSBAR)",
+  CMD_CONFIG_PROLOGUE_ROUTING_CROSSBAR: "(PRELOADING_PROLOGUE_ROUTING_CROSSBAR)",
+  CMD_LOAD_REQUEST:                     "(LOAD_REQUEST)",
+  CMD_LOAD_RESPONSE:                    "(LOAD_RESPONSE)",
+  CMD_STORE_REQUEST:                    "(STORE_REQUEST)",
+  CMD_CONST:                            "(CONST_DATA)"
 }
 

--- a/lib/messages.py
+++ b/lib/messages.py
@@ -597,7 +597,8 @@ def mk_intra_cgra_pkt(ntiles = 4,
              f"{ctrl_tile_outports}_{ctrl_registers_per_reg_bank}"
 
   def str_func(s):
-    out_str = '(ctrl_operation)' + str(s.ctrl_operation)
+    out_str = '(ctrl_action)' + str(s.ctrl_action)
+    out_str += '(ctrl_operation)' + str(s.ctrl_operation)
     out_str += '|(ctrl_fu_in)'
     for i in range(ctrl_fu_inports):
       if i != 0:

--- a/lib/util/common.py
+++ b/lib/util/common.py
@@ -6,7 +6,7 @@ Author : Cheng Tan
   Date : Dec 24, 2022
 """
 
-# Constants for routing directions
+# Constants for routing directions.
 
 PORT_NORTH     = 0
 PORT_SOUTH     = 1
@@ -25,3 +25,7 @@ PORT_CONST = 2
 LINK_NO_MEM   = 0
 LINK_FROM_MEM = 1
 LINK_TO_MEM   = 2
+
+# Constant for prologue max count.
+
+PROLOGUE_MAX_COUNT = 7

--- a/lib/util/common.py
+++ b/lib/util/common.py
@@ -29,3 +29,4 @@ LINK_TO_MEM   = 2
 # Constant for prologue max count.
 
 PROLOGUE_MAX_COUNT = 7
+

--- a/mem/ctrl/CtrlMemDynamicRTL.py
+++ b/mem/ctrl/CtrlMemDynamicRTL.py
@@ -50,6 +50,8 @@ class CtrlMemDynamicRTL(Component):
     # Sends the ctrl packets towards the controller.
     s.send_pkt_to_controller = SendIfcRTL(CtrlPktType)
 
+    s.tile_id = InPort(mk_bits(clog2(num_tiles + 1)))
+
     # Component
     s.reg_file = RegisterFile(CtrlSignalType, ctrl_mem_size, 1, 1)
     s.recv_pkt_queue = NormalQueueRTL(CtrlPktType)

--- a/mem/ctrl/CtrlMemDynamicRTL.py
+++ b/mem/ctrl/CtrlMemDynamicRTL.py
@@ -149,7 +149,7 @@ class CtrlMemDynamicRTL(Component):
     @update_ff
     def update_whether_we_can_iterate_ctrl():
       if s.reset:
-        s.start_iterate_ctrl << = 0
+        s.start_iterate_ctrl <<= 0
       else:
         if s.recv_pkt_queue.send.val:
           if s.recv_pkt_queue.send.msg.ctrl_action == CMD_LAUNCH:

--- a/noc/CrossbarRTL.py
+++ b/noc/CrossbarRTL.py
@@ -13,6 +13,7 @@ from pymtl3 import *
 from ..lib.basic.val_rdy.ifcs import ValRdyRecvIfcRTL as RecvIfcRTL
 from ..lib.basic.val_rdy.ifcs import ValRdySendIfcRTL as SendIfcRTL
 from ..lib.opt_type import *
+from ..lib.util.common import *
 
 class CrossbarRTL(Component):
 
@@ -22,6 +23,7 @@ class CrossbarRTL(Component):
     InType = mk_bits(clog2(num_inports + 1))
     num_index = num_inports if num_inports != 1 else 2
     NumInportType = mk_bits(clog2(num_index))
+    PrologueCountType = mk_bits(clog2(PROLOGUE_MAX_COUNT + 1))
 
     # Interface
     s.recv_opt = RecvIfcRTL(CtrlType)
@@ -38,6 +40,13 @@ class CrossbarRTL(Component):
     s.recv_valid_vector = Wire(num_outports)
     s.recv_required_vector = Wire(num_inports)
     s.send_required_vector = Wire(num_outports)
+
+    # Prologue-related wires and registers, which are used to indicate
+    # whether the prologue steps have already been satisfied.
+    s.recv_prologue_vector = Wire(num_outports)
+    s.recv_prologue_or_valid_vector = Wire(num_outports)
+    s.prologue_counter = [Wire(PrologueCountType) for _ in range(num_inports)]
+    s.prologue_count_inport = [InPort(PrologueCountType) for _ in range(num_inports)]
 
     # Routing logic
     @update
@@ -87,7 +96,38 @@ class CrossbarRTL(Component):
             s.send_data[i].msg.predicate @= s.recv_data[s.in_dir_local[i]].msg.predicate
 
         s.send_predicate.msg.predicate @= reduce_or(s.recv_predicate_vector)
-        s.recv_opt.rdy @= reduce_and(s.send_rdy_vector) & reduce_and(s.recv_valid_vector)
+        # s.recv_opt.rdy @= reduce_and(s.send_rdy_vector) & reduce_and(s.recv_valid_vector)
+        s.recv_opt.rdy @= reduce_and(s.send_rdy_vector) & \
+                          reduce_and(s.recv_prologue_or_valid_vector)
+
+    @update_ff
+    def update_prologue_counter():
+      if s.reset:
+        for i in range(num_inports):
+          s.prologue_counter[i] <<= 0
+      elif s.recv_opt.rdy:
+        for i in range(num_outports):
+          if (s.in_dir[i] > 0) & \
+             (s.prologue_counter[s.in_dir_local[i]] < s.prologue_count_inport[s.in_dir_local[i]]):
+            s.prologue_counter[s.in_dir_local[i]] <<= s.prologue_counter[s.in_dir_local[i]] + 1
+
+    @update
+    def update_prologue_vector():
+      s.recv_prologue_vector @= 0
+      for i in range(num_outports):
+        if s.in_dir[i] > 0:
+          # Records whether the prologue steps have already been satisfied.
+          s.recv_prologue_vector[i] @= \
+              (s.prologue_counter[s.in_dir_local[i]] >= s.prologue_count_inport[s.in_dir_local[i]])
+        else:
+          s.recv_prologue_vector[i] @= 1
+
+    @update
+    def update_prologue_or_valid_vector():
+      s.recv_prologue_or_valid_vector @= 0
+      for i in range(num_outports):
+        s.recv_prologue_or_valid_vector[i] @= \
+            s.recv_valid_vector[i] | s.recv_prologue_vector[i]
 
     @update
     def update_in_dir_vector():
@@ -103,9 +143,7 @@ class CrossbarRTL(Component):
 
     @update
     def update_rdy_vector():
-
       s.send_rdy_vector @= 0
-
       for i in range(num_outports):
         if s.in_dir[i] > 0:
           s.send_rdy_vector[i] @= s.send_data[i].rdy
@@ -114,9 +152,7 @@ class CrossbarRTL(Component):
 
     @update
     def update_valid_vector():
-
       s.recv_valid_vector @= 0
-
       for i in range(num_outports):
         if s.in_dir[i] > 0:
           s.recv_valid_vector[i] @= s.recv_data[s.in_dir_local[i]].val
@@ -125,13 +161,11 @@ class CrossbarRTL(Component):
 
     @update
     def update_recv_required_vector():
-
       for i in range(num_inports):
         s.recv_required_vector[i] @= 0
 
       for i in range(num_outports):
         if s.in_dir[i] > 0:
-          # FIXME: @yo96, this might be a long critical path?
           s.recv_required_vector[s.in_dir_local[i]] @= 1
 
     @update

--- a/noc/CrossbarRTL.py
+++ b/noc/CrossbarRTL.py
@@ -102,7 +102,6 @@ class CrossbarRTL(Component):
         # s.recv_opt.rdy @= reduce_and(s.send_rdy_vector) & reduce_and(s.recv_valid_vector)
         s.recv_opt.rdy @= reduce_and(s.send_rdy_vector) & \
                           reduce_and(s.recv_valid_or_prologue_allowing_vector)
-        print("[cheng] tile[", s.tile_id, "], crossbar_id[", s.crossbar_id, "], within xbar (though not sure which one), s.recv_opt.rdy: ", s.recv_opt.rdy, "; reduce_and(s.send_rdy_vector): ", reduce_and(s.send_rdy_vector), "; reduce_and(s.recv_valid_or_prologue_allowing_vector): ", reduce_and(s.recv_valid_or_prologue_allowing_vector), "; s.prologue_allowing_vector: ", s.prologue_allowing_vector, "; s.prologue_allowing_vector[0]: ", s.prologue_allowing_vector[0])
 
     @update_ff
     def update_prologue_counter():
@@ -113,14 +112,7 @@ class CrossbarRTL(Component):
         for i in range(num_outports):
           if (s.in_dir[i] > 0) & \
              (s.prologue_counter[s.in_dir_local[i]] < s.prologue_count_inport[s.in_dir_local[i]]):
-            print("[cheng] increasing fu_xbar_prologue, s.in_dir_local[", i, "]: ", s.in_dir_local[i], "; s.prologue_count_inport[s.in_dir_local[i]]: ", s.prologue_count_inport[s.in_dir_local[i]])
             s.prologue_counter[s.in_dir_local[i]] <<= s.prologue_counter[s.in_dir_local[i]] + 1
-
-      for i in range(num_outports):
-        if (s.in_dir[i] > 0) & \
-           (s.prologue_counter[s.in_dir_local[i]] < s.prologue_count_inport[s.in_dir_local[i]]):
-          print("[cheng] s.in_dir_local[", i, "]: ", s.in_dir_local[i], "; s.prologue_count_inport[s.in_dir_local[i]]: ", s.prologue_count_inport[s.in_dir_local[i]])
-
 
     @update
     def update_prologue_allowing_vector():

--- a/noc/test/CrossbarRTL_test.py
+++ b/noc/test/CrossbarRTL_test.py
@@ -36,7 +36,7 @@ class TestHarness(Component):
                   for i in range(num_outports)]
 
     s.dut = CrossbarUnit(DataType, PredicateType, CtrlType, num_inports,
-                         num_outports)
+                         num_outports, 1)
 
     for i in range(num_inports):
       s.src_data[i].send //= s.dut.recv_data[i]

--- a/systolic/CgraSystolicArrayRTL.py
+++ b/systolic/CgraSystolicArrayRTL.py
@@ -106,6 +106,10 @@ class CgraSystolicArrayRTL(Component):
     s.recv_from_cpu_pkt //= s.controller.recv_from_cpu_pkt
     s.send_to_cpu_pkt //= s.controller.send_to_cpu_pkt
 
+    # Assigns tile id.
+    for i in range(s.num_tiles):
+      s.tile[i].tile_id //= i
+
     # Connects ring with each control memory.
     for i in range(s.num_tiles):
       s.ctrl_ring.send[i] //= s.tile[i].recv_from_controller_pkt

--- a/tile/TileRTL.py
+++ b/tile/TileRTL.py
@@ -24,6 +24,7 @@ from ..fu.single.PhiRTL import PhiRTL
 from ..lib.basic.val_rdy.ifcs import ValRdyRecvIfcRTL as RecvIfcRTL
 from ..lib.basic.val_rdy.ifcs import ValRdySendIfcRTL as SendIfcRTL
 from ..lib.cmd_type import *
+from ..lib.util.common import *
 from ..mem.const.ConstQueueDynamicRTL import ConstQueueDynamicRTL
 from ..mem.ctrl.CtrlMemDynamicRTL import CtrlMemDynamicRTL
 from ..mem.register_cluster.RegisterClusterRTL import RegisterClusterRTL
@@ -73,16 +74,18 @@ class TileRTL(Component):
     # Components.
     s.element = FlexibleFuRTL(DataType, PredicateType, CtrlSignalType,
                               num_fu_inports, num_fu_outports,
-                              data_mem_size, FuList)
+                              data_mem_size, num_tiles, FuList)
     s.const_mem = ConstQueueDynamicRTL(DataType, data_mem_size)
     s.routing_crossbar = CrossbarRTL(DataType, PredicateType,
                                      CtrlSignalType,
                                      num_routing_xbar_inports,
-                                     num_routing_xbar_outports)
+                                     num_routing_xbar_outports,
+                                     num_tiles)
     s.fu_crossbar = CrossbarRTL(DataType, PredicateType,
                                 CtrlSignalType,
                                 num_fu_xbar_inports,
-                                num_fu_xbar_outports)
+                                num_fu_xbar_outports,
+                                num_tiles)
     s.register_cluster = \
         RegisterClusterRTL(DataType, CtrlSignalType, num_fu_inports,
                            num_registers_per_reg_bank)
@@ -110,6 +113,18 @@ class TileRTL(Component):
     s.element_done = Wire(1)
     s.fu_crossbar_done = Wire(1)
     s.routing_crossbar_done = Wire(1)
+
+    s.tile_id = InPort(mk_bits(clog2(num_tiles + 1)))
+
+    # Propagates tile id.
+    s.element.tile_id //= s.tile_id
+    s.ctrl_mem.tile_id //= s.tile_id
+    s.fu_crossbar.tile_id //= s.tile_id
+    s.routing_crossbar.tile_id //= s.tile_id
+
+    # Assigns crossbar id.
+    s.routing_crossbar.crossbar_id //= PORT_ROUTING_CROSSBAR
+    s.fu_crossbar.crossbar_id //= PORT_FU_CROSSBAR
 
     # Constant queue.
     s.element.recv_const //= s.const_mem.send_const
@@ -193,7 +208,12 @@ class TileRTL(Component):
         s.const_mem.recv_const.val @= 0
         s.recv_from_controller_pkt.rdy @= 0
 
-        if s.recv_from_controller_pkt.val & ((s.recv_from_controller_pkt.msg.ctrl_action == CMD_CONFIG) | (s.recv_from_controller_pkt.msg.ctrl_action == CMD_LAUNCH)):
+        if s.recv_from_controller_pkt.val & \
+           ((s.recv_from_controller_pkt.msg.ctrl_action == CMD_CONFIG) | \
+            (s.recv_from_controller_pkt.msg.ctrl_action == CMD_CONFIG_PROLOGUE_FU) | \
+            (s.recv_from_controller_pkt.msg.ctrl_action == CMD_CONFIG_PROLOGUE_FU_CROSSBAR) | \
+            (s.recv_from_controller_pkt.msg.ctrl_action == CMD_CONFIG_PROLOGUE_ROUTING_CROSSBAR) | \
+            (s.recv_from_controller_pkt.msg.ctrl_action == CMD_LAUNCH)):
             s.ctrl_mem.recv_pkt_from_controller.val @= 1
             s.ctrl_mem.recv_pkt_from_controller.msg @= s.recv_from_controller_pkt.msg
             s.recv_from_controller_pkt.rdy @= s.ctrl_mem.recv_pkt_from_controller.rdy

--- a/tile/TileRTL.py
+++ b/tile/TileRTL.py
@@ -110,6 +110,15 @@ class TileRTL(Component):
     # Constant queue.
     s.element.recv_const //= s.const_mem.send_const
 
+    # Prologue port.
+    s.element.prologue_count_inport //= s.ctrl_mem.prologue_count_outport_fu
+    for i in range(num_routing_xbar_inports):
+      s.routing_crossbar.prologue_count_inport[i] //= \
+          s.ctrl_mem.prologue_count_outport_routing_crossbar[i]
+    for i in range(num_fu_xbar_inports):
+      s.fu_crossbar.prologue_count_inport[i] //= \
+          s.ctrl_mem.prologue_count_outport_fu_crossbar[i]
+
     for i in range(len(FuList)):
       if FuList[i] == MemUnitRTL:
         s.to_mem_raddr //= s.element.to_mem_raddr[i]

--- a/tile/test/TileRTL_test.py
+++ b/tile/test/TileRTL_test.py
@@ -64,6 +64,9 @@ class TestHarness(Component):
                 num_registers_per_reg_bank,
                 FunctionUnit, FuList)
 
+    # Connects tile id.
+    s.dut.tile_id //= 0
+
     connect(s.src_ctrl_pkt.send, s.dut.recv_from_controller_pkt)
     s.complete_signal_sink_out.recv //= s.dut.send_to_controller_pkt
 


### PR DESCRIPTION
Allow users to pre-configure the prologue execution for each operation and each routing.
 - Required by temporal mapping. The design now makes the operation execution depend on input data arrival, leading to some tiles blocking the operations that are mapped after the pending operations, detailed in https://github.com/tancheng/VectorCGRA/issues/73.
 - [ ] Test.
 - Also fixed https://github.com/tancheng/VectorCGRA/issues/105.