### PR TITLE
Model CGRA with bottom and left mem

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -81,6 +81,6 @@ jobs:
         # separate crossbars (for tiles and FUs), crossbar-based data memory (for multi-bank), and controller.
         pytest ../scale_out/test/RingMultiCgraRTL_test.py -xvs --test-verilog --dump-vtb --dump-vcd
         # Multi-cgra with mesh topology.
-        pytest ../scale_out/test/MeshMultiCgraRTL_test.py::test_verilog_homo_2x2_2x2 -xvs --test-verilog --dump-vtb --dump-vcd
+        pytest ../scale_out/test/MeshMultiCgraRTL_test.py::test_verilog_homo_2x2_4x4 -xvs --test-verilog --dump-vtb --dump-vcd
         # Const Queue
         pytest ../mem/const/test/ConstQueueDynamicRTL_test.py -xvs

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -78,8 +78,8 @@ class CgraRTL(Component):
                                         data_mem_size_global,
                                         data_mem_size_per_bank,
                                         num_banks_per_cgra,
-                                        height + width, # left and bottom connecting to data mem
-                                        height + width,
+                                        height + width - 1, # left and bottom connecting to data mem
+                                        height + width - 1,
                                         multi_cgra_rows,
                                         multi_cgra_columns,
                                         s.num_tiles,
@@ -92,7 +92,7 @@ class CgraRTL(Component):
     # An additional router for controller to receive CMD_COMPLETE signal from Ring to CPU.
     # The last argument of 1 is for the latency per hop.
     s.ctrl_ring = RingNetworkRTL(CtrlPktType, CtrlRingPos, s.num_tiles + 1, 1)
-    s.controller_id = InPort(CgraIdType)
+    s.cgra_id = InPort(CgraIdType)
 
     # Address lower and upper bound.
     s.address_lower = InPort(DataAddrType)
@@ -100,19 +100,19 @@ class CgraRTL(Component):
 
     # Connections
     # Connects the controller id.
-    s.controller.controller_id //= s.controller_id
-    s.data_mem.cgra_id //= s.controller_id
+    s.controller.cgra_id //= s.cgra_id
+    s.data_mem.cgra_id //= s.cgra_id
 
     # Connects the address lower and upper bound.
     s.data_mem.address_lower //= s.address_lower
     s.data_mem.address_upper //= s.address_upper
 
     # Connects data memory with controller.
-    s.data_mem.recv_raddr[height + width - 1] //= s.controller.send_to_tile_load_request_addr
-    s.data_mem.recv_from_noc_load_src_cgra //= s.controller.send_to_tile_load_request_src_cgra
-    s.data_mem.recv_from_noc_load_src_tile //= s.controller.send_to_tile_load_request_src_tile
-    s.data_mem.recv_waddr[height + width - 1] //= s.controller.send_to_tile_store_request_addr
-    s.data_mem.recv_wdata[height + width - 1] //= s.controller.send_to_tile_store_request_data
+    s.data_mem.recv_raddr[height + width - 1] //= s.controller.send_to_mem_load_request_addr
+    s.data_mem.recv_from_noc_load_src_cgra //= s.controller.send_to_mem_load_request_src_cgra
+    s.data_mem.recv_from_noc_load_src_tile //= s.controller.send_to_mem_load_request_src_tile
+    s.data_mem.recv_waddr[height + width - 1] //= s.controller.send_to_mem_store_request_addr
+    s.data_mem.recv_wdata[height + width - 1] //= s.controller.send_to_mem_store_request_data
     s.data_mem.recv_from_noc_rdata //= s.controller.send_to_tile_load_response_data
     s.data_mem.send_to_noc_load_request_pkt //= s.controller.recv_from_tile_load_request_pkt
     s.data_mem.send_to_noc_load_response_pkt //= s.controller.recv_from_tile_load_response_pkt
@@ -128,7 +128,7 @@ class CgraRTL(Component):
     # Assigns tile id.
     for i in range(s.num_tiles):
       s.tile[i].tile_id //= i
-      s.tile[i].cgra_id //= s.controller_id
+      s.tile[i].cgra_id //= s.cgra_id
 
     # Connects ring with each control memory.
     for i in range(s.num_tiles):

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -78,7 +78,8 @@ class CgraRTL(Component):
                                         data_mem_size_global,
                                         data_mem_size_per_bank,
                                         num_banks_per_cgra,
