### PR TITLE
Multi cgra load data

### DIFF
--- a/controller/ControllerRTL.py
+++ b/controller/ControllerRTL.py
@@ -152,7 +152,13 @@ class ControllerRTL(Component):
                      0, # ctrl_fu_in
                      0, # ctrl_routing_xbar_outport
                      0, # ctrl_fu_xbar_outport
-                     0) # ctrl_routing_predicate_in
+                     0, # ctrl_routing_predicate_in
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0)
 
 
 
@@ -180,7 +186,13 @@ class ControllerRTL(Component):
                      0, # ctrl_fu_in
                      0, # ctrl_routing_xbar_outport
                      0, # ctrl_fu_xbar_outport
-                     0) # ctrl_routing_predicate_in
+                     0, # ctrl_routing_predicate_in
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0)
 
 
 
@@ -211,7 +223,13 @@ class ControllerRTL(Component):
                      0, # ctrl_fu_in
                      0, # ctrl_routing_xbar_outport
                      0, # ctrl_fu_xbar_outport
-                     0) # ctrl_routing_predicate_in
+                     0, # ctrl_routing_predicate_in
+                     0,
+                     0,
+                     0,
+                     0,
+                     0,
+                     0)
 
 
 
@@ -220,12 +238,12 @@ class ControllerRTL(Component):
           s.recv_from_cpu_pkt_queue.send.val
       s.recv_from_cpu_pkt_queue.send.rdy @= s.crossbar.recv[kFromCpuCtrlAndDataIdx].rdy
       s.crossbar.recv[kFromCpuCtrlAndDataIdx].msg @= \
-          NocPktType(s.recv_from_cpu_pkt_queue.send.msg.cgra_id, # src
-                     0, # dst 
-                     s.idTo2d_x_lut[s.recv_from_cpu_pkt_queue.send.msg.cgra_id], # src_x
-                     s.idTo2d_y_lut[s.recv_from_cpu_pkt_queue.send.msg.cgra_id], # src_y
-                     0, # dst_x
-                     0, # dst_y
+          NocPktType(s.controller_id, # src
+                     s.recv_from_cpu_pkt_queue.send.msg.cgra_id, # dst
+                     0, # src_x
+                     0, # src_y
+                     s.idTo2d_x_lut[s.recv_from_cpu_pkt_queue.send.msg.cgra_id], # dst_x
+                     s.idTo2d_y_lut[s.recv_from_cpu_pkt_queue.send.msg.cgra_id], # dst_y
                      s.recv_from_cpu_pkt_queue.send.msg.dst, # tile id 
                      0, # opaque
                      0, # vc_id
@@ -240,7 +258,13 @@ class ControllerRTL(Component):
                      s.recv_from_cpu_pkt_queue.send.msg.ctrl_fu_in, # ctrl_fu_in
                      s.recv_from_cpu_pkt_queue.send.msg.ctrl_routing_xbar_outport, # ctrl_routing_xbar_outport
                      s.recv_from_cpu_pkt_queue.send.msg.ctrl_fu_xbar_outport, # ctrl_fu_xbar_outport
-                     s.recv_from_cpu_pkt_queue.send.msg.ctrl_routing_predicate_in) # ctrl_routing_predicate_in
+                     s.recv_from_cpu_pkt_queue.send.msg.ctrl_routing_predicate_in, # ctrl_routing_predicate_in
+                     s.recv_from_cpu_pkt_queue.send.msg.ctrl_vector_factor_power,
+                     s.recv_from_cpu_pkt_queue.send.msg.ctrl_is_last_ctrl,
+                     s.recv_from_cpu_pkt_queue.send.msg.ctrl_write_reg_from,
+                     s.recv_from_cpu_pkt_queue.send.msg.ctrl_write_reg_idx,
+                     s.recv_from_cpu_pkt_queue.send.msg.ctrl_read_reg_from,
+                     s.recv_from_cpu_pkt_queue.send.msg.ctrl_read_reg_idx)
         
       # TODO: For the other cmd types.
 
