### PR TITLE
Ubuntu 20.04 retirement.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -83,4 +83,4 @@ jobs:
         # Multi-cgra with mesh topology.
         pytest ../multi_cgra/test/MeshMultiCgraRTL_test.py::test_sim_homo_2x2_2x2 -xvs --test-verilog --dump-vtb --dump-vcd
         # Const Queue
-        pytest ../mem/const/test/ConstQueueDynamicRTL_test.py -xvs
+        # pytest ../mem/const/test/ConstQueueDynamicRTL_test.py -xvs

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -83,4 +83,4 @@ jobs:
         # Multi-cgra with mesh topology.
         pytest ../multi_cgra/test/MeshMultiCgraRTL_test.py::test_sim_homo_2x2_2x2 -xvs --test-verilog --dump-vtb --dump-vcd
         # Const Queue
-        # pytest ../mem/const/test/ConstQueueDynamicRTL_test.py -xvs
+        pytest ../mem/const/test/ConstQueueDynamicRTL_test.py -xvs


### PR DESCRIPTION
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101