-                                        height, height,
+                                        height + width, # left and bottom connecting to data mem
+                                        height + width,
                                         multi_cgra_rows,
                                         multi_cgra_columns,
                                         s.num_tiles,
@@ -107,11 +108,11 @@ class CgraRTL(Component):
     s.data_mem.address_upper //= s.address_upper
 
     # Connects data memory with controller.
-    s.data_mem.recv_raddr[height] //= s.controller.send_to_tile_load_request_addr
+    s.data_mem.recv_raddr[height + width - 1] //= s.controller.send_to_tile_load_request_addr
     s.data_mem.recv_from_noc_load_src_cgra //= s.controller.send_to_tile_load_request_src_cgra
     s.data_mem.recv_from_noc_load_src_tile //= s.controller.send_to_tile_load_request_src_tile
-    s.data_mem.recv_waddr[height] //= s.controller.send_to_tile_store_request_addr
-    s.data_mem.recv_wdata[height] //= s.controller.send_to_tile_store_request_data
+    s.data_mem.recv_waddr[height + width - 1] //= s.controller.send_to_tile_store_request_addr
+    s.data_mem.recv_wdata[height + width - 1] //= s.controller.send_to_tile_store_request_data
     s.data_mem.recv_from_noc_rdata //= s.controller.send_to_tile_load_response_data
     s.data_mem.send_to_noc_load_request_pkt //= s.controller.recv_from_tile_load_request_pkt
     s.data_mem.send_to_noc_load_response_pkt //= s.controller.recv_from_tile_load_response_pkt
@@ -164,38 +165,38 @@ class CgraRTL(Component):
         if i // width == 0:
           s.tile[i].send_data[PORT_SOUTHWEST].rdy //= 0
           s.tile[i].recv_data[PORT_SOUTHWEST].val //= 0
-          s.tile[i].recv_data[PORT_SOUTHWEST].msg //= DataType( 0, 0 )
+          s.tile[i].recv_data[PORT_SOUTHWEST].msg //= DataType(0, 0)
           s.tile[i].send_data[PORT_SOUTHEAST].rdy //= 0
           s.tile[i].recv_data[PORT_SOUTHEAST].val //= 0
-          s.tile[i].recv_data[PORT_SOUTHEAST].msg //= DataType( 0, 0 )
+          s.tile[i].recv_data[PORT_SOUTHEAST].msg //= DataType(0, 0)
 
         if i // width == height - 1:
           s.tile[i].send_data[PORT_NORTHWEST].rdy //= 0
           s.tile[i].recv_data[PORT_NORTHWEST].val //= 0
-          s.tile[i].recv_data[PORT_NORTHWEST].msg //= DataType( 0, 0 )
+          s.tile[i].recv_data[PORT_NORTHWEST].msg //= DataType(0, 0)
           s.tile[i].send_data[PORT_NORTHEAST].rdy //= 0
           s.tile[i].recv_data[PORT_NORTHEAST].val //= 0
-          s.tile[i].recv_data[PORT_NORTHEAST].msg //= DataType( 0, 0 )
+          s.tile[i].recv_data[PORT_NORTHEAST].msg //= DataType(0, 0)
 
         if i % width == 0 and i // width > 0:
           s.tile[i].send_data[PORT_SOUTHWEST].rdy //= 0
           s.tile[i].recv_data[PORT_SOUTHWEST].val //= 0
-          s.tile[i].recv_data[PORT_SOUTHWEST].msg //= DataType( 0, 0 )
+          s.tile[i].recv_data[PORT_SOUTHWEST].msg //= DataType(0, 0)
 
         if i % width == 0 and i // width < height - 1:
           s.tile[i].send_data[PORT_NORTHWEST].rdy //= 0
           s.tile[i].recv_data[PORT_NORTHWEST].val //= 0
-          s.tile[i].recv_data[PORT_NORTHWEST].msg //= DataType( 0, 0 )
+          s.tile[i].recv_data[PORT_NORTHWEST].msg //= DataType(0, 0)
 
         if i % width == width - 1 and i // width > 0:
           s.tile[i].send_data[PORT_SOUTHEAST].rdy //= 0
           s.tile[i].recv_data[PORT_SOUTHEAST].val //= 0
-          s.tile[i].recv_data[PORT_SOUTHEAST].msg //= DataType( 0, 0 )
+          s.tile[i].recv_data[PORT_SOUTHEAST].msg //= DataType(0, 0)
 
         if i % width == width - 1 and i // width < height - 1:
           s.tile[i].send_data[PORT_NORTHEAST].rdy //= 0
           s.tile[i].recv_data[PORT_NORTHEAST].val //= 0
-          s.tile[i].recv_data[PORT_NORTHEAST].msg //= DataType( 0, 0 )
+          s.tile[i].recv_data[PORT_NORTHEAST].msg //= DataType(0, 0)
 
 
       if i // width == 0:
@@ -214,11 +215,11 @@ class CgraRTL(Component):
         s.tile[i].send_data[PORT_EAST] //= s.send_data_on_boundary_east[i // width]
         s.tile[i].recv_data[PORT_EAST] //= s.recv_data_on_boundary_east[i // width]
 
-      if i % width == 0:
-        s.tile[i].to_mem_raddr   //= s.data_mem.recv_raddr[i//width]
-        s.tile[i].from_mem_rdata //= s.data_mem.send_rdata[i//width]
-        s.tile[i].to_mem_waddr   //= s.data_mem.recv_waddr[i//width]
-        s.tile[i].to_mem_wdata   //= s.data_mem.recv_wdata[i//width]
+      if i % width == 0 or i // width == 0:
+        s.tile[i].to_mem_raddr   //= s.data_mem.recv_raddr[width + i // width - 1 if i >= width else i % width]
+        s.tile[i].from_mem_rdata //= s.data_mem.send_rdata[width + i // width - 1 if i >= width else i % width]
+        s.tile[i].to_mem_waddr   //= s.data_mem.recv_waddr[width + i // width - 1 if i >= width else i % width]
+        s.tile[i].to_mem_wdata   //= s.data_mem.recv_wdata[width + i // width - 1 if i >= width else i % width]
       else:
         s.tile[i].to_mem_raddr.rdy   //= 0
         s.tile[i].from_mem_rdata.val //= 0

--- a/cgra/CgraTemplateRTL.py
+++ b/cgra/CgraTemplateRTL.py
@@ -88,7 +88,7 @@ class CgraTemplateRTL(Component):
     # The last argument of 1 is for the latency per hop.
     s.ctrl_ring = RingNetworkRTL(CtrlPktType, CtrlRingPos, s.num_tiles + 1, 1)
 
-    s.controller_id = InPort(CgraIdType)
+    s.cgra_id = InPort(CgraIdType)
 
     # Address lower and upper bound.
     s.address_lower = InPort(DataAddrType)
@@ -96,19 +96,19 @@ class CgraTemplateRTL(Component):
 
     # Connections
     # Connects controller id.
-    s.controller.controller_id //= s.controller_id
-    s.data_mem.cgra_id //= s.controller_id
+    s.controller.cgra_id //= s.cgra_id
+    s.data_mem.cgra_id //= s.cgra_id
 
     # Connects the address lower and upper bound.
     s.data_mem.address_lower //= s.address_lower
     s.data_mem.address_upper //= s.address_upper
 
     # Connects data memory with controller.
-    s.data_mem.recv_raddr[dataSPM.getNumOfValidReadPorts()] //= s.controller.send_to_tile_load_request_addr
-    s.data_mem.recv_from_noc_load_src_cgra //= s.controller.send_to_tile_load_request_src_cgra
-    s.data_mem.recv_from_noc_load_src_tile //= s.controller.send_to_tile_load_request_src_tile
-    s.data_mem.recv_waddr[dataSPM.getNumOfValidWritePorts()] //= s.controller.send_to_tile_store_request_addr
-    s.data_mem.recv_wdata[dataSPM.getNumOfValidWritePorts()] //= s.controller.send_to_tile_store_request_data
+    s.data_mem.recv_raddr[dataSPM.getNumOfValidReadPorts()] //= s.controller.send_to_mem_load_request_addr
+    s.data_mem.recv_from_noc_load_src_cgra //= s.controller.send_to_mem_load_request_src_cgra
+    s.data_mem.recv_from_noc_load_src_tile //= s.controller.send_to_mem_load_request_src_tile
+    s.data_mem.recv_waddr[dataSPM.getNumOfValidWritePorts()] //= s.controller.send_to_mem_store_request_addr
+    s.data_mem.recv_wdata[dataSPM.getNumOfValidWritePorts()] //= s.controller.send_to_mem_store_request_data
     s.data_mem.recv_from_noc_rdata //= s.controller.send_to_tile_load_response_data
     s.data_mem.send_to_noc_load_request_pkt //= s.controller.recv_from_tile_load_request_pkt
     s.data_mem.send_to_noc_load_response_pkt //= s.controller.recv_from_tile_load_response_pkt
