### PR TITLE
Allow routing and compute to complete separately but be aware of each other

### DIFF
--- a/mem/ctrl/CtrlMemDynamicRTL.py
+++ b/mem/ctrl/CtrlMemDynamicRTL.py
@@ -205,7 +205,7 @@ class CtrlMemDynamicRTL(Component):
             s.times <<= s.times + TimeType(1)
 
           # Reads the next ctrl signal only when the current one is done.
-          if s.send_ctrl.rdy:
+          if s.send_ctrl.rdy & s.send_ctrl.val:
             if s.reg_file.raddr[0] == trunc(s.ctrl_count_per_iter_val - 1, CtrlAddrType):
               s.reg_file.raddr[0] <<= 0
             else:

--- a/tile/TileRTL.py
+++ b/tile/TileRTL.py
@@ -272,10 +272,15 @@ class TileRTL(Component):
       else:
         if s.element.recv_opt.rdy:
           s.element_done <<= 1
-        elif s.fu_crossbar.recv_opt.rdy:
+        if s.fu_crossbar.recv_opt.rdy:
           s.fu_crossbar_done <<= 1
-        elif s.routing_crossbar.recv_opt.rdy:
+        if s.routing_crossbar.recv_opt.rdy:
           s.routing_crossbar_done <<= 1
+
+    @update
+    def notify_crossbars_compute_status():
+      s.routing_crossbar.compute_done @= s.element_done
+      s.fu_crossbar.compute_done @= s.element_done
 
   # Line trace
   def line_trace(s):


### PR DESCRIPTION
Allow routing and compute to complete separately but be aware of each other.

Without the fix, the tile is not aware of `fu_xbar` and `routing_xbar`'s `already done` status.