@@ -313,12 +337,12 @@ class ControllerRTL(Component):
                                                     s.recv_from_inter_cgra_noc.msg.addr,  # addr
                                                     s.recv_from_inter_cgra_noc.msg.data,  # data
                                                     s.recv_from_inter_cgra_noc.msg.predicate,  # data_predicate
-                                                    0,  # ctrl_vector_factor_power
-                                                    0,  # ctrl_is_last_ctrl
-                                                    0,  # ctrl_write_reg_from
-                                                    0,  # ctrl_write_reg_idx
-                                                    0,  # ctrl_read_reg_from
-                                                    0)  # ctrl_read_reg_idx
+                                                    s.recv_from_inter_cgra_noc.msg.ctrl_vector_factor_power,  # ctrl_vector_factor_power
+                                                    s.recv_from_inter_cgra_noc.msg.ctrl_is_last_ctrl,  # ctrl_is_last_ctrl
+                                                    s.recv_from_inter_cgra_noc.msg.ctrl_write_reg_from,  # ctrl_write_reg_from
+                                                    s.recv_from_inter_cgra_noc.msg.ctrl_write_reg_idx,  # ctrl_write_reg_idx
+                                                    s.recv_from_inter_cgra_noc.msg.ctrl_read_reg_from,  # ctrl_read_reg_from
+                                                    s.recv_from_inter_cgra_noc.msg.ctrl_read_reg_idx)  # ctrl_read_reg_idx
 
         # else:
         #   # TODO: Handle other cmd types.
@@ -351,7 +375,13 @@ class ControllerRTL(Component):
                      s.crossbar.send[0].msg.ctrl_fu_in,
                      s.crossbar.send[0].msg.ctrl_routing_xbar_outport,
                      s.crossbar.send[0].msg.ctrl_fu_xbar_outport,
-                     s.crossbar.send[0].msg.ctrl_routing_predicate_in)
+                     s.crossbar.send[0].msg.ctrl_routing_predicate_in,
+                     s.crossbar.send[0].msg.ctrl_vector_factor_power,
+                     s.crossbar.send[0].msg.ctrl_is_last_ctrl,
+                     s.crossbar.send[0].msg.ctrl_write_reg_from,
+                     s.crossbar.send[0].msg.ctrl_write_reg_idx,
+                     s.crossbar.send[0].msg.ctrl_read_reg_from,
+                     s.crossbar.send[0].msg.ctrl_read_reg_idx)
 
   def line_trace(s):
     recv_from_cpu_pkt_str = "recv_from_cpu_pkt: " + str(s.recv_from_cpu_pkt.msg)

--- a/lib/messages.py
+++ b/lib/messages.py
@@ -474,6 +474,7 @@ def mk_multi_cgra_noc_pkt(ncols = 4, nrows = 4, ntiles = 16,
                           ctrl_fu_outports = 2,
                           ctrl_tile_inports = 4,
                           ctrl_tile_outports = 4,
+                          ctrl_registers_per_reg_bank = 16,
                           prefix="MeshMultiCGRAPacket"):
 
   IdType = mk_bits(max(clog2(ncols * nrows), 1))