@@ -123,7 +123,7 @@ class CgraTemplateRTL(Component):
 
     # Assigns tile id.
     for i in range(s.num_tiles):
-      s.tile[i].cgra_id //= s.controller_id
+      s.tile[i].cgra_id //= s.cgra_id
       s.tile[i].tile_id //= i
 
     # Connects ring with each control memory.

--- a/cgra/test/CgraRTL_test.py
+++ b/cgra/test/CgraRTL_test.py
@@ -70,7 +70,7 @@ class TestHarness(Component):
     s.complete_signal_sink_out = TestSinkRTL(CtrlPktType, complete_signal_sink_out)
 
     # Connections
-    s.dut.controller_id //= cgra_id
+    s.dut.cgra_id //= cgra_id
     # As we always first issue request pkt from CPU to NoC, 
     # when there is no NoC for single CGRA test, 
     # we have to connect from_noc and to_noc in testbench.

--- a/cgra/test/CgraRTL_test.py
+++ b/cgra/test/CgraRTL_test.py
@@ -310,7 +310,7 @@ def test_homogeneous_2x2(cmdline_opts):
 def test_heterogeneous_king_mesh_2x2(cmdline_opts):
   topology = "KingMesh"
   th = init_param(topology)
-  th.set_param("top.dut.tile[1].construct", FuList=[ShifterRTL, AdderRTL])
+  th.set_param("top.dut.tile[1].construct", FuList=[ShifterRTL, AdderRTL, MemUnitRTL])
   th.elaborate()
   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',

--- a/cgra/test/CgraTemplateRTL_test.py
+++ b/cgra/test/CgraTemplateRTL_test.py
@@ -86,7 +86,7 @@ class TestHarness(Component):
     # recognized.
     s.bypass_queue = BypassQueueRTL(NocPktType, 1)
     # Connections
-    s.dut.controller_id //= cgra_id
+    s.dut.cgra_id //= cgra_id
     s.src_ctrl_pkt.send //= s.dut.recv_from_cpu_pkt
     # As we always first issue request pkt from CPU to NoC,
     # when there is no NoC for single CGRA test,

--- a/controller/test/ControllerRTL_test.py
+++ b/controller/test/ControllerRTL_test.py
@@ -30,14 +30,14 @@ class TestHarness(Component):
                 MsgType,
                 AddrType,
                 PktType,
-                controller_id,
+                cgra_id,
                 from_tile_load_request_pkt_msgs,
                 from_tile_load_response_pkt_msgs,
                 from_tile_store_request_pkt_msgs,
-                expected_to_tile_load_request_addr_msgs,
-                expected_to_tile_load_response_data_msgs,
-                expected_to_tile_store_request_addr_msgs,
-                expected_to_tile_store_request_data_msgs,
+                expected_to_mem_load_request_addr_msgs,
+                expected_to_mem_load_response_data_msgs,
+                expected_to_mem_store_request_addr_msgs,
+                expected_to_mem_store_request_data_msgs,
                 from_noc_pkts,
                 expected_to_noc_pkts,
                 controller2addr_map,
@@ -49,10 +49,10 @@ class TestHarness(Component):
     s.src_from_tile_load_response_pkt_en_rdy = TestSrcRTL(PktType, from_tile_load_response_pkt_msgs)
     s.src_from_tile_store_request_pkt_en_rdy = TestSrcRTL(PktType, from_tile_store_request_pkt_msgs)
 
