### PR TITLE
Translate-Only Util

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -81,6 +81,6 @@ jobs:
         # separate crossbars (for tiles and FUs), crossbar-based data memory (for multi-bank), and controller.
         pytest ../multi_cgra/test/RingMultiCgraRTL_test.py -xvs --test-verilog --dump-vtb --dump-vcd
         # Multi-cgra with mesh topology.
-        pytest ../multi_cgra/test/MeshMultiCgraRTL_test.py::test_sim_homo_2x2_2x2 -xvs --test-verilog --dump-vtb --dump-vcd
+        pytest ../multi_cgra/test/MeshMultiCgraRTL_test.py::test_verilog_homo_2x2_4x4 -xvs --test-verilog --dump-vtb --dump-vcd
         # Const Queue
         pytest ../mem/const/test/ConstQueueDynamicRTL_test.py -xvs

--- a/multi_cgra/test/MeshMultiCgraRTL_test.py
+++ b/multi_cgra/test/MeshMultiCgraRTL_test.py
@@ -8,6 +8,7 @@ Author : Cheng Tan
   Date : Jan 8, 2024
 """
 
+from re import sub
 from pymtl3.passes.backends.verilog import (
   VerilogVerilatorImportPass,
   VerilogPlaceholderPass,
@@ -319,9 +320,12 @@ def _enable_translate_recursively(m):
 def translate_model(top, submodules_to_translate):
   top.elaborate()
   top.apply(VerilogPlaceholderPass())
-  for submodule in submodules_to_translate:
-    m = getattr(top, submodule)
-    _enable_translate_recursively(m)
+  if not submodules_to_translate:
+    _enable_translate_recursively(top)
+  else:
+    for submodule in submodules_to_translate:
+      m = getattr(top, submodule)
+      _enable_translate_recursively(m)
   top.apply(VerilogTranslationPass())
 
 def test_verilog_homo_2x2_4x4(cmdline_opts):

--- a/multi_cgra/test/MeshMultiCgraRTL_test.py
+++ b/multi_cgra/test/MeshMultiCgraRTL_test.py
@@ -9,12 +9,10 @@ Author : Cheng Tan
 """
 
 from pymtl3.passes.backends.verilog import (
-  VerilogTranslationImportPass,
   VerilogVerilatorImportPass,
   VerilogPlaceholderPass,
 )
 from pymtl3.passes.backends.verilog.translation.VerilogTranslationPass import VerilogTranslationPass
-from pymtl3.passes.backends.verilog.import_.VerilogVerilatorImportPass import VerilogVerilatorImportPass
 from pymtl3.stdlib.test_utils import (run_sim,
                                       config_model_with_cmdline_opts)
 


### PR DESCRIPTION
Added a translated-only util function that only performs translation but not import. Import would invoke Verilator to compile the generated Verilog and for large design it would take forever.