@@ -498,6 +499,11 @@ def mk_multi_cgra_noc_pkt(ncols = 4, nrows = 4, ntiles = 16,
   CtrlFuOutType = mk_bits(clog2(ctrl_fu_outports + 1))
   CtrlPredicateType = mk_bits(predicate_nbits)
   VcIdType = mk_bits(clog2(vc))
+
+  vector_factor_power_nbits = 3
+  CtrlVectorFactorPowerType = mk_bits(vector_factor_power_nbits)
+  CtrlRegFromType = mk_bits(2)
+  CtrlRegIdxType = mk_bits(clog2(ctrl_registers_per_reg_bank))
 
   new_name = f"{prefix}_{ncols*nrows}_{ncols}x{nrows}_{vc}_{opaque_nbits}_" \
              f"{addr_nbits}_{data_nbits}_{predicate_nbits}_{ctrl_actions}_{ctrl_mem_size}_" \
@@ -525,6 +531,17 @@ def mk_multi_cgra_noc_pkt(ncols = 4, nrows = 4, ntiles = 16,
   field_dict['ctrl_routing_xbar_outport'] = [CtrlTileInType for _ in range(num_routing_outports)]
   field_dict['ctrl_fu_xbar_outport'] = [CtrlFuOutType for _ in range(num_routing_outports)]
   field_dict['ctrl_routing_predicate_in'] = [CtrlPredicateType for _ in range(ctrl_tile_inports)]
+
+  field_dict['ctrl_vector_factor_power'] = CtrlVectorFactorPowerType
+  field_dict['ctrl_is_last_ctrl'] = b1
+  # Register file related signals.
+  # Indicates whether to write data into the register bank, and the
+  # corresponding inport.
+  field_dict['ctrl_write_reg_from'] = [CtrlRegFromType for _ in range(ctrl_fu_inports)]
+  field_dict['ctrl_write_reg_idx'] = [CtrlRegIdxType for _ in range(ctrl_fu_inports)]
+  # Indicates whether to read data from the register bank.
+  field_dict['ctrl_read_reg_from'] = [b1 for _ in range(ctrl_fu_inports)]
+  field_dict['ctrl_read_reg_idx'] = [CtrlRegIdxType for _ in range(ctrl_fu_inports)]
 
   def str_func(s):
       return f"{s.src}>{s.dst},{s.src_x},{s.src_y}>{s.dst_x},{s.dst_y} || tileid:{s.tile_id} ||" \

--- a/scale_out/test/MeshMultiCgraRTL_test.py
+++ b/scale_out/test/MeshMultiCgraRTL_test.py
@@ -234,7 +234,7 @@ def test_homo_2x2_2x2(cmdline_opts):
 
                  # cgra_id src dst vc_id opq cmd_type    addr operation predicate
        CtrlPktType(0,      0,  0,  0,    0,  CMD_CONFIG, 0,   OPT_LD_CONST,  b1(0),
-                   [FuInType(1), FuInType(0), FuInType(0), FuInType(0)],
+                   [FuInType(0), FuInType(0), FuInType(0), FuInType(0)],
                    [TileInType(0), TileInType(0), TileInType(0), TileInType(0),
                     TileInType(0), TileInType(0), TileInType(0), TileInType(0)],
 
@@ -245,11 +245,11 @@ def test_homo_2x2_2x2(cmdline_opts):
                   ),
 
        CtrlPktType(0,      0,  0,  0,    0,  CMD_CONFIG, 0,   OPT_INC,  b1(0),
-                   pickRegister,
+                   [FuInType(1), FuInType(0), FuInType(0), FuInType(0)],
                    [TileInType(0), TileInType(0), TileInType(0), TileInType(0),
                     TileInType(0), TileInType(0), TileInType(0), TileInType(0)],
 
-                   [FuOutType(1), FuOutType(0), FuOutType(0), FuOutType(1),
+                   [FuOutType(1), FuOutType(0), FuOutType(0), FuOutType(0),
                     FuOutType(0), FuOutType(0), FuOutType(0), FuOutType(0)],
                    ctrl_read_reg_from = [b1(1), b1(0), b1(0), b1(0)],
                    ctrl_read_reg_idx = [RegIdxType(7), RegIdxType(0), RegIdxType(0), RegIdxType(0)]
@@ -263,7 +263,7 @@ def test_homo_2x2_2x2(cmdline_opts):
 
                  # cgra_id src dst vc_id opq cmd_type    addr operation predicate
        CtrlPktType(0,      0,  2,  0,    0,  CMD_CONFIG, 0,   OPT_STR_CONST,  b1(0),
-                   pickRegister,
+                   [FuInType(1), FuInType(0), FuInType(0), FuInType(0)],
                    [TileInType(0), TileInType(0), TileInType(0), TileInType(0),
                     # TODO: make below as TileInType(5) to double check.
                     TileInType(2), TileInType(0), TileInType(0), TileInType(0)],

--- a/scale_out/test/MeshMultiCgraRTL_test.py
+++ b/scale_out/test/MeshMultiCgraRTL_test.py
@@ -156,77 +156,21 @@ def test_homo_2x2_2x2(cmdline_opts):
                                      ctrl_fu_outports = num_fu_outports,
                                      ctrl_tile_inports = num_tile_inports,
                                      ctrl_tile_outports = num_tile_outports)
-  pickRegister = [FuInType(x + 1) for x in range(num_fu_inports)]
-  src_opt_per_tile = [[
-                # cgra_id src dst vc_id opq cmd_type    addr operation predicate
-      CtrlPktType(0,      0,  i,  0,    0,  CMD_CONFIG, 0,   OPT_INC,  b1(0),
-                  pickRegister,
-                  [TileInType(4), TileInType(3), TileInType(2), TileInType(1),
-                   # TODO: make below as TileInType(5) to double check.
-                   TileInType(0), TileInType(0), TileInType(0), TileInType(0)],
-                  
-                  [FuOutType(0), FuOutType(0), FuOutType(0), FuOutType(0),
-                   FuOutType(1), FuOutType(1), FuOutType(1), FuOutType(1)], 0, 0, 0, 0, 0),
-
-      CtrlPktType(0,      0,  i,  0,    0,  CMD_CONFIG, 1,   OPT_INC, b1(0),
-                  pickRegister,
-                  [TileInType(4), TileInType(3), TileInType(2), TileInType(1),
-                   TileInType(0), TileInType(0), TileInType(0), TileInType(0)],
-                  
-                  [FuOutType(0), FuOutType(0), FuOutType(0), FuOutType(0),
-                   FuOutType(1), FuOutType(1), FuOutType(1), FuOutType(1)], 0, 0, 0, 0, 0),
-
-      CtrlPktType(0,      0,  i,  0,    0,  CMD_CONFIG, 2,   OPT_ADD, b1(0),
-                  pickRegister,
-                  [TileInType(4), TileInType(3), TileInType(2), TileInType(1),
-                   TileInType(0), TileInType(0), TileInType(0), TileInType(0)],
-
-                  [FuOutType(0), FuOutType(0), FuOutType(0), FuOutType(0),
-                   FuOutType(1), FuOutType(1), FuOutType(1), FuOutType(1)], 0, 0, 0, 0, 0),
-
-      CtrlPktType(0,      0,  i,  0,    0,  CMD_CONFIG, 3,   OPT_STR, b1(0),
-                  pickRegister,
-                  [TileInType(4), TileInType(3), TileInType(2), TileInType(1),
-                   TileInType(0), TileInType(0), TileInType(0), TileInType(0)],
-
-                  [FuOutType(0), FuOutType(0), FuOutType(0), FuOutType(0),
-                   FuOutType(1), FuOutType(1), FuOutType(1), FuOutType(1)], 0, 0, 0, 0, 0),
-
-      CtrlPktType(0,      0,  i,  0,    0,  CMD_CONFIG, 4,   OPT_ADD, b1(0),
-                  pickRegister,
-                  [TileInType(4), TileInType(3), TileInType(2), TileInType(1),
-                   TileInType(0), TileInType(0), TileInType(0), TileInType(0)],
-
-                  [FuOutType(0), FuOutType(0), FuOutType(0), FuOutType(0),
-                   FuOutType(1), FuOutType(1), FuOutType(1), FuOutType(1)], 0, 0, 0, 0, 0),
-
-      CtrlPktType(0,      0,  i,  0,    0,  CMD_CONFIG, 5,   OPT_ADD, b1(0),
-                  pickRegister,
-                  [TileInType(4), TileInType(3), TileInType(2), TileInType(1),  
-                   TileInType(0), TileInType(0), TileInType(0), TileInType(0)],
-
-                  [FuOutType(0), FuOutType(0), FuOutType(0), FuOutType(0),
-                   FuOutType(1), FuOutType(1), FuOutType(1), FuOutType(1)], 0, 0, 0, 0, 0),
-
-      # This last one is for launching kernel.
-      CtrlPktType(0,      0,  i,  0,    0,  CMD_LAUNCH, 0,   OPT_ADD, b1(0),
-                  pickRegister,
-                  [TileInType(4), TileInType(3), TileInType(2), TileInType(1),
-                   TileInType(0), TileInType(0), TileInType(0), TileInType(0)],
-
-                  [FuOutType(0), FuOutType(0), FuOutType(0), FuOutType(0),
-                   FuOutType(1), FuOutType(1), FuOutType(1), FuOutType(1)], 0, 0, 0, 0, 0)
-      ] for i in range(num_tiles)]
 
   # vc_id needs to be 1 due to the message might traverse across the date line via ring.
   #                                       cgra_id, src,       dst, opaque, vc, ctrl_action
   complete_signal_sink_out = [CtrlPktType(      0,   0, num_tiles,      0,  1, ctrl_action = CMD_COMPLETE)]
 
-  # src_ctrl_pkt = []
-  # for opt_per_tile in src_opt_per_tile:
-  #   src_ctrl_pkt.extend(opt_per_tile)
+  '''
+  Creates test performing load -> inc -> store. Specifically,
+  tile 0 performs `load` on memory address 2, and stores the result (0xfe) in register 7.
+  tile 0 read data from register 7 and performs `inc` (0xfe -> 0xff), and sends result to tile 2.
+  tile 2 waits for the data from tile 0, and performs stores (0xff) to memory address 3.
+  '''
   src_ctrl_pkt = \
       [
+       # Preload data.
+       CtrlPktType(0, 0, 0, 0, 0, ctrl_action = CMD_STORE_REQUEST, addr = 2, data = 254, data_predicate = 1),
        # Tile 0.
 
        # Indicates the load address of 2.
@@ -239,12 +183,14 @@ def test_homo_2x2_2x2(cmdline_opts):
                     TileInType(0), TileInType(0), TileInType(0), TileInType(0)],
 
                    [FuOutType(0), FuOutType(0), FuOutType(0), FuOutType(0),
-                    FuOutType(0), FuOutType(0), FuOutType(0), FuOutType(0)],
-                   ctrl_write_reg_from = [b2(1), b2(0), b2(0), b2(0)],
+                    # Note that we still need to set FU xbar.
+                    FuOutType(1), FuOutType(0), FuOutType(0), FuOutType(0)],
+                   # 2 indicates the FU xbar port (instead of const queue or routing xbar port).
+                   ctrl_write_reg_from = [b2(2), b2(0), b2(0), b2(0)],
                    ctrl_write_reg_idx = [RegIdxType(7), RegIdxType(0), RegIdxType(0), RegIdxType(0)]
                   ),
 
-       CtrlPktType(0,      0,  0,  0,    0,  CMD_CONFIG, 0,   OPT_INC,  b1(0),
+       CtrlPktType(0,      0,  0,  0,    0,  CMD_CONFIG, 1,   OPT_INC,  b1(0),
                    [FuInType(1), FuInType(0), FuInType(0), FuInType(0)],
                    [TileInType(0), TileInType(0), TileInType(0), TileInType(0),
                     TileInType(0), TileInType(0), TileInType(0), TileInType(0)],


### PR DESCRIPTION
Creat test:
 - tile 0 performs `load` on memory address 2, and stores the result (0xfe) in register 7.
 - tile 0 read data from register 7 and performs `inc` (0xfe -> 0xff), and sends result to tile 2.
 - tile 2 waits for the data from tile 0, and performs stores (0xff) to memory address 3.

TODO:
 - increase per-cgra memory and address range.
 - extend the test to make the store happen on another cgra.
   - Triage https://github.com/tancheng/VectorCGRA/issues/103.
 - enable load from CPU for e2e verification.
 - this PR is blocked by https://github.com/tancheng/VectorCGRA/pull/108.
 - this PR can close https://github.com/tancheng/VectorCGRA/issues/91.