-    s.sink_to_tile_load_request_addr_en_rdy = TestSinkRTL(AddrType, expected_to_tile_load_request_addr_msgs)
-    s.sink_to_tile_load_response_data_en_rdy = TestSinkRTL(MsgType, expected_to_tile_load_response_data_msgs)
-    s.sink_to_tile_store_request_addr_en_rdy = TestSinkRTL(AddrType, expected_to_tile_store_request_addr_msgs)
-    s.sink_to_tile_store_request_data_en_rdy = TestSinkRTL(MsgType, expected_to_tile_store_request_data_msgs)
+    s.sink_to_mem_load_request_addr_en_rdy = TestSinkRTL(AddrType, expected_to_mem_load_request_addr_msgs)
+    s.sink_to_mem_load_response_data_en_rdy = TestSinkRTL(MsgType, expected_to_mem_load_response_data_msgs)
+    s.sink_to_mem_store_request_addr_en_rdy = TestSinkRTL(AddrType, expected_to_mem_store_request_addr_msgs)
+    s.sink_to_mem_store_request_data_en_rdy = TestSinkRTL(MsgType, expected_to_mem_store_request_data_msgs)
 
     s.src_from_noc_val_rdy = TestSrcRTL(PktType, from_noc_pkts)
     s.sink_to_noc_val_rdy = TestSinkRTL(PktType, expected_to_noc_pkts)
@@ -69,17 +69,17 @@ class TestHarness(Component):
                           idTo2d_map)
 
     # Connections
-    s.dut.controller_id //= controller_id
+    s.dut.cgra_id //= cgra_id
     s.src_from_tile_load_request_pkt_en_rdy.send //= s.dut.recv_from_tile_load_request_pkt
     s.src_from_tile_load_response_pkt_en_rdy.send //= s.dut.recv_from_tile_load_response_pkt
     s.src_from_tile_store_request_pkt_en_rdy.send //= s.dut.recv_from_tile_store_request_pkt
 
-    s.dut.send_to_tile_store_request_addr //= s.sink_to_tile_store_request_addr_en_rdy.recv
-    s.dut.send_to_tile_store_request_data //= s.sink_to_tile_store_request_data_en_rdy.recv
-    s.dut.send_to_tile_load_response_data //= s.sink_to_tile_load_response_data_en_rdy.recv
-    s.dut.send_to_tile_load_request_addr //= s.sink_to_tile_load_request_addr_en_rdy.recv
-    s.dut.send_to_tile_load_request_src_cgra.rdy //= 1
-    s.dut.send_to_tile_load_request_src_tile.rdy //= 1
+    s.dut.send_to_mem_store_request_addr //= s.sink_to_mem_store_request_addr_en_rdy.recv
+    s.dut.send_to_mem_store_request_data //= s.sink_to_mem_store_request_data_en_rdy.recv
+    s.dut.send_to_mem_load_response_data //= s.sink_to_mem_load_response_data_en_rdy.recv
+    s.dut.send_to_mem_load_request_addr  //= s.sink_to_mem_load_request_addr_en_rdy.recv
+    s.dut.send_to_mem_load_request_src_cgra.rdy //= 1
+    s.dut.send_to_mem_load_request_src_tile.rdy //= 1
 
     s.src_from_noc_val_rdy.send //= s.dut.recv_from_inter_cgra_noc
     s.dut.send_to_inter_cgra_noc //= s.sink_to_noc_val_rdy.recv
@@ -95,10 +95,10 @@ class TestHarness(Component):
     return s.src_from_tile_load_request_pkt_en_rdy.done()  and \
            s.src_from_tile_load_response_pkt_en_rdy.done() and \
            s.src_from_tile_store_request_pkt_en_rdy.done() and \
-           s.sink_to_tile_load_request_addr_en_rdy.done()  and \
-           s.sink_to_tile_load_response_data_en_rdy.done() and \
-           s.sink_to_tile_store_request_addr_en_rdy.done() and \
-           s.sink_to_tile_store_request_data_en_rdy.done() and \
+           s.sink_to_mem_load_request_addr_en_rdy.done()  and \
+           s.sink_to_mem_load_response_data_en_rdy.done() and \
+           s.sink_to_mem_store_request_addr_en_rdy.done() and \
+           s.sink_to_mem_store_request_data_en_rdy.done() and \
            s.src_from_noc_val_rdy.done() and \
            s.sink_to_noc_val_rdy.done()
 
@@ -165,7 +165,7 @@ num_tile_outports = 4
 data_mem_size_global = 16
 addr_nbits = clog2(data_mem_size_global)
 num_registers_per_reg_bank = 16
-controller_id = 0
+cgra_id = 0
 
 idTo2d_map = {
         0: [0, 0],
@@ -227,11 +227,11 @@ from_tile_store_request_pkts = [
     InterCgraPktType(payload = CgraPayloadType(cmd = CMD_STORE_REQUEST, data = DataType(150, 1), data_addr = 15)),
 ]
 
-expected_to_tile_load_request_addr_msgs =  [DataAddrType(2)]
-expected_to_tile_load_response_addr_msgs = [DataAddrType(8), DataAddrType(9)]
-expected_to_tile_load_response_data_msgs = [DataType(80, 1), DataType(90, 1)]
-expected_to_tile_store_request_addr_msgs = [DataAddrType(5)]
-expected_to_tile_store_request_data_msgs = [DataType(50, 1)]
+expected_to_mem_load_request_addr_msgs =  [DataAddrType(2)]
+expected_to_mem_load_response_addr_msgs = [DataAddrType(8), DataAddrType(9)]
+expected_to_mem_load_response_data_msgs = [DataType(80, 1), DataType(90, 1)]
+expected_to_mem_store_request_addr_msgs = [DataAddrType(5)]
+expected_to_mem_store_request_data_msgs = [DataType(50, 1)]
 
 from_noc_pkts = [
                    # src  dst src_x src_y dst_x dst_y src_tile dst_tile opq vc                 cmd
@@ -264,14 +264,14 @@ def test_simple(cmdline_opts):
                    DataType,
                    DataAddrType,
                    InterCgraPktType,
-                   controller_id,
+                   cgra_id,
                    from_tile_load_request_pkts,
                    from_tile_load_response_pkts,
                    from_tile_store_request_pkts,
-                   expected_to_tile_load_request_addr_msgs,
-                   expected_to_tile_load_response_data_msgs,
-                   expected_to_tile_store_request_addr_msgs,
-                   expected_to_tile_store_request_data_msgs,
+                   expected_to_mem_load_request_addr_msgs,
+                   expected_to_mem_load_response_data_msgs,
+                   expected_to_mem_store_request_addr_msgs,
+                   expected_to_mem_store_request_data_msgs,
                    from_noc_pkts,
                    expected_to_noc_pkts,
                    controller2addr_map,

--- a/controller/test/ControllerRTL_test.py
+++ b/controller/test/ControllerRTL_test.py
@@ -76,7 +76,7 @@ class TestHarness(Component):
 
     s.dut.send_to_mem_store_request_addr //= s.sink_to_mem_store_request_addr_en_rdy.recv
     s.dut.send_to_mem_store_request_data //= s.sink_to_mem_store_request_data_en_rdy.recv
-    s.dut.send_to_mem_load_response_data //= s.sink_to_mem_load_response_data_en_rdy.recv
+    s.dut.send_to_tile_load_response_data //= s.sink_to_mem_load_response_data_en_rdy.recv
     s.dut.send_to_mem_load_request_addr  //= s.sink_to_mem_load_request_addr_en_rdy.recv
     s.dut.send_to_mem_load_request_src_cgra.rdy //= 1
     s.dut.send_to_mem_load_request_src_tile.rdy //= 1

--- a/scale_out/MeshMultiCgraRTL.py
+++ b/scale_out/MeshMultiCgraRTL.py
@@ -15,8 +15,8 @@ from ..lib.opt_type import *
 from ..noc.PyOCN.pymtl3_net.meshnet.MeshNetworkRTL import MeshNetworkRTL
 from ..noc.PyOCN.pymtl3_net.ocnlib.ifcs.positions import mk_mesh_pos
 
-
 class MeshMultiCgraRTL(Component):
+
   def construct(s, CgraDataType, PredicateType, CtrlPktType,
                 CgraPayloadType, CtrlSignalType, NocPktType,
                 cgra_rows, cgra_columns, tile_rows, tile_columns,

--- a/scale_out/MeshMultiCgraRTL.py
+++ b/scale_out/MeshMultiCgraRTL.py
@@ -69,7 +69,7 @@ class MeshMultiCgraRTL(Component):
 
     # Connects controller id.
     for cgra_id in range(s.num_cgras):
-      s.cgra[cgra_id].controller_id //= cgra_id
+      s.cgra[cgra_id].cgra_id //= cgra_id
 
     # Connects memory address upper and lower bound for each CGRA.
     for cgra_id in range(s.num_cgras):

--- a/scale_out/RingMultiCgraRTL.py
+++ b/scale_out/RingMultiCgraRTL.py
@@ -68,7 +68,7 @@ class RingMultiCgraRTL(Component):
 
     # Connects the controller id.
     for cgra_id in range(s.num_cgras):
-      s.cgra[cgra_id].controller_id //= cgra_id
+      s.cgra[cgra_id].cgra_id //= cgra_id
 
     # Connects memory address upper and lower bound for each CGRA.
     for cgra_id in range(s.num_cgras):

--- a/scale_out/test/MeshMultiCgraRTL_test.py
+++ b/scale_out/test/MeshMultiCgraRTL_test.py
@@ -286,7 +286,7 @@ def initialize_test_harness(cmdline_opts,
                    ctrl_steps, controller2addr_map, expected_sink_out_pkt)
   return th
 
-def test_sim_homo_2x2_3x3(cmdline_opts):
+def test_sim_homo_2x2_2x2(cmdline_opts):
   th = initialize_test_harness(cmdline_opts,
                                num_cgra_rows = 2,
                                num_cgra_columns = 2,
@@ -301,18 +301,18 @@ def test_sim_homo_2x2_3x3(cmdline_opts):
   th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
   run_sim(th)
 
-# def test_verilog_homo_3x3_4x4(cmdline_opts):
-#   th = initialize_test_harness(cmdline_opts,
-#                                num_cgra_rows = 2,
-#                                num_cgra_columns = 2,
-#                                num_x_tiles_per_cgra = 3,
-#                                num_y_tiles_per_cgra = 3,
-#                                num_banks_per_cgra = 4,
-#                                data_mem_size_per_bank = 1024)
-#   th.elaborate()
-#   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
-#                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
-#                        'ALWCOMBORDER'])
-#   th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
-#   th.apply(DefaultPassGroup())
+def test_verilog_homo_2x2_4x4(cmdline_opts):
+  th = initialize_test_harness(cmdline_opts,
+                               num_cgra_rows = 2,
+                               num_cgra_columns = 2,
+                               num_x_tiles_per_cgra = 4,
+                               num_y_tiles_per_cgra = 4,
+                               num_banks_per_cgra = 8,
+                               data_mem_size_per_bank = 256)
+  th.elaborate()
+  th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
+                      ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
+                       'ALWCOMBORDER'])
+  th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
+  th.apply(DefaultPassGroup())
 

--- a/scale_out/test/MeshMultiCgraRTL_test.py
+++ b/scale_out/test/MeshMultiCgraRTL_test.py
@@ -119,22 +119,22 @@ def run_sim(test_harness, max_cycles = 100):
   test_harness.sim_tick()
   test_harness.sim_tick()
 
-def initialize_test_harness(cmdline_opts):
-  num_tile_inports  = 4
+def initialize_test_harness(cmdline_opts,
+                            num_cgra_rows = 2,
+                            num_cgra_columns = 2,
+                            num_x_tiles_per_cgra = 2,
+                            num_y_tiles_per_cgra = 2,
+                            num_banks_per_cgra = 2,
+                            data_mem_size_per_bank = 16):
+  num_tile_inports = 4
   num_tile_outports = 4
   num_fu_inports = 4
   num_fu_outports = 2
   num_routing_outports = num_tile_outports + num_fu_inports
   ctrl_mem_size = 16
-  data_mem_size_global = 128
-  num_cgra_rows = 2
-  num_cgra_columns = 2
   num_cgras = num_cgra_rows * num_cgra_columns
-  num_banks_per_cgra = 2
-  data_mem_size_per_bank = data_mem_size_global // num_cgras // num_banks_per_cgra
-  x_tiles = 2
-  y_tiles = 2
-  num_tiles = x_tiles * y_tiles
+  data_mem_size_global = data_mem_size_per_bank * num_banks_per_cgra * num_cgras
+  num_tiles = num_x_tiles_per_cgra * num_y_tiles_per_cgra
   TileInType = mk_bits(clog2(num_tile_inports + 1))
   FuInType = mk_bits(clog2(num_fu_inports + 1))
   FuOutType = mk_bits(clog2(num_fu_outports + 1))
@@ -280,14 +280,20 @@ def initialize_test_harness(cmdline_opts):
 
   th = TestHarness(DUT, FunctionUnit, FuList, DataType, PredicateType, IntraCgraPktType,
                    CgraPayloadType, CtrlType, InterCgraPktType, num_cgra_rows, num_cgra_columns,
-                   x_tiles, y_tiles, ctrl_mem_size, data_mem_size_global,
+                   num_x_tiles_per_cgra, num_y_tiles_per_cgra, ctrl_mem_size, data_mem_size_global,
                    data_mem_size_per_bank, num_banks_per_cgra,
                    num_registers_per_reg_bank, src_ctrl_pkt, src_query_pkt,
                    ctrl_steps, controller2addr_map, expected_sink_out_pkt)
   return th
 
-def test_sim_homo_2x2_2x2(cmdline_opts):
-  th = initialize_test_harness(cmdline_opts)
+def test_sim_homo_2x2_3x3(cmdline_opts):
+  th = initialize_test_harness(cmdline_opts,
+                               num_cgra_rows = 2,
+                               num_cgra_columns = 2,
+                               num_x_tiles_per_cgra = 2,
+                               num_y_tiles_per_cgra = 2,
+                               num_banks_per_cgra = 2,
+                               data_mem_size_per_bank = 16)
   th.elaborate()
   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
@@ -295,12 +301,18 @@ def test_sim_homo_2x2_2x2(cmdline_opts):
   th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
   run_sim(th)
 
-def test_verilog_homo_2x2_2x2(cmdline_opts):
-  th = initialize_test_harness(cmdline_opts)
-  th.elaborate()
-  th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
-                      ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
-                       'ALWCOMBORDER'])
-  th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
-  th.apply(DefaultPassGroup())
+# def test_verilog_homo_3x3_4x4(cmdline_opts):
+#   th = initialize_test_harness(cmdline_opts,
+#                                num_cgra_rows = 2,
+#                                num_cgra_columns = 2,
+#                                num_x_tiles_per_cgra = 3,
+#                                num_y_tiles_per_cgra = 3,
+#                                num_banks_per_cgra = 4,
+#                                data_mem_size_per_bank = 1024)
+#   th.elaborate()
+#   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
+#                       ['UNSIGNED', 'UNOPTFLAT', 'WIDTH', 'WIDTHCONCAT',
+#                        'ALWCOMBORDER'])
+#   th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
+#   th.apply(DefaultPassGroup())
 

--- a/systolic/CgraSystolicArrayRTL.py
+++ b/systolic/CgraSystolicArrayRTL.py
@@ -107,7 +107,7 @@ class CgraSystolicArrayRTL(Component):
 
     # Connections
     # Connects controller id.
-    s.controller.controller_id //= cgra_id
+    s.controller.cgra_id //= cgra_id
     s.data_mem.cgra_id //= cgra_id
 
     # Connects the address lower and upper bound.
@@ -115,11 +115,11 @@ class CgraSystolicArrayRTL(Component):
     s.data_mem.address_upper //= s.address_upper
 
     # Connects data memory with controller.
-    s.data_mem.recv_raddr[4] //= s.controller.send_to_tile_load_request_addr
-    s.data_mem.recv_from_noc_load_src_cgra //= s.controller.send_to_tile_load_request_src_cgra
-    s.data_mem.recv_from_noc_load_src_tile //= s.controller.send_to_tile_load_request_src_tile
-    s.data_mem.recv_waddr[4] //= s.controller.send_to_tile_store_request_addr
-    s.data_mem.recv_wdata[4] //= s.controller.send_to_tile_store_request_data
+    s.data_mem.recv_raddr[4] //= s.controller.send_to_mem_load_request_addr
+    s.data_mem.recv_from_noc_load_src_cgra //= s.controller.send_to_mem_load_request_src_cgra
+    s.data_mem.recv_from_noc_load_src_tile //= s.controller.send_to_mem_load_request_src_tile
+    s.data_mem.recv_waddr[4] //= s.controller.send_to_mem_store_request_addr
+    s.data_mem.recv_wdata[4] //= s.controller.send_to_mem_store_request_data
     s.data_mem.recv_from_noc_rdata //= s.controller.send_to_tile_load_response_data
     s.data_mem.send_to_noc_load_request_pkt //= s.controller.recv_from_tile_load_request_pkt
     s.data_mem.send_to_noc_load_response_pkt //= s.controller.recv_from_tile_load_response_pkt


### PR DESCRIPTION
Instead of only allowing left-most tiles to connect to data memory, this PR allows first row and first column tiles (i.e., bottom and left) to connect to data mem.
 - Correspondingly, more ports need to be exposed on data mem.
 - This PR would provide the infra (modeling the required CgraRTL) for https://github.com/tancheng/VectorCGRA/pull/115