### PR TITLE
133 p0 deprecate systolic array

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -82,3 +82,5 @@ jobs:
         pytest ../multi_cgra/test/MeshMultiCgraRTL_test.py::test_verilog_homo_2x2_4x4 -xvs --test-verilog --dump-vtb --dump-vcd
         # Const Queue
         pytest ../mem/const/test/ConstQueueDynamicRTL_test.py -xvs
+        # Data Mem
+        pytest ../mem/data/test/DataMemWithCrossbarRTL_test.py -xvs --test-verilog --dump-vtb --dump-vcd

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -39,8 +39,8 @@ class CgraRTL(Component):
 
     s.num_tiles = width * height
     # The left and bottom tiles are connected to the data memory.
-    s.data_mem_num_rd_tiles = height + width - 1
-    s.data_mem_num_wr_tiles = height + width - 1
+    data_mem_num_rd_tiles = height + width - 1
+    data_mem_num_wr_tiles = height + width - 1
 
     num_cgras = multi_cgra_rows * multi_cgra_columns
     # An additional router for controller to receive CMD_COMPLETE signal from Ring to CPU.
@@ -82,8 +82,8 @@ class CgraRTL(Component):
                                         data_mem_size_global,
                                         data_mem_size_per_bank,
                                         num_banks_per_cgra,
-                                        s.data_mem_num_rd_tiles,
-                                        s.data_mem_num_wr_tiles,
+                                        data_mem_num_rd_tiles,
+                                        data_mem_num_wr_tiles,
                                         multi_cgra_rows,
                                         multi_cgra_columns,
                                         s.num_tiles,

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -115,15 +115,15 @@ class CgraRTL(Component):
 
 
     # Replace below with one noc pkt port and decouple in DataMem itself.
-    # 1. can reduce number of recv_raddr, recv_waddr and recv_wdata to height + width - 2
-    s.data_mem.recv_raddr[s.data_mem_num_rd_tiles] //= s.controller.send_to_mem_load_request_addr
-    s.data_mem.recv_from_noc_load_src_cgra //= s.controller.send_to_mem_load_request_src_cgra
-    s.data_mem.recv_from_noc_load_src_tile //= s.controller.send_to_mem_load_request_src_tile
+    # 1. can reduce number of recv_raddr to num_rd_tiles - 1
+    # 2. can also do with store request?
+    # s.data_mem.recv_raddr[s.data_mem_num_rd_tiles] //= s.controller.send_to_mem_load_request_addr
+    # s.data_mem.recv_from_noc_load_src_cgra //= s.controller.send_to_mem_load_request_src_cgra
+    # s.data_mem.recv_from_noc_load_src_tile //= s.controller.send_to_mem_load_request_src_tile
+    s.data_mem.recv_from_noc_load_request //= s.controller.send_to_mem_load_request
+
     s.data_mem.recv_waddr[s.data_mem_num_wr_tiles] //= s.controller.send_to_mem_store_request_addr
     s.data_mem.recv_wdata[s.data_mem_num_wr_tiles] //= s.controller.send_to_mem_store_request_data
-
-
-
 
     s.data_mem.recv_from_noc_rdata //= s.controller.send_to_tile_load_response_data
     s.data_mem.send_to_noc_load_request_pkt //= s.controller.recv_from_tile_load_request_pkt

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -115,9 +115,7 @@ class CgraRTL(Component):
 
     # Connects data memory with controller.
     s.data_mem.recv_from_noc_load_request //= s.controller.send_to_mem_load_request
-
     s.data_mem.recv_from_noc_store_request //= s.controller.send_to_mem_store_request
-
     s.data_mem.recv_from_noc_load_response_pkt //= s.controller.send_to_tile_load_response
     s.data_mem.send_to_noc_load_request_pkt //= s.controller.recv_from_tile_load_request_pkt
     s.data_mem.send_to_noc_load_response_pkt //= s.controller.recv_from_tile_load_response_pkt

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -38,7 +38,7 @@ class CgraRTL(Component):
       s.num_mesh_ports = 8
 
     s.num_tiles = width * height
-    # left and bottom connecting to data mem
+    # The left and bottom tiles are connected to the data memory.
     s.data_mem_num_rd_tiles = height + width - 1
     s.data_mem_num_wr_tiles = height + width - 1
 
@@ -82,7 +82,7 @@ class CgraRTL(Component):
                                         data_mem_size_global,
                                         data_mem_size_per_bank,
                                         num_banks_per_cgra,
-                                        s.data_mem_num_rd_tiles, # left and bottom connecting to data mem
+                                        s.data_mem_num_rd_tiles,
                                         s.data_mem_num_wr_tiles,
                                         multi_cgra_rows,
                                         multi_cgra_columns,
@@ -122,8 +122,9 @@ class CgraRTL(Component):
     # s.data_mem.recv_from_noc_load_src_tile //= s.controller.send_to_mem_load_request_src_tile
     s.data_mem.recv_from_noc_load_request //= s.controller.send_to_mem_load_request
 
-    s.data_mem.recv_waddr[s.data_mem_num_wr_tiles] //= s.controller.send_to_mem_store_request_addr
-    s.data_mem.recv_wdata[s.data_mem_num_wr_tiles] //= s.controller.send_to_mem_store_request_data
+    # s.data_mem.recv_waddr[s.data_mem_num_wr_tiles] //= s.controller.send_to_mem_store_request_addr
+    # s.data_mem.recv_wdata[s.data_mem_num_wr_tiles] //= s.controller.send_to_mem_store_request_data
+    s.data_mem.recv_from_noc_store_request //= s.controller.send_to_mem_store_request
 
     s.data_mem.recv_from_noc_rdata //= s.controller.send_to_tile_load_response_data
     s.data_mem.send_to_noc_load_request_pkt //= s.controller.recv_from_tile_load_request_pkt

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -126,7 +126,7 @@ class CgraRTL(Component):
     # s.data_mem.recv_wdata[s.data_mem_num_wr_tiles] //= s.controller.send_to_mem_store_request_data
     s.data_mem.recv_from_noc_store_request //= s.controller.send_to_mem_store_request
 
-    s.data_mem.recv_from_noc_rdata //= s.controller.send_to_tile_load_response_data
+    s.data_mem.recv_from_noc_load_response_pkt //= s.controller.send_to_tile_load_response
     s.data_mem.send_to_noc_load_request_pkt //= s.controller.recv_from_tile_load_request_pkt
     s.data_mem.send_to_noc_load_response_pkt //= s.controller.recv_from_tile_load_response_pkt
     s.data_mem.send_to_noc_store_pkt //= s.controller.recv_from_tile_store_request_pkt

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -123,13 +123,13 @@ class CgraRTL(Component):
     s.data_mem.send_to_noc_load_response_pkt //= s.controller.recv_from_tile_load_response_pkt
     s.data_mem.send_to_noc_store_pkt //= s.controller.recv_from_tile_store_request_pkt
 
-    if not is_multi_cgra:
-      s.bypass_queue = BypassQueueRTL(NocPktType, 1)
-      s.send_to_inter_cgra_noc //= s.bypass_queue.recv
-      s.recv_from_inter_cgra_noc //= s.bypass_queue.send
-    else:
+    if is_multi_cgra:
       s.recv_from_inter_cgra_noc //= s.controller.recv_from_inter_cgra_noc
       s.send_to_inter_cgra_noc //= s.controller.send_to_inter_cgra_noc
+    else:
+      s.bypass_queue = BypassQueueRTL(NocPktType, 1)
+      s.bypass_queue.send //= s.controller.recv_from_inter_cgra_noc
+      s.bypass_queue.recv //= s.controller.send_to_inter_cgra_noc
 
     # Connects the ctrl interface between CPU and controller.
     s.recv_from_cpu_pkt //= s.controller.recv_from_cpu_pkt

--- a/cgra/CgraRTL.py
+++ b/cgra/CgraRTL.py
@@ -112,18 +112,8 @@ class CgraRTL(Component):
     s.data_mem.address_upper //= s.address_upper
 
     # Connects data memory with controller.
-
-
-    # Replace below with one noc pkt port and decouple in DataMem itself.
-    # 1. can reduce number of recv_raddr to num_rd_tiles - 1
-    # 2. can also do with store request?
-    # s.data_mem.recv_raddr[s.data_mem_num_rd_tiles] //= s.controller.send_to_mem_load_request_addr
-    # s.data_mem.recv_from_noc_load_src_cgra //= s.controller.send_to_mem_load_request_src_cgra
-    # s.data_mem.recv_from_noc_load_src_tile //= s.controller.send_to_mem_load_request_src_tile
     s.data_mem.recv_from_noc_load_request //= s.controller.send_to_mem_load_request
 
-    # s.data_mem.recv_waddr[s.data_mem_num_wr_tiles] //= s.controller.send_to_mem_store_request_addr
-    # s.data_mem.recv_wdata[s.data_mem_num_wr_tiles] //= s.controller.send_to_mem_store_request_data
     s.data_mem.recv_from_noc_store_request //= s.controller.send_to_mem_store_request
 
     s.data_mem.recv_from_noc_load_response_pkt //= s.controller.send_to_tile_load_response

--- a/cgra/CgraTemplateRTL.py
+++ b/cgra/CgraTemplateRTL.py
@@ -104,11 +104,15 @@ class CgraTemplateRTL(Component):
     s.data_mem.address_upper //= s.address_upper
 
     # Connects data memory with controller.
-    s.data_mem.recv_raddr[dataSPM.getNumOfValidReadPorts()] //= s.controller.send_to_mem_load_request_addr
-    s.data_mem.recv_from_noc_load_src_cgra //= s.controller.send_to_mem_load_request_src_cgra
-    s.data_mem.recv_from_noc_load_src_tile //= s.controller.send_to_mem_load_request_src_tile
-    s.data_mem.recv_waddr[dataSPM.getNumOfValidWritePorts()] //= s.controller.send_to_mem_store_request_addr
-    s.data_mem.recv_wdata[dataSPM.getNumOfValidWritePorts()] //= s.controller.send_to_mem_store_request_data
+    # s.data_mem.recv_raddr[dataSPM.getNumOfValidReadPorts()] //= s.controller.send_to_mem_load_request_addr
+    # s.data_mem.recv_from_noc_load_src_cgra //= s.controller.send_to_mem_load_request_src_cgra
+    # s.data_mem.recv_from_noc_load_src_tile //= s.controller.send_to_mem_load_request_src_tile
+    s.data_mem.recv_from_noc_load_request //= s.controller.send_to_mem_load_request
+
+    # s.data_mem.recv_waddr[dataSPM.getNumOfValidWritePorts()] //= s.controller.send_to_mem_store_request_addr
+    # s.data_mem.recv_wdata[dataSPM.getNumOfValidWritePorts()] //= s.controller.send_to_mem_store_request_data
+    s.data_mem.recv_from_noc_store_request //= s.controller.send_to_mem_store_request
+
     s.data_mem.recv_from_noc_rdata //= s.controller.send_to_tile_load_response_data
     s.data_mem.send_to_noc_load_request_pkt //= s.controller.recv_from_tile_load_request_pkt
     s.data_mem.send_to_noc_load_response_pkt //= s.controller.recv_from_tile_load_response_pkt

--- a/cgra/CgraTemplateRTL.py
+++ b/cgra/CgraTemplateRTL.py
@@ -106,9 +106,7 @@ class CgraTemplateRTL(Component):
 
     # Connects data memory with controller.
     s.data_mem.recv_from_noc_load_request //= s.controller.send_to_mem_load_request
-
     s.data_mem.recv_from_noc_store_request //= s.controller.send_to_mem_store_request
-
     s.data_mem.recv_from_noc_load_response_pkt //= s.controller.send_to_tile_load_response
     s.data_mem.send_to_noc_load_request_pkt //= s.controller.recv_from_tile_load_request_pkt
     s.data_mem.send_to_noc_load_response_pkt //= s.controller.recv_from_tile_load_response_pkt

--- a/cgra/CgraTemplateRTL.py
+++ b/cgra/CgraTemplateRTL.py
@@ -113,7 +113,7 @@ class CgraTemplateRTL(Component):
     # s.data_mem.recv_wdata[dataSPM.getNumOfValidWritePorts()] //= s.controller.send_to_mem_store_request_data
     s.data_mem.recv_from_noc_store_request //= s.controller.send_to_mem_store_request
 
-    s.data_mem.recv_from_noc_rdata //= s.controller.send_to_tile_load_response_data
+    s.data_mem.recv_from_noc_load_response_pkt //= s.controller.send_to_tile_load_response
     s.data_mem.send_to_noc_load_request_pkt //= s.controller.recv_from_tile_load_request_pkt
     s.data_mem.send_to_noc_load_response_pkt //= s.controller.recv_from_tile_load_response_pkt
     s.data_mem.send_to_noc_store_pkt //= s.controller.recv_from_tile_store_request_pkt

--- a/cgra/CgraTemplateRTL.py
+++ b/cgra/CgraTemplateRTL.py
@@ -7,7 +7,6 @@ Author : Cheng Tan
   Date : Dec 30, 2024
 """
 
-from pymtl3 import *
 from ..controller.ControllerRTL import ControllerRTL
 from ..lib.basic.val_rdy.ifcs import ValRdyRecvIfcRTL as RecvIfcRTL
 from ..lib.basic.val_rdy.ifcs import ValRdySendIfcRTL as SendIfcRTL
@@ -104,13 +103,8 @@ class CgraTemplateRTL(Component):
     s.data_mem.address_upper //= s.address_upper
 
     # Connects data memory with controller.
-    # s.data_mem.recv_raddr[dataSPM.getNumOfValidReadPorts()] //= s.controller.send_to_mem_load_request_addr
-    # s.data_mem.recv_from_noc_load_src_cgra //= s.controller.send_to_mem_load_request_src_cgra
-    # s.data_mem.recv_from_noc_load_src_tile //= s.controller.send_to_mem_load_request_src_tile
     s.data_mem.recv_from_noc_load_request //= s.controller.send_to_mem_load_request
 
-    # s.data_mem.recv_waddr[dataSPM.getNumOfValidWritePorts()] //= s.controller.send_to_mem_store_request_addr
-    # s.data_mem.recv_wdata[dataSPM.getNumOfValidWritePorts()] //= s.controller.send_to_mem_store_request_data
     s.data_mem.recv_from_noc_store_request //= s.controller.send_to_mem_store_request
 
     s.data_mem.recv_from_noc_load_response_pkt //= s.controller.send_to_tile_load_response

--- a/cgra/test/CgraRTL_test.py
+++ b/cgra/test/CgraRTL_test.py
@@ -67,12 +67,13 @@ class TestHarness(Component):
                 data_mem_size_global, data_mem_size_per_bank,
                 num_banks_per_cgra, num_registers_per_reg_bank,
                 ctrl_steps, ctrl_steps, FunctionUnit,
-                FuList, topology, controller2addr_map, idTo2d_map)
+                FuList, topology, controller2addr_map, idTo2d_map,
+                is_multi_cgra = False)
 
     # Uses a bypass queue here to enable the verilator simulation.
     # Without bypass queue, the connection will not be translated and
     # recognized.
-    s.bypass_queue = BypassQueueRTL(NocPktType, 1)
+    # s.bypass_queue = BypassQueueRTL(NocPktType, 1)
     cmp_fn = lambda a, b : a.payload.data == b.payload.data and a.payload.cmd == b.payload.cmd
     s.complete_signal_sink_out = TestSinkRTL(CtrlPktType, complete_signal_sink_out, cmp_fn = cmp_fn)
 
@@ -81,8 +82,8 @@ class TestHarness(Component):
     # As we always first issue request pkt from CPU to NoC, 
     # when there is no NoC for single CGRA test, 
     # we have to connect from_noc and to_noc in testbench.
-    s.dut.send_to_inter_cgra_noc //= s.bypass_queue.recv
-    s.bypass_queue.send //= s.dut.recv_from_inter_cgra_noc
+    # s.dut.send_to_inter_cgra_noc //= s.bypass_queue.recv
+    # s.bypass_queue.send //= s.dut.recv_from_inter_cgra_noc
 
     s.complete_signal_sink_out.recv //= s.dut.send_to_cpu_pkt
 

--- a/cgra/test/CgraRTL_test.py
+++ b/cgra/test/CgraRTL_test.py
@@ -32,7 +32,6 @@ from ...fu.vector.VectorAdderComboRTL import VectorAdderComboRTL
 from ...fu.vector.VectorMulComboRTL import VectorMulComboRTL
 from ...lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL
 from ...lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
-from ...lib.basic.val_rdy.queues import BypassQueueRTL
 from ...lib.messages import *
 from ...lib.opt_type import *
 
@@ -70,21 +69,11 @@ class TestHarness(Component):
                 FuList, topology, controller2addr_map, idTo2d_map,
                 is_multi_cgra = False)
 
-    # Uses a bypass queue here to enable the verilator simulation.
-    # Without bypass queue, the connection will not be translated and
-    # recognized.
-    # s.bypass_queue = BypassQueueRTL(NocPktType, 1)
     cmp_fn = lambda a, b : a.payload.data == b.payload.data and a.payload.cmd == b.payload.cmd
     s.complete_signal_sink_out = TestSinkRTL(CtrlPktType, complete_signal_sink_out, cmp_fn = cmp_fn)
 
     # Connections
     s.dut.cgra_id //= cgra_id
-    # As we always first issue request pkt from CPU to NoC, 
-    # when there is no NoC for single CGRA test, 
-    # we have to connect from_noc and to_noc in testbench.
-    # s.dut.send_to_inter_cgra_noc //= s.bypass_queue.recv
-    # s.bypass_queue.send //= s.dut.recv_from_inter_cgra_noc
-
     s.complete_signal_sink_out.recv //= s.dut.send_to_cpu_pkt
 
     complete_count_value = \

--- a/cgra/test/CgraTemplateRTL_test.py
+++ b/cgra/test/CgraTemplateRTL_test.py
@@ -29,8 +29,6 @@ from ...fu.single.SelRTL import SelRTL
 from ...fu.single.ShifterRTL import ShifterRTL
 from ...lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL
 from ...lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
-from ...lib.basic.val_rdy.queues import BypassQueueRTL
-from ...lib.cmd_type import *
 from ...lib.messages import *
 from ...lib.opt_type import *
 from ...lib.util.common import *
@@ -79,20 +77,11 @@ class TestHarness(Component):
                 num_registers_per_reg_bank,
                 ctrl_steps, ctrl_steps, FunctionUnit, FuList,
                 TileList, LinkList, dataSPM, controller2addr_map,
-                idTo2d_map)
+                idTo2d_map, is_multi_cgra = False)
 
-    # Uses a bypass queue here to enable the verilator simulation.
-    # Without bypass queue, the connection will not be translated and
-    # recognized.
-    s.bypass_queue = BypassQueueRTL(NocPktType, 1)
     # Connections
     s.dut.cgra_id //= cgra_id
     s.src_ctrl_pkt.send //= s.dut.recv_from_cpu_pkt
-    # As we always first issue request pkt from CPU to NoC,
-    # when there is no NoC for single CGRA test,
-    # we have to connect from_noc and to_noc in testbench.
-    s.dut.send_to_inter_cgra_noc //= s.bypass_queue.recv
-    s.bypass_queue.send //= s.dut.recv_from_inter_cgra_noc
     s.complete_signal_sink_out.recv //= s.dut.send_to_cpu_pkt
 
     # Connects memory address upper and lower bound for each CGRA.

--- a/controller/ControllerRTL.py
+++ b/controller/ControllerRTL.py
@@ -12,7 +12,6 @@ Author : Cheng Tan
 from ..lib.basic.val_rdy.ifcs import RecvIfcRTL
 from ..lib.basic.val_rdy.ifcs import SendIfcRTL
 from ..lib.basic.val_rdy.queues import NormalQueueRTL
-from ..lib.cmd_type import *
 from ..lib.messages import *
 from ..lib.opt_type import *
 from ..lib.util.common import *
@@ -59,17 +58,8 @@ class ControllerRTL(Component):
     s.recv_from_tile_load_response_pkt = RecvIfcRTL(InterCgraPktType)
     s.recv_from_tile_store_request_pkt = RecvIfcRTL(InterCgraPktType)
 
-    # Replace with NoC pkt
-    # s.send_to_mem_load_request_addr = SendIfcRTL(DataAddrType)
-    # s.send_to_mem_load_request_src_cgra = SendIfcRTL(CgraIdType)
-    # s.send_to_mem_load_request_src_tile = SendIfcRTL(TileIdType)
-
     s.send_to_mem_load_request = SendIfcRTL(InterCgraPktType)
-
     s.send_to_tile_load_response = SendIfcRTL(InterCgraPktType)
-
-    # s.send_to_mem_store_request_addr = SendIfcRTL(DataAddrType)
-    # s.send_to_mem_store_request_data = SendIfcRTL(DataType)
     s.send_to_mem_store_request = SendIfcRTL(InterCgraPktType)
 
     # Component
@@ -77,16 +67,8 @@ class ControllerRTL(Component):
     s.recv_from_tile_load_response_pkt_queue = ChannelRTL(InterCgraPktType, latency = 1)
     s.recv_from_tile_store_request_pkt_queue = ChannelRTL(InterCgraPktType, latency = 1)
 
-    # Replace
-    # s.send_to_mem_load_request_addr_queue = ChannelRTL(DataAddrType, latency = 1)
-    # s.send_to_mem_load_request_src_cgra_queue = ChannelRTL(CgraIdType, latency = 1)
-    # s.send_to_mem_load_request_src_tile_queue = ChannelRTL(TileIdType, latency = 1)
     s.send_to_mem_load_request_queue = ChannelRTL(InterCgraPktType, latency = 1)
-
     s.send_to_tile_load_response_queue = ChannelRTL(InterCgraPktType, latency = 1)
-
-    # s.send_to_mem_store_request_addr_queue = ChannelRTL(DataAddrType, latency = 1)
-    # s.send_to_mem_store_request_data_queue = ChannelRTL(DataType, latency = 1)
     s.send_to_mem_store_request_queue = ChannelRTL(InterCgraPktType, latency = 1)
 
     # Crossbar with 4 inports (load and store requests towards remote
@@ -129,14 +111,8 @@ class ControllerRTL(Component):
     s.recv_from_tile_store_request_pkt_queue.recv //= s.recv_from_tile_store_request_pkt
 
     # Requests towards local from others, 1 cycle delay to improve timing.
-    # s.send_to_mem_load_request_addr_queue.send //= s.send_to_mem_load_request_addr
-    # s.send_to_mem_load_request_src_cgra_queue.send //= s.send_to_mem_load_request_src_cgra
-    # s.send_to_mem_load_request_src_tile_queue.send //= s.send_to_mem_load_request_src_tile
     s.send_to_mem_load_request_queue.send //= s.send_to_mem_load_request
-
     s.send_to_tile_load_response_queue.send //= s.send_to_tile_load_response
-    # s.send_to_mem_store_request_addr_queue.send //= s.send_to_mem_store_request_addr
-    # s.send_to_mem_store_request_data_queue.send //= s.send_to_mem_store_request_data
     s.send_to_mem_store_request_queue.send //= s.send_to_mem_store_request
 
     # For control signals delivery from CPU to tiles.
@@ -219,27 +195,14 @@ class ControllerRTL(Component):
     # def update_received_msg_from_noc():
 
       # Initiates the signals.
-      # s.send_to_mem_load_request_addr_queue.recv.val @= 0
-      # s.send_to_mem_load_request_src_cgra_queue.recv.val @= 0
-      # s.send_to_mem_load_request_src_tile_queue.recv.val @= 0
       s.send_to_mem_load_request_queue.recv.val @= 0
-
-      # s.send_to_mem_store_request_addr_queue.recv.val @= 0
-      # s.send_to_mem_store_request_data_queue.recv.val @= 0
       s.send_to_mem_store_request_queue.recv.val @= 0
-
       s.send_to_tile_load_response_queue.recv.val @= 0
 
-      # s.send_to_mem_load_request_addr_queue.recv.msg @= DataAddrType()
-      # s.send_to_mem_load_request_src_cgra_queue.recv.msg @= CgraIdType()
-      # s.send_to_mem_load_request_src_tile_queue.recv.msg @= TileIdType()
       s.send_to_mem_load_request_queue.recv.msg @= InterCgraPktType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-
-      # s.send_to_mem_store_request_addr_queue.recv.msg @= DataAddrType()
-      # s.send_to_mem_store_request_data_queue.recv.msg @= DataType()
       s.send_to_mem_store_request_queue.recv.msg @= InterCgraPktType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-
       s.send_to_tile_load_response_queue.recv.msg @= InterCgraPktType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+
       s.recv_from_inter_cgra_noc.rdy @= 0
       s.send_to_ctrl_ring_pkt.val @= 0
       s.send_to_ctrl_ring_pkt.msg @= IntraCgraPktType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
@@ -248,26 +211,13 @@ class ControllerRTL(Component):
       received_pkt = s.recv_from_inter_cgra_noc.msg
       if s.recv_from_inter_cgra_noc.val:
         if s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_LOAD_REQUEST:
-          # s.send_to_mem_load_request_addr_queue.recv.val @= 1
-          # s.send_to_mem_load_request_src_cgra_queue.recv.val @= 1
-          # s.send_to_mem_load_request_src_tile_queue.recv.val @= 1
           s.send_to_mem_load_request_queue.recv.val @= 1
 
           if s.send_to_mem_load_request_queue.recv.rdy:
             s.recv_from_inter_cgra_noc.rdy @= 1
-
-            # s.send_to_mem_load_request_addr_queue.recv.msg @= DataAddrType(received_pkt.payload.data_addr)
-            # s.send_to_mem_load_request_src_cgra_queue.recv.msg @= received_pkt.src
-            # # FIXME: We can avoid this by sending the entire payload to data memory,
-            # # https://github.com/tancheng/VectorCGRA/issues/117.
-            # s.send_to_mem_load_request_src_tile_queue.recv.msg @= received_pkt.src_tile_id
             s.send_to_mem_load_request_queue.recv.msg @= received_pkt
 
         elif s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_STORE_REQUEST:
-          # s.send_to_mem_store_request_data_queue.recv.msg @= received_pkt.payload.data
-          # s.send_to_mem_store_request_addr_queue.recv.msg @= received_pkt.payload.data_addr
-          # s.send_to_mem_store_request_addr_queue.recv.val @= 1
-          # s.send_to_mem_store_request_data_queue.recv.val @= 1
           s.send_to_mem_store_request_queue.recv.msg @= received_pkt
           s.send_to_mem_store_request_queue.recv.val @= 1
 
@@ -366,7 +316,6 @@ class ControllerRTL(Component):
     crossbar_str = "crossbar: {" + s.crossbar.line_trace() + "}"
     send_to_mem_load_request_str = "send_to_mem_load_request: " + str(s.send_to_mem_load_request.msg)
     send_to_mem_store_request_str = "send_to_mem_store_request: " + str(s.send_to_mem_store_request.msg)
-    # send_to_mem_store_request_data_str = "send_to_mem_store_request_data: " + str(s.send_to_mem_store_request_data.msg)
     recv_from_noc_str ="recv_from_noc_pkt.val: " + str(s.recv_from_inter_cgra_noc.val) + " recv_from_noc_pkt.msg: " + str(s.recv_from_inter_cgra_noc.msg) + " recv_from_noc_pkt.rdy: " + str(s.recv_from_inter_cgra_noc.rdy)
     send_to_noc_str = "send_to_noc_pkt: " + str(s.send_to_inter_cgra_noc.msg) + "; rdy: " + str(s.send_to_inter_cgra_noc.rdy) + "; val: " + str(s.send_to_inter_cgra_noc.val)
     return f'{recv_from_cpu_pkt_str} || {recv_from_cpu_pkt_queue_str} || {crossbar_recv_str} ||  {send_to_ctrl_ring_pkt_str} || {recv_from_tile_load_request_pkt_str} || {recv_from_tile_load_response_pkt_str} || {recv_from_tile_store_request_pkt_str} || {crossbar_str} || {send_to_mem_load_request_str} || {send_to_mem_store_request_str} || {recv_from_noc_str} || {send_to_noc_str}\n'

--- a/controller/ControllerRTL.py
+++ b/controller/ControllerRTL.py
@@ -233,13 +233,13 @@ class ControllerRTL(Component):
       # s.send_to_mem_load_request_addr_queue.recv.msg @= DataAddrType()
       # s.send_to_mem_load_request_src_cgra_queue.recv.msg @= CgraIdType()
       # s.send_to_mem_load_request_src_tile_queue.recv.msg @= TileIdType()
-      s.send_to_mem_load_request_queue.recv.msg @= InterCgraPktType()
+      s.send_to_mem_load_request_queue.recv.msg @= InterCgraPktType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 
       # s.send_to_mem_store_request_addr_queue.recv.msg @= DataAddrType()
       # s.send_to_mem_store_request_data_queue.recv.msg @= DataType()
-      s.send_to_mem_store_request_queue.recv.msg @= InterCgraPktType()
+      s.send_to_mem_store_request_queue.recv.msg @= InterCgraPktType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 
-      s.send_to_tile_load_response_data_queue.recv.msg @= DataType()
+      s.send_to_tile_load_response_data_queue.recv.msg @= DataType(0, 0, 0, 0)
       s.recv_from_inter_cgra_noc.rdy @= 0
       s.send_to_ctrl_ring_pkt.val @= 0
       s.send_to_ctrl_ring_pkt.msg @= IntraCgraPktType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)

--- a/controller/ControllerRTL.py
+++ b/controller/ControllerRTL.py
@@ -66,7 +66,7 @@ class ControllerRTL(Component):
 
     s.send_to_mem_load_request = SendIfcRTL(InterCgraPktType)
 
-    s.send_to_tile_load_response_data = SendIfcRTL(DataType)
+    s.send_to_tile_load_response = SendIfcRTL(InterCgraPktType)
 
     # s.send_to_mem_store_request_addr = SendIfcRTL(DataAddrType)
     # s.send_to_mem_store_request_data = SendIfcRTL(DataType)
@@ -83,7 +83,7 @@ class ControllerRTL(Component):
     # s.send_to_mem_load_request_src_tile_queue = ChannelRTL(TileIdType, latency = 1)
     s.send_to_mem_load_request_queue = ChannelRTL(InterCgraPktType, latency = 1)
 
-    s.send_to_tile_load_response_data_queue = ChannelRTL(DataType, latency = 1)
+    s.send_to_tile_load_response_queue = ChannelRTL(InterCgraPktType, latency = 1)
 
     # s.send_to_mem_store_request_addr_queue = ChannelRTL(DataAddrType, latency = 1)
     # s.send_to_mem_store_request_data_queue = ChannelRTL(DataType, latency = 1)
@@ -134,7 +134,7 @@ class ControllerRTL(Component):
     # s.send_to_mem_load_request_src_tile_queue.send //= s.send_to_mem_load_request_src_tile
     s.send_to_mem_load_request_queue.send //= s.send_to_mem_load_request
 
-    s.send_to_tile_load_response_data_queue.send //= s.send_to_tile_load_response_data
+    s.send_to_tile_load_response_queue.send //= s.send_to_tile_load_response
     # s.send_to_mem_store_request_addr_queue.send //= s.send_to_mem_store_request_addr
     # s.send_to_mem_store_request_data_queue.send //= s.send_to_mem_store_request_data
     s.send_to_mem_store_request_queue.send //= s.send_to_mem_store_request
@@ -228,7 +228,7 @@ class ControllerRTL(Component):
       # s.send_to_mem_store_request_data_queue.recv.val @= 0
       s.send_to_mem_store_request_queue.recv.val @= 0
 
-      s.send_to_tile_load_response_data_queue.recv.val @= 0
+      s.send_to_tile_load_response_queue.recv.val @= 0
 
       # s.send_to_mem_load_request_addr_queue.recv.msg @= DataAddrType()
       # s.send_to_mem_load_request_src_cgra_queue.recv.msg @= CgraIdType()
@@ -239,7 +239,7 @@ class ControllerRTL(Component):
       # s.send_to_mem_store_request_data_queue.recv.msg @= DataType()
       s.send_to_mem_store_request_queue.recv.msg @= InterCgraPktType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 
-      s.send_to_tile_load_response_data_queue.recv.msg @= DataType(0, 0, 0, 0)
+      s.send_to_tile_load_response_queue.recv.msg @= InterCgraPktType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
       s.recv_from_inter_cgra_noc.rdy @= 0
       s.send_to_ctrl_ring_pkt.val @= 0
       s.send_to_ctrl_ring_pkt.msg @= IntraCgraPktType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
@@ -296,9 +296,9 @@ class ControllerRTL(Component):
                                  s.recv_from_inter_cgra_noc.msg.payload)
 
           else:
-            s.recv_from_inter_cgra_noc.rdy @= s.send_to_tile_load_response_data_queue.recv.rdy
-            s.send_to_tile_load_response_data_queue.recv.msg @= received_pkt.payload.data
-            s.send_to_tile_load_response_data_queue.recv.val @= 1
+            s.recv_from_inter_cgra_noc.rdy @= s.send_to_tile_load_response_queue.recv.rdy
+            s.send_to_tile_load_response_queue.recv.msg @= received_pkt
+            s.send_to_tile_load_response_queue.recv.val @= 1
 
         elif s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_COMPLETE:
           s.recv_from_inter_cgra_noc.rdy @= s.send_to_cpu_pkt_queue.recv.rdy

--- a/controller/ControllerRTL.py
+++ b/controller/ControllerRTL.py
@@ -60,16 +60,17 @@ class ControllerRTL(Component):
     s.recv_from_tile_store_request_pkt = RecvIfcRTL(InterCgraPktType)
 
     # Replace with NoC pkt
-    s.send_to_mem_load_request_addr = SendIfcRTL(DataAddrType)
-    s.send_to_mem_load_request_src_cgra = SendIfcRTL(CgraIdType)
-    s.send_to_mem_load_request_src_tile = SendIfcRTL(TileIdType)
+    # s.send_to_mem_load_request_addr = SendIfcRTL(DataAddrType)
+    # s.send_to_mem_load_request_src_cgra = SendIfcRTL(CgraIdType)
+    # s.send_to_mem_load_request_src_tile = SendIfcRTL(TileIdType)
 
     s.send_to_mem_load_request = SendIfcRTL(InterCgraPktType)
 
-
     s.send_to_tile_load_response_data = SendIfcRTL(DataType)
-    s.send_to_mem_store_request_addr = SendIfcRTL(DataAddrType)
-    s.send_to_mem_store_request_data = SendIfcRTL(DataType)
+
+    # s.send_to_mem_store_request_addr = SendIfcRTL(DataAddrType)
+    # s.send_to_mem_store_request_data = SendIfcRTL(DataType)
+    s.send_to_mem_store_request = SendIfcRTL(InterCgraPktType)
 
     # Component
     s.recv_from_tile_load_request_pkt_queue = ChannelRTL(InterCgraPktType, latency = 1)
@@ -83,8 +84,10 @@ class ControllerRTL(Component):
     s.send_to_mem_load_request_queue = ChannelRTL(InterCgraPktType, latency = 1)
 
     s.send_to_tile_load_response_data_queue = ChannelRTL(DataType, latency = 1)
-    s.send_to_mem_store_request_addr_queue = ChannelRTL(DataAddrType, latency = 1)
-    s.send_to_mem_store_request_data_queue = ChannelRTL(DataType, latency = 1)
+
+    # s.send_to_mem_store_request_addr_queue = ChannelRTL(DataAddrType, latency = 1)
+    # s.send_to_mem_store_request_data_queue = ChannelRTL(DataType, latency = 1)
+    s.send_to_mem_store_request_queue = ChannelRTL(InterCgraPktType, latency = 1)
 
     # Crossbar with 4 inports (load and store requests towards remote
     # memory, load response from local memory, ctrl&data packet from cpu,
@@ -132,8 +135,9 @@ class ControllerRTL(Component):
     s.send_to_mem_load_request_queue.send //= s.send_to_mem_load_request
 
     s.send_to_tile_load_response_data_queue.send //= s.send_to_tile_load_response_data
-    s.send_to_mem_store_request_addr_queue.send //= s.send_to_mem_store_request_addr
-    s.send_to_mem_store_request_data_queue.send //= s.send_to_mem_store_request_data
+    # s.send_to_mem_store_request_addr_queue.send //= s.send_to_mem_store_request_addr
+    # s.send_to_mem_store_request_data_queue.send //= s.send_to_mem_store_request_data
+    s.send_to_mem_store_request_queue.send //= s.send_to_mem_store_request
 
     # For control signals delivery from CPU to tiles.
     s.recv_from_cpu_pkt //= s.recv_from_cpu_pkt_queue.recv
@@ -220,8 +224,10 @@ class ControllerRTL(Component):
       # s.send_to_mem_load_request_src_tile_queue.recv.val @= 0
       s.send_to_mem_load_request_queue.recv.val @= 0
 
-      s.send_to_mem_store_request_addr_queue.recv.val @= 0
-      s.send_to_mem_store_request_data_queue.recv.val @= 0
+      # s.send_to_mem_store_request_addr_queue.recv.val @= 0
+      # s.send_to_mem_store_request_data_queue.recv.val @= 0
+      s.send_to_mem_store_request_queue.recv.val @= 0
+
       s.send_to_tile_load_response_data_queue.recv.val @= 0
 
       # s.send_to_mem_load_request_addr_queue.recv.msg @= DataAddrType()
@@ -229,8 +235,10 @@ class ControllerRTL(Component):
       # s.send_to_mem_load_request_src_tile_queue.recv.msg @= TileIdType()
       s.send_to_mem_load_request_queue.recv.msg @= InterCgraPktType()
 
-      s.send_to_mem_store_request_addr_queue.recv.msg @= DataAddrType()
-      s.send_to_mem_store_request_data_queue.recv.msg @= DataType()
+      # s.send_to_mem_store_request_addr_queue.recv.msg @= DataAddrType()
+      # s.send_to_mem_store_request_data_queue.recv.msg @= DataType()
+      s.send_to_mem_store_request_queue.recv.msg @= InterCgraPktType()
+
       s.send_to_tile_load_response_data_queue.recv.msg @= DataType()
       s.recv_from_inter_cgra_noc.rdy @= 0
       s.send_to_ctrl_ring_pkt.val @= 0
@@ -256,13 +264,14 @@ class ControllerRTL(Component):
             s.send_to_mem_load_request_queue.recv.msg @= received_pkt
 
         elif s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_STORE_REQUEST:
-          s.send_to_mem_store_request_data_queue.recv.msg @= received_pkt.payload.data
-          s.send_to_mem_store_request_addr_queue.recv.msg @= received_pkt.payload.data_addr
-          s.send_to_mem_store_request_addr_queue.recv.val @= 1
-          s.send_to_mem_store_request_data_queue.recv.val @= 1
+          # s.send_to_mem_store_request_data_queue.recv.msg @= received_pkt.payload.data
+          # s.send_to_mem_store_request_addr_queue.recv.msg @= received_pkt.payload.data_addr
+          # s.send_to_mem_store_request_addr_queue.recv.val @= 1
+          # s.send_to_mem_store_request_data_queue.recv.val @= 1
+          s.send_to_mem_store_request_queue.recv.msg @= received_pkt
+          s.send_to_mem_store_request_queue.recv.val @= 1
 
-          if s.send_to_mem_store_request_addr_queue.recv.rdy & \
-             s.send_to_mem_store_request_data_queue.recv.rdy:
+          if s.send_to_mem_store_request_queue.recv.rdy:
             s.recv_from_inter_cgra_noc.rdy @= 1
 
         elif s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_LOAD_RESPONSE:
@@ -355,9 +364,9 @@ class ControllerRTL(Component):
     recv_from_tile_load_response_pkt_str = "recv_from_tile_load_response_pkt: " + str(s.recv_from_tile_load_response_pkt.msg)
     recv_from_tile_store_request_pkt_str = "recv_from_tile_store_request_pkt: " + str(s.recv_from_tile_store_request_pkt.msg)
     crossbar_str = "crossbar: {" + s.crossbar.line_trace() + "}"
-    send_to_mem_load_request_addr_str = "send_to_mem_load_request_addr: " + str(s.send_to_mem_load_request_addr.msg)
-    send_to_mem_store_request_addr_str = "send_to_mem_store_request_addr: " + str(s.send_to_mem_store_request_addr.msg)
-    send_to_mem_store_request_data_str = "send_to_mem_store_request_data: " + str(s.send_to_mem_store_request_data.msg)
+    send_to_mem_load_request_str = "send_to_mem_load_request: " + str(s.send_to_mem_load_request.msg)
+    send_to_mem_store_request_str = "send_to_mem_store_request: " + str(s.send_to_mem_store_request.msg)
+    # send_to_mem_store_request_data_str = "send_to_mem_store_request_data: " + str(s.send_to_mem_store_request_data.msg)
     recv_from_noc_str ="recv_from_noc_pkt.val: " + str(s.recv_from_inter_cgra_noc.val) + " recv_from_noc_pkt.msg: " + str(s.recv_from_inter_cgra_noc.msg) + " recv_from_noc_pkt.rdy: " + str(s.recv_from_inter_cgra_noc.rdy)
     send_to_noc_str = "send_to_noc_pkt: " + str(s.send_to_inter_cgra_noc.msg) + "; rdy: " + str(s.send_to_inter_cgra_noc.rdy) + "; val: " + str(s.send_to_inter_cgra_noc.val)
-    return f'{recv_from_cpu_pkt_str} || {recv_from_cpu_pkt_queue_str} || {crossbar_recv_str} ||  {send_to_ctrl_ring_pkt_str} || {recv_from_tile_load_request_pkt_str} || {recv_from_tile_load_response_pkt_str} || {recv_from_tile_store_request_pkt_str} || {crossbar_str} || {send_to_mem_load_request_addr_str} || {send_to_mem_store_request_addr_str} || {send_to_mem_store_request_data_str} || {recv_from_noc_str} || {send_to_noc_str}\n'
+    return f'{recv_from_cpu_pkt_str} || {recv_from_cpu_pkt_queue_str} || {crossbar_recv_str} ||  {send_to_ctrl_ring_pkt_str} || {recv_from_tile_load_request_pkt_str} || {recv_from_tile_load_response_pkt_str} || {recv_from_tile_store_request_pkt_str} || {crossbar_str} || {send_to_mem_load_request_str} || {send_to_mem_store_request_str} || {recv_from_noc_str} || {send_to_noc_str}\n'

--- a/controller/test/ControllerRTL_test.py
+++ b/controller/test/ControllerRTL_test.py
@@ -36,8 +36,7 @@ class TestHarness(Component):
                 from_tile_store_request_pkt_msgs,
                 expected_to_mem_load_request_msgs,
                 expected_to_mem_load_response_data_msgs,
-                expected_to_mem_store_request_addr_msgs,
-                expected_to_mem_store_request_data_msgs,
+                expected_to_mem_store_request_msgs,
                 from_noc_pkts,
                 expected_to_noc_pkts,
                 controller2addr_map,
@@ -54,8 +53,9 @@ class TestHarness(Component):
     s.sink_to_mem_load_request_en_rdy = TestSinkRTL(PktType, expected_to_mem_load_request_msgs, cmp_fn = cmp_fn)
 
     s.sink_to_mem_load_response_data_en_rdy = TestSinkRTL(MsgType, expected_to_mem_load_response_data_msgs)
-    s.sink_to_mem_store_request_addr_en_rdy = TestSinkRTL(AddrType, expected_to_mem_store_request_addr_msgs)
-    s.sink_to_mem_store_request_data_en_rdy = TestSinkRTL(MsgType, expected_to_mem_store_request_data_msgs)
+    # s.sink_to_mem_store_request_addr_en_rdy = TestSinkRTL(AddrType, expected_to_mem_store_request_addr_msgs)
+    # s.sink_to_mem_store_request_data_en_rdy = TestSinkRTL(MsgType, expected_to_mem_store_request_data_msgs)
+    s.sink_to_mem_store_request_en_rdy = TestSinkRTL(PktType, expected_to_mem_store_request_msgs, cmp_fn = cmp_fn)
 
     s.src_from_noc_val_rdy = TestSrcRTL(PktType, from_noc_pkts)
     s.sink_to_noc_val_rdy = TestSinkRTL(PktType, expected_to_noc_pkts)
@@ -77,8 +77,10 @@ class TestHarness(Component):
     s.src_from_tile_load_response_pkt_en_rdy.send //= s.dut.recv_from_tile_load_response_pkt
     s.src_from_tile_store_request_pkt_en_rdy.send //= s.dut.recv_from_tile_store_request_pkt
 
-    s.dut.send_to_mem_store_request_addr //= s.sink_to_mem_store_request_addr_en_rdy.recv
-    s.dut.send_to_mem_store_request_data //= s.sink_to_mem_store_request_data_en_rdy.recv
+    # s.dut.send_to_mem_store_request_addr //= s.sink_to_mem_store_request_addr_en_rdy.recv
+    # s.dut.send_to_mem_store_request_data //= s.sink_to_mem_store_request_data_en_rdy.recv
+    s.dut.send_to_mem_store_request //= s.sink_to_mem_store_request_en_rdy.recv
+
     s.dut.send_to_tile_load_response_data //= s.sink_to_mem_load_response_data_en_rdy.recv
 
     # s.dut.send_to_mem_load_request_addr  //= s.sink_to_mem_load_request_addr_en_rdy.recv
@@ -102,8 +104,7 @@ class TestHarness(Component):
            s.src_from_tile_store_request_pkt_en_rdy.done() and \
            s.sink_to_mem_load_request_en_rdy.done()  and \
            s.sink_to_mem_load_response_data_en_rdy.done() and \
-           s.sink_to_mem_store_request_addr_en_rdy.done() and \
-           s.sink_to_mem_store_request_data_en_rdy.done() and \
+           s.sink_to_mem_store_request_en_rdy.done() and \
            s.src_from_noc_val_rdy.done() and \
            s.sink_to_noc_val_rdy.done()
 
@@ -236,8 +237,9 @@ expected_to_mem_load_request_msgs =  [InterCgraPktType(payload = CgraPayloadType
 
 expected_to_mem_load_response_addr_msgs = [DataAddrType(8), DataAddrType(9)]
 expected_to_mem_load_response_data_msgs = [DataType(80, 1), DataType(90, 1)]
-expected_to_mem_store_request_addr_msgs = [DataAddrType(5)]
-expected_to_mem_store_request_data_msgs = [DataType(50, 1)]
+# expected_to_mem_store_request_addr_msgs = [DataAddrType(5)]
+# expected_to_mem_store_request_data_msgs = [DataType(50, 1)]
+expected_to_mem_store_request_msgs =  [InterCgraPktType(payload = CgraPayloadType(cmd = CMD_STORE_REQUEST,  data = DataType(50,  1), data_addr = 5))]
 
 from_noc_pkts = [
                    # src  dst src_x src_y dst_x dst_y src_tile dst_tile opq vc                 cmd
@@ -276,8 +278,7 @@ def test_simple(cmdline_opts):
                    from_tile_store_request_pkts,
                    expected_to_mem_load_request_msgs,
                    expected_to_mem_load_response_data_msgs,
-                   expected_to_mem_store_request_addr_msgs,
-                   expected_to_mem_store_request_data_msgs,
+                   expected_to_mem_store_request_msgs,
                    from_noc_pkts,
                    expected_to_noc_pkts,
                    controller2addr_map,

--- a/controller/test/ControllerRTL_test.py
+++ b/controller/test/ControllerRTL_test.py
@@ -47,13 +47,9 @@ class TestHarness(Component):
     s.src_from_tile_load_response_pkt = TestSrcRTL(PktType, from_tile_load_response_pkt_msgs)
     s.src_from_tile_store_request_pkt = TestSrcRTL(PktType, from_tile_store_request_pkt_msgs)
 
-    # s.sink_to_mem_load_request_addr = TestSinkRTL(AddrType, expected_to_mem_load_request_addr_msgs)
     cmp_fn = lambda a, b : a.payload.data == b.payload.data and a.payload.cmd == b.payload.cmd
     s.sink_to_mem_load_request = TestSinkRTL(PktType, expected_to_mem_load_request_msgs, cmp_fn = cmp_fn)
-
     s.sink_to_mem_load_response = TestSinkRTL(PktType, expected_to_mem_load_response, cmp_fn = cmp_fn)
-    # s.sink_to_mem_store_request_addr = TestSinkRTL(AddrType, expected_to_mem_store_request_addr_msgs)
-    # s.sink_to_mem_store_request_data = TestSinkRTL(MsgType, expected_to_mem_store_request_data_msgs)
     s.sink_to_mem_store_request = TestSinkRTL(PktType, expected_to_mem_store_request_msgs, cmp_fn = cmp_fn)
 
     s.src_from_noc = TestSrcRTL(PktType, from_noc_pkts)
@@ -76,15 +72,8 @@ class TestHarness(Component):
     s.src_from_tile_load_response_pkt.send //= s.dut.recv_from_tile_load_response_pkt
     s.src_from_tile_store_request_pkt.send //= s.dut.recv_from_tile_store_request_pkt
 
-    # s.dut.send_to_mem_store_request_addr //= s.sink_to_mem_store_request_addr.recv
-    # s.dut.send_to_mem_store_request_data //= s.sink_to_mem_store_request_data.recv
     s.dut.send_to_mem_store_request //= s.sink_to_mem_store_request.recv
-
     s.dut.send_to_tile_load_response //= s.sink_to_mem_load_response.recv
-
-    # s.dut.send_to_mem_load_request_addr  //= s.sink_to_mem_load_request_addr.recv
-    # s.dut.send_to_mem_load_request_src_cgra.rdy //= 1
-    # s.dut.send_to_mem_load_request_src_tile.rdy //= 1
     s.dut.send_to_mem_load_request //= s.sink_to_mem_load_request.recv
 
     s.src_from_noc.send //= s.dut.recv_from_inter_cgra_noc
@@ -231,7 +220,6 @@ from_tile_store_request_pkts = [
     InterCgraPktType(payload = CgraPayloadType(cmd = CMD_STORE_REQUEST, data = DataType(150, 1), data_addr = 15)),
 ]
 
-# expected_to_mem_load_request_addr_msgs =  [DataAddrType(2)]
 expected_to_mem_load_request_msgs =  [InterCgraPktType(payload = CgraPayloadType(cmd = CMD_LOAD_REQUEST,  data = DataType(0,  1), data_addr = 2))]
 
 expected_to_mem_load_response_addr_msgs = [DataAddrType(8), DataAddrType(9)]
@@ -239,8 +227,6 @@ expected_to_mem_load_response = [
     InterCgraPktType(0,   0,  0,    0,    0,    0,    0,       0,       0,  0, CgraPayloadType(CMD_LOAD_RESPONSE, DataType(80, 1), data_addr = 8)),
     InterCgraPktType(0,   0,  0,    0,    0,    0,    0,       0,       0,  0, CgraPayloadType(CMD_LOAD_RESPONSE, DataType(90, 1), data_addr = 9))
 ]
-# expected_to_mem_store_request_addr_msgs = [DataAddrType(5)]
-# expected_to_mem_store_request_data_msgs = [DataType(50, 1)]
 expected_to_mem_store_request_msgs =  [InterCgraPktType(payload = CgraPayloadType(cmd = CMD_STORE_REQUEST,  data = DataType(50,  1), data_addr = 5))]
 
 from_noc_pkts = [

--- a/controller/test/ControllerRTL_test.py
+++ b/controller/test/ControllerRTL_test.py
@@ -13,10 +13,9 @@ from pymtl3.stdlib.test_utils import config_model_with_cmdline_opts
 from ..ControllerRTL import ControllerRTL
 from ...lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL
 from ...lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
-from ...lib.cmd_type import *
 from ...lib.messages import *
 from ...lib.opt_type import *
-from ...noc.PyOCN.pymtl3_net.ocnlib.test.stream_sinks import NetSinkRTL as TestNetSinkRTL
+
 
 #-------------------------------------------------------------------------
 # TestHarness
@@ -44,21 +43,21 @@ class TestHarness(Component):
                 num_cgras,
                 num_tiles):
 
-    s.src_from_tile_load_request_pkt_en_rdy = TestSrcRTL(PktType, from_tile_load_request_pkt_msgs)
-    s.src_from_tile_load_response_pkt_en_rdy = TestSrcRTL(PktType, from_tile_load_response_pkt_msgs)
-    s.src_from_tile_store_request_pkt_en_rdy = TestSrcRTL(PktType, from_tile_store_request_pkt_msgs)
+    s.src_from_tile_load_request_pkt = TestSrcRTL(PktType, from_tile_load_request_pkt_msgs)
+    s.src_from_tile_load_response_pkt = TestSrcRTL(PktType, from_tile_load_response_pkt_msgs)
+    s.src_from_tile_store_request_pkt = TestSrcRTL(PktType, from_tile_store_request_pkt_msgs)
 
-    # s.sink_to_mem_load_request_addr_en_rdy = TestSinkRTL(AddrType, expected_to_mem_load_request_addr_msgs)
+    # s.sink_to_mem_load_request_addr = TestSinkRTL(AddrType, expected_to_mem_load_request_addr_msgs)
     cmp_fn = lambda a, b : a.payload.data == b.payload.data and a.payload.cmd == b.payload.cmd
-    s.sink_to_mem_load_request_en_rdy = TestSinkRTL(PktType, expected_to_mem_load_request_msgs, cmp_fn = cmp_fn)
+    s.sink_to_mem_load_request = TestSinkRTL(PktType, expected_to_mem_load_request_msgs, cmp_fn = cmp_fn)
 
-    s.sink_to_mem_load_response_data_en_rdy = TestSinkRTL(MsgType, expected_to_mem_load_response_data_msgs)
-    # s.sink_to_mem_store_request_addr_en_rdy = TestSinkRTL(AddrType, expected_to_mem_store_request_addr_msgs)
-    # s.sink_to_mem_store_request_data_en_rdy = TestSinkRTL(MsgType, expected_to_mem_store_request_data_msgs)
-    s.sink_to_mem_store_request_en_rdy = TestSinkRTL(PktType, expected_to_mem_store_request_msgs, cmp_fn = cmp_fn)
+    s.sink_to_mem_load_response_data = TestSinkRTL(MsgType, expected_to_mem_load_response_data_msgs)
+    # s.sink_to_mem_store_request_addr = TestSinkRTL(AddrType, expected_to_mem_store_request_addr_msgs)
+    # s.sink_to_mem_store_request_data = TestSinkRTL(MsgType, expected_to_mem_store_request_data_msgs)
+    s.sink_to_mem_store_request = TestSinkRTL(PktType, expected_to_mem_store_request_msgs, cmp_fn = cmp_fn)
 
-    s.src_from_noc_val_rdy = TestSrcRTL(PktType, from_noc_pkts)
-    s.sink_to_noc_val_rdy = TestSinkRTL(PktType, expected_to_noc_pkts)
+    s.src_from_noc = TestSrcRTL(PktType, from_noc_pkts)
+    s.sink_to_noc = TestSinkRTL(PktType, expected_to_noc_pkts)
 
     s.dut = ControllerRTL(ControllerIdType,
                           CpuPktType,
@@ -73,23 +72,23 @@ class TestHarness(Component):
 
     # Connections
     s.dut.cgra_id //= cgra_id
-    s.src_from_tile_load_request_pkt_en_rdy.send //= s.dut.recv_from_tile_load_request_pkt
-    s.src_from_tile_load_response_pkt_en_rdy.send //= s.dut.recv_from_tile_load_response_pkt
-    s.src_from_tile_store_request_pkt_en_rdy.send //= s.dut.recv_from_tile_store_request_pkt
+    s.src_from_tile_load_request_pkt.send //= s.dut.recv_from_tile_load_request_pkt
+    s.src_from_tile_load_response_pkt.send //= s.dut.recv_from_tile_load_response_pkt
+    s.src_from_tile_store_request_pkt.send //= s.dut.recv_from_tile_store_request_pkt
 
-    # s.dut.send_to_mem_store_request_addr //= s.sink_to_mem_store_request_addr_en_rdy.recv
-    # s.dut.send_to_mem_store_request_data //= s.sink_to_mem_store_request_data_en_rdy.recv
-    s.dut.send_to_mem_store_request //= s.sink_to_mem_store_request_en_rdy.recv
+    # s.dut.send_to_mem_store_request_addr //= s.sink_to_mem_store_request_addr.recv
+    # s.dut.send_to_mem_store_request_data //= s.sink_to_mem_store_request_data.recv
+    s.dut.send_to_mem_store_request //= s.sink_to_mem_store_request.recv
 
-    s.dut.send_to_tile_load_response_data //= s.sink_to_mem_load_response_data_en_rdy.recv
+    s.dut.send_to_tile_load_response_data //= s.sink_to_mem_load_response_data.recv
 
-    # s.dut.send_to_mem_load_request_addr  //= s.sink_to_mem_load_request_addr_en_rdy.recv
+    # s.dut.send_to_mem_load_request_addr  //= s.sink_to_mem_load_request_addr.recv
     # s.dut.send_to_mem_load_request_src_cgra.rdy //= 1
     # s.dut.send_to_mem_load_request_src_tile.rdy //= 1
-    s.dut.send_to_mem_load_request //= s.sink_to_mem_load_request_en_rdy.recv
+    s.dut.send_to_mem_load_request //= s.sink_to_mem_load_request.recv
 
-    s.src_from_noc_val_rdy.send //= s.dut.recv_from_inter_cgra_noc
-    s.dut.send_to_inter_cgra_noc //= s.sink_to_noc_val_rdy.recv
+    s.src_from_noc.send //= s.dut.recv_from_inter_cgra_noc
+    s.dut.send_to_inter_cgra_noc //= s.sink_to_noc.recv
 
     s.dut.recv_from_cpu_pkt.val //= 0
     s.dut.recv_from_cpu_pkt.msg //= CpuPktType()
@@ -99,14 +98,14 @@ class TestHarness(Component):
     s.dut.recv_from_ctrl_ring_pkt.msg //= CpuPktType()
 
   def done(s):
-    return s.src_from_tile_load_request_pkt_en_rdy.done()  and \
-           s.src_from_tile_load_response_pkt_en_rdy.done() and \
-           s.src_from_tile_store_request_pkt_en_rdy.done() and \
-           s.sink_to_mem_load_request_en_rdy.done()  and \
-           s.sink_to_mem_load_response_data_en_rdy.done() and \
-           s.sink_to_mem_store_request_en_rdy.done() and \
-           s.src_from_noc_val_rdy.done() and \
-           s.sink_to_noc_val_rdy.done()
+    return s.src_from_tile_load_request_pkt.done()  and \
+           s.src_from_tile_load_response_pkt.done() and \
+           s.src_from_tile_store_request_pkt.done() and \
+           s.sink_to_mem_load_request.done()  and \
+           s.sink_to_mem_load_response_data.done() and \
+           s.sink_to_mem_store_request.done() and \
+           s.src_from_noc.done() and \
+           s.sink_to_noc.done()
 
   def line_trace(s):
     return s.dut.line_trace()

--- a/controller/test/ControllerRTL_test.py
+++ b/controller/test/ControllerRTL_test.py
@@ -34,7 +34,7 @@ class TestHarness(Component):
                 from_tile_load_response_pkt_msgs,
                 from_tile_store_request_pkt_msgs,
                 expected_to_mem_load_request_msgs,
-                expected_to_mem_load_response_data_msgs,
+                expected_to_mem_load_response,
                 expected_to_mem_store_request_msgs,
                 from_noc_pkts,
                 expected_to_noc_pkts,
@@ -51,7 +51,7 @@ class TestHarness(Component):
     cmp_fn = lambda a, b : a.payload.data == b.payload.data and a.payload.cmd == b.payload.cmd
     s.sink_to_mem_load_request = TestSinkRTL(PktType, expected_to_mem_load_request_msgs, cmp_fn = cmp_fn)
 
-    s.sink_to_mem_load_response_data = TestSinkRTL(MsgType, expected_to_mem_load_response_data_msgs)
+    s.sink_to_mem_load_response = TestSinkRTL(PktType, expected_to_mem_load_response, cmp_fn = cmp_fn)
     # s.sink_to_mem_store_request_addr = TestSinkRTL(AddrType, expected_to_mem_store_request_addr_msgs)
     # s.sink_to_mem_store_request_data = TestSinkRTL(MsgType, expected_to_mem_store_request_data_msgs)
     s.sink_to_mem_store_request = TestSinkRTL(PktType, expected_to_mem_store_request_msgs, cmp_fn = cmp_fn)
@@ -80,7 +80,7 @@ class TestHarness(Component):
     # s.dut.send_to_mem_store_request_data //= s.sink_to_mem_store_request_data.recv
     s.dut.send_to_mem_store_request //= s.sink_to_mem_store_request.recv
 
-    s.dut.send_to_tile_load_response_data //= s.sink_to_mem_load_response_data.recv
+    s.dut.send_to_tile_load_response //= s.sink_to_mem_load_response.recv
 
     # s.dut.send_to_mem_load_request_addr  //= s.sink_to_mem_load_request_addr.recv
     # s.dut.send_to_mem_load_request_src_cgra.rdy //= 1
@@ -102,7 +102,7 @@ class TestHarness(Component):
            s.src_from_tile_load_response_pkt.done() and \
            s.src_from_tile_store_request_pkt.done() and \
            s.sink_to_mem_load_request.done()  and \
-           s.sink_to_mem_load_response_data.done() and \
+           s.sink_to_mem_load_response.done() and \
            s.sink_to_mem_store_request.done() and \
            s.src_from_noc.done() and \
            s.sink_to_noc.done()
@@ -235,7 +235,10 @@ from_tile_store_request_pkts = [
 expected_to_mem_load_request_msgs =  [InterCgraPktType(payload = CgraPayloadType(cmd = CMD_LOAD_REQUEST,  data = DataType(0,  1), data_addr = 2))]
 
 expected_to_mem_load_response_addr_msgs = [DataAddrType(8), DataAddrType(9)]
-expected_to_mem_load_response_data_msgs = [DataType(80, 1), DataType(90, 1)]
+expected_to_mem_load_response = [
+    InterCgraPktType(0,   0,  0,    0,    0,    0,    0,       0,       0,  0, CgraPayloadType(CMD_LOAD_RESPONSE, DataType(80, 1), data_addr = 8)),
+    InterCgraPktType(0,   0,  0,    0,    0,    0,    0,       0,       0,  0, CgraPayloadType(CMD_LOAD_RESPONSE, DataType(90, 1), data_addr = 9))
+]
 # expected_to_mem_store_request_addr_msgs = [DataAddrType(5)]
 # expected_to_mem_store_request_data_msgs = [DataType(50, 1)]
 expected_to_mem_store_request_msgs =  [InterCgraPktType(payload = CgraPayloadType(cmd = CMD_STORE_REQUEST,  data = DataType(50,  1), data_addr = 5))]
@@ -276,7 +279,7 @@ def test_simple(cmdline_opts):
                    from_tile_load_response_pkts,
                    from_tile_store_request_pkts,
                    expected_to_mem_load_request_msgs,
-                   expected_to_mem_load_response_data_msgs,
+                   expected_to_mem_load_response,
                    expected_to_mem_store_request_msgs,
                    from_noc_pkts,
                    expected_to_noc_pkts,

--- a/mem/data/DataMemWithCrossbarRTL.py
+++ b/mem/data/DataMemWithCrossbarRTL.py
@@ -184,21 +184,39 @@ class DataMemWithCrossbarRTL(Component):
         s.wr_pkt[i] @= TileSramXbarWrPktType(i, 0, 0, 0, 0)
 
       if s.init_mem_done != b1(0):
-        for i in range(num_xbar_in_rd_ports):
-          if i == num_xbar_in_rd_ports - 1:
-            recv_raddr = s.recv_from_noc_load_request.msg.payload.data_addr
-            cgra_id = s.recv_from_noc_load_request.msg.src
-            tile_id = TileIdType(s.recv_from_noc_load_request.msg.src_tile_id)
-          else:
-            recv_raddr = s.recv_raddr[i].msg
-
+        for i in range(num_rd_tiles):
+          recv_raddr = s.recv_raddr[i].msg
           # Calculates the target bank index.
           if (recv_raddr >= s.address_lower) & (recv_raddr <= s.address_upper):
-            bank_index = trunc((recv_raddr - s.address_lower) >> per_bank_addr_nbits,
-                               XbarOutRdType)
+            bank_index = trunc((recv_raddr - s.address_lower) >> per_bank_addr_nbits, XbarOutRdType)
           else:
             bank_index = XbarOutRdType(num_banks_per_cgra)
           s.rd_pkt[i] @= TileSramXbarRdPktType(i, bank_index, recv_raddr, cgra_id, tile_id)
+
+        recv_raddr = s.recv_from_noc_load_request.msg.payload.data_addr
+        # Calculates the target bank index.
+        if (recv_raddr >= s.address_lower) & (recv_raddr <= s.address_upper):
+          bank_index = trunc((recv_raddr - s.address_lower) >> per_bank_addr_nbits, XbarOutRdType)
+        else:
+          bank_index = XbarOutRdType(num_banks_per_cgra)
+        cgra_id = s.recv_from_noc_load_request.msg.src
+        tile_id = TileIdType(s.recv_from_noc_load_request.msg.src_tile_id)
+        s.rd_pkt[num_rd_tiles] @= TileSramXbarRdPktType(num_rd_tiles, bank_index, recv_raddr, cgra_id, tile_id)
+
+          # if i == num_xbar_in_rd_ports - 1:
+          #   recv_raddr = s.recv_from_noc_load_request.msg.payload.data_addr
+          #   cgra_id = s.recv_from_noc_load_request.msg.src
+          #   tile_id = TileIdType(s.recv_from_noc_load_request.msg.src_tile_id)
+          # else:
+          #   recv_raddr = s.recv_raddr[i].msg
+          #
+          # # Calculates the target bank index.
+          # if (recv_raddr >= s.address_lower) & (recv_raddr <= s.address_upper):
+          #   bank_index = trunc((recv_raddr - s.address_lower) >> per_bank_addr_nbits,
+          #                      XbarOutRdType)
+          # else:
+          #   bank_index = XbarOutRdType(num_banks_per_cgra)
+          # s.rd_pkt[i] @= TileSramXbarRdPktType(i, bank_index, recv_raddr, cgra_id, tile_id)
         # for i in range(num_rd_tiles):
         #   s.rd_pkt[i].src_cgra @= s.cgra_id
         #   # FIXME: change to exact tile id.
@@ -206,18 +224,33 @@ class DataMemWithCrossbarRTL(Component):
         # s.rd_pkt[num_rd_tiles].src_cgra @= s.recv_from_noc_load_src_cgra.msg
         # s.rd_pkt[num_rd_tiles].src_tile @= s.recv_from_noc_load_src_tile.msg
 
-        for i in range(num_xbar_in_wr_ports):
-          if i == num_xbar_in_wr_ports - 1:
-            recv_waddr = s.recv_from_noc_store_request.msg.payload.data_addr
-          else:
-            recv_waddr = s.recv_waddr[i].msg
+        for i in range(num_wr_tiles):
+          recv_waddr = s.recv_waddr[i].msg
           # Calculates the target bank index.
           if (recv_waddr >= s.address_lower) & (recv_waddr <= s.address_upper):
-            bank_index = trunc((recv_waddr - s.address_lower) >> per_bank_addr_nbits,
-                               XbarOutWrType)
+            bank_index = trunc((recv_waddr - s.address_lower) >> per_bank_addr_nbits, XbarOutWrType)
           else:
             bank_index = XbarOutWrType(num_banks_per_cgra)
           s.wr_pkt[i] @= TileSramXbarWrPktType(i, bank_index, recv_waddr, 0, 0)
+
+        recv_waddr = s.recv_from_noc_store_request.msg.payload.data_addr
+        if (recv_waddr >= s.address_lower) & (recv_waddr <= s.address_upper):
+          bank_index = trunc((recv_waddr - s.address_lower) >> per_bank_addr_nbits, XbarOutWrType)
+        else:
+          bank_index = XbarOutWrType(num_banks_per_cgra)
+        s.wr_pkt[num_wr_tiles] @= TileSramXbarWrPktType(num_wr_tiles, bank_index, recv_waddr, 0, 0)
+
+          # if i == num_xbar_in_wr_ports - 1:
+          #   recv_waddr = s.recv_from_noc_store_request.msg.payload.data_addr
+          # else:
+          #   recv_waddr = s.recv_waddr[i].msg
+          # # Calculates the target bank index.
+          # if (recv_waddr >= s.address_lower) & (recv_waddr <= s.address_upper):
+          #   bank_index = trunc((recv_waddr - s.address_lower) >> per_bank_addr_nbits,
+          #                      XbarOutWrType)
+          # else:
+          #   bank_index = XbarOutWrType(num_banks_per_cgra)
+          # s.wr_pkt[i] @= TileSramXbarWrPktType(i, bank_index, recv_waddr, 0, 0)
 
 
     # Connects xbar with the sram.

--- a/mem/data/DataMemWithCrossbarRTL.py
+++ b/mem/data/DataMemWithCrossbarRTL.py
@@ -364,9 +364,9 @@ class DataMemWithCrossbarRTL(Component):
             s.read_crossbar.recv[i].val @= s.recv_raddr[i].val
             s.read_crossbar.recv[i].msg @= s.rd_pkt[i]
             s.recv_raddr[i].rdy @= s.read_crossbar.recv[i].rdy
-        s.read_crossbar.recv[s.num_rd_tiles].val @= s.recv_from_noc_load_request.val
-        s.read_crossbar.recv[s.num_rd_tiles].msg @= s.rd_pkt[s.num_rd_tiles]
-        s.recv_from_noc_load_request.rdy @= s.read_crossbar.recv[s.num_rd_tiles].rdy
+        s.read_crossbar.recv[-1].val @= s.recv_from_noc_load_request.val
+        s.read_crossbar.recv[-1].msg @= s.rd_pkt[s.num_rd_tiles]
+        s.recv_from_noc_load_request.rdy @= s.read_crossbar.recv[-1].rdy
 
         # for i in range(num_xbar_in_rd_ports):
         #   s.read_crossbar.recv[i].val @= s.recv_raddr[i].val
@@ -379,9 +379,9 @@ class DataMemWithCrossbarRTL(Component):
           s.write_crossbar.recv[i].val @= s.recv_waddr[i].val
           s.write_crossbar.recv[i].msg @= s.wr_pkt[i]
           s.recv_waddr[i].rdy @= s.write_crossbar.recv[i].rdy
-        s.write_crossbar.recv[s.num_wr_tiles].val @= s.recv_from_noc_store_request.val
-        s.write_crossbar.recv[s.num_wr_tiles].msg @= s.wr_pkt[s.num_wr_tiles]
-        s.recv_from_noc_store_request.rdy @= s.write_crossbar.recv[s.num_wr_tiles].rdy
+        s.write_crossbar.recv[-1].val @= s.recv_from_noc_store_request.val
+        s.write_crossbar.recv[-1].msg @= s.wr_pkt[s.num_wr_tiles]
+        s.recv_from_noc_store_request.rdy @= s.write_crossbar.recv[-1].rdy
 
         # Connects the read ports towards SRAM and NoC from the xbar.
         for b in range(num_banks_per_cgra):

--- a/mem/data/DataMemWithCrossbarRTL.py
+++ b/mem/data/DataMemWithCrossbarRTL.py
@@ -346,6 +346,7 @@ class DataMemWithCrossbarRTL(Component):
           s.write_crossbar.recv[i].val @= s.recv_waddr[i].val
           s.write_crossbar.recv[i].msg @= s.wr_pkt[i]
           s.recv_waddr[i].rdy @= s.write_crossbar.recv[i].rdy
+        # [-1] indicates the element of [num_xbar_in_wr_ports - 1] or [s.num_wr_tiles] index.
         s.write_crossbar.recv[-1].val @= s.recv_from_noc_store_request.val
         s.write_crossbar.recv[-1].msg @= s.wr_pkt[-1]
         s.recv_from_noc_store_request.rdy @= s.write_crossbar.recv[-1].rdy

--- a/mem/data/DataMemWithCrossbarRTL.py
+++ b/mem/data/DataMemWithCrossbarRTL.py
@@ -183,7 +183,11 @@ class DataMemWithCrossbarRTL(Component):
           else:
             bank_index_load_local = XbarOutRdType(num_banks_per_cgra)
           # FIXME: change to exact tile id.
-          s.rd_pkt[i] @= TileSramXbarRdPktType(i, bank_index_load_local, recv_raddr, s.cgra_id, 0)
+          s.rd_pkt[i] @= TileSramXbarRdPktType(i,                       # src
+                                               bank_index_load_local,   # dst
+                                               recv_raddr,              # addr
+                                               s.cgra_id,               # src_cgra
+                                               0)                       # src_tile
 
         recv_raddr_from_noc = s.recv_from_noc_load_request.msg.payload.data_addr
         # Calculates the target bank index.
@@ -191,7 +195,11 @@ class DataMemWithCrossbarRTL(Component):
           bank_index_load_from_noc = trunc((recv_raddr_from_noc - s.address_lower) >> per_bank_addr_nbits, XbarOutRdType)
         else:
           bank_index_load_from_noc = XbarOutRdType(num_banks_per_cgra)
-        s.rd_pkt[num_rd_tiles] @= TileSramXbarRdPktType(num_rd_tiles, bank_index_load_from_noc, recv_raddr_from_noc, s.recv_from_noc_load_request.msg.src, s.recv_from_noc_load_request.msg.src_tile_id)
+        s.rd_pkt[num_rd_tiles] @= TileSramXbarRdPktType(num_rd_tiles,                                   # src
+                                                        bank_index_load_from_noc,                       # dst
+                                                        recv_raddr_from_noc,                            # addr
+                                                        s.recv_from_noc_load_request.msg.src,           # src_cgra
+                                                        s.recv_from_noc_load_request.msg.src_tile_id)   # src_tile
 
         for i in range(num_wr_tiles):
           recv_waddr = s.recv_waddr[i].msg
@@ -200,14 +208,22 @@ class DataMemWithCrossbarRTL(Component):
             bank_index_store_local = trunc((recv_waddr - s.address_lower) >> per_bank_addr_nbits, XbarOutWrType)
           else:
             bank_index_store_local = XbarOutWrType(num_banks_per_cgra)
-          s.wr_pkt[i] @= TileSramXbarWrPktType(i, bank_index_store_local, recv_waddr, 0, 0)
+          s.wr_pkt[i] @= TileSramXbarWrPktType(i,                       # src
+                                               bank_index_store_local,  # dst
+                                               recv_waddr,              # addr
+                                               0,                       # src_cgra
+                                               0)                       # src_tile
 
         recv_waddr_from_noc = s.recv_from_noc_store_request.msg.payload.data_addr
         if (recv_waddr_from_noc >= s.address_lower) & (recv_waddr_from_noc <= s.address_upper):
           bank_index_store_from_noc = trunc((recv_waddr_from_noc - s.address_lower) >> per_bank_addr_nbits, XbarOutWrType)
         else:
           bank_index_store_from_noc = XbarOutWrType(num_banks_per_cgra)
-        s.wr_pkt[num_wr_tiles] @= TileSramXbarWrPktType(num_wr_tiles, bank_index_store_from_noc, recv_waddr_from_noc, 0, 0)
+        s.wr_pkt[num_wr_tiles] @= TileSramXbarWrPktType(num_wr_tiles,               # src
+                                                        bank_index_store_from_noc,  # dst
+                                                        recv_waddr_from_noc,        # addr
+                                                        0,                          # src_cgra
+                                                        0)                          # src_tile
 
 
     # Connects xbar with the sram.

--- a/mem/data/DataMemWithCrossbarRTL.py
+++ b/mem/data/DataMemWithCrossbarRTL.py
@@ -330,6 +330,7 @@ class DataMemWithCrossbarRTL(Component):
             s.read_crossbar.recv[i].val @= s.recv_raddr[i].val
             s.read_crossbar.recv[i].msg @= s.rd_pkt[i]
             s.recv_raddr[i].rdy @= s.read_crossbar.recv[i].rdy
+        # [-1] indicates the element of [num_xbar_in_rd_ports - 1] or [s.num_rd_tiles] index.
         s.read_crossbar.recv[-1].val @= s.recv_from_noc_load_request.val
         s.read_crossbar.recv[-1].msg @= s.rd_pkt[-1]
         s.recv_from_noc_load_request.rdy @= s.read_crossbar.recv[-1].rdy

--- a/mem/data/DataMemWithCrossbarRTL.py
+++ b/mem/data/DataMemWithCrossbarRTL.py
@@ -193,15 +193,15 @@ class DataMemWithCrossbarRTL(Component):
             bank_index = XbarOutRdType(num_banks_per_cgra)
           s.rd_pkt[i] @= TileSramXbarRdPktType(i, bank_index, recv_raddr, cgra_id, tile_id)
 
-        recv_raddr = s.recv_from_noc_load_request.msg.payload.data_addr
+        recv_raddr_from_noc = s.recv_from_noc_load_request.msg.payload.data_addr
         # Calculates the target bank index.
-        if (recv_raddr >= s.address_lower) & (recv_raddr <= s.address_upper):
-          bank_index = trunc((recv_raddr - s.address_lower) >> per_bank_addr_nbits, XbarOutRdType)
+        if (recv_raddr_from_noc >= s.address_lower) & (recv_raddr_from_noc <= s.address_upper):
+          bank_index = trunc((recv_raddr_from_noc - s.address_lower) >> per_bank_addr_nbits, XbarOutRdType)
         else:
           bank_index = XbarOutRdType(num_banks_per_cgra)
-        cgra_id = s.recv_from_noc_load_request.msg.src
-        tile_id = TileIdType(s.recv_from_noc_load_request.msg.src_tile_id)
-        s.rd_pkt[num_rd_tiles] @= TileSramXbarRdPktType(num_rd_tiles, bank_index, recv_raddr, cgra_id, tile_id)
+        src_cgra_id = s.recv_from_noc_load_request.msg.src
+        src_tile_id = TileIdType(s.recv_from_noc_load_request.msg.src_tile_id)
+        s.rd_pkt[num_rd_tiles] @= TileSramXbarRdPktType(num_rd_tiles, bank_index, recv_raddr_from_noc, src_cgra_id, src_tile_id)
 
           # if i == num_xbar_in_rd_ports - 1:
           #   recv_raddr = s.recv_from_noc_load_request.msg.payload.data_addr
@@ -233,12 +233,12 @@ class DataMemWithCrossbarRTL(Component):
             bank_index = XbarOutWrType(num_banks_per_cgra)
           s.wr_pkt[i] @= TileSramXbarWrPktType(i, bank_index, recv_waddr, 0, 0)
 
-        recv_waddr = s.recv_from_noc_store_request.msg.payload.data_addr
-        if (recv_waddr >= s.address_lower) & (recv_waddr <= s.address_upper):
-          bank_index = trunc((recv_waddr - s.address_lower) >> per_bank_addr_nbits, XbarOutWrType)
+        recv_waddr_from_noc = s.recv_from_noc_store_request.msg.payload.data_addr
+        if (recv_waddr_from_noc >= s.address_lower) & (recv_waddr_from_noc <= s.address_upper):
+          bank_index = trunc((recv_waddr_from_noc - s.address_lower) >> per_bank_addr_nbits, XbarOutWrType)
         else:
           bank_index = XbarOutWrType(num_banks_per_cgra)
-        s.wr_pkt[num_wr_tiles] @= TileSramXbarWrPktType(num_wr_tiles, bank_index, recv_waddr, 0, 0)
+        s.wr_pkt[num_wr_tiles] @= TileSramXbarWrPktType(num_wr_tiles, bank_index, recv_waddr_from_noc, 0, 0)
 
           # if i == num_xbar_in_wr_ports - 1:
           #   recv_waddr = s.recv_from_noc_store_request.msg.payload.data_addr

--- a/mem/data/test/DataMemWithCrossbarRTL_test.py
+++ b/mem/data/test/DataMemWithCrossbarRTL_test.py
@@ -8,16 +8,15 @@ Author : Cheng Tan
   Date : Dec 6, 2024
 """
 
-from pymtl3 import *
-from pymtl3.passes.backends.verilog import (VerilogTranslationPass,
-                                            VerilogVerilatorImportPass)
+from pymtl3.passes.backends.verilog import (VerilogTranslationPass)
 from pymtl3.stdlib.test_utils import config_model_with_cmdline_opts
+
 from ..DataMemWithCrossbarRTL import DataMemWithCrossbarRTL
-from ....lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
 from ....lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL
-from ....lib.cmd_type import *
+from ....lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
 from ....lib.messages import *
 from ....lib.opt_type import *
+
 
 #-------------------------------------------------------------------------
 # Test harness
@@ -208,7 +207,6 @@ def test_const_queue(cmdline_opts):
                ]
 
   # Input data.
-  # noc_send_read_addr = [DataAddrType(42)]
   send_to_noc_load_request_pkt = [
                      # src  dst src_x src_y dst_x dst_y src_tile dst_tile opq vc
       InterCgraPktType(0,   0,  0,    0,    0,    0,    0,       0,       0,  0, CgraPayloadType(CMD_LOAD_REQUEST, data_addr = 42)),

--- a/mem/data/test/DataMemWithCrossbarRTL_test.py
+++ b/mem/data/test/DataMemWithCrossbarRTL_test.py
@@ -30,7 +30,7 @@ class TestHarness(Component):
                 rd_tiles, wr_tiles, num_cgra_rows, num_cgra_columns,
                 num_tiles,
                 read_addr, read_data, write_addr,
-                write_data, noc_recv_load_data,
+                write_data, noc_recv_load,
                 send_to_noc_load_request_pkt, send_to_noc_store_pkt,
                 preload_data_per_bank):
 
@@ -47,7 +47,7 @@ class TestHarness(Component):
     s.recv_wdata = [TestSrcRTL(DataType, write_data[i])
                     for i in range(wr_tiles)]
 
-    s.recv_from_noc_rdata = TestSrcRTL(DataType, noc_recv_load_data)
+    s.recv_from_noc = TestSrcRTL(NocPktType, noc_recv_load)
 
     s.send_to_noc_load_request_pkt = TestSinkRTL(NocPktType, send_to_noc_load_request_pkt)
     s.send_to_noc_store_pkt = TestSinkRTL(NocPktType, send_to_noc_store_pkt)
@@ -73,7 +73,7 @@ class TestHarness(Component):
       s.data_mem.recv_waddr[i] //= s.recv_waddr[i].send
       s.data_mem.recv_wdata[i] //= s.recv_wdata[i].send
 
-    s.data_mem.recv_from_noc_rdata //= s.recv_from_noc_rdata.send
+    s.data_mem.recv_from_noc_load_response_pkt //= s.recv_from_noc.send
     s.data_mem.send_to_noc_load_request_pkt //= s.send_to_noc_load_request_pkt.recv
     s.data_mem.send_to_noc_store_pkt //= s.send_to_noc_store_pkt.recv
 
@@ -93,7 +93,7 @@ class TestHarness(Component):
 
     if not s.send_to_noc_load_request_pkt.done() or \
        not s.send_to_noc_store_pkt.done() or \
-       not s.recv_from_noc_rdata.done():
+       not s.recv_from_noc.done():
       return False
 
     return True
@@ -213,7 +213,8 @@ def test_const_queue(cmdline_opts):
                      # src  dst src_x src_y dst_x dst_y src_tile dst_tile opq vc
       InterCgraPktType(0,   0,  0,    0,    0,    0,    0,       0,       0,  0, CgraPayloadType(CMD_LOAD_REQUEST, data_addr = 42)),
   ]
-  noc_recv_load_data = [DataType(0xbbbb, 1)]
+
+  noc_recv_load = [InterCgraPktType(0,   0,  0,    0,    0,    0,    0,       0,       0,  0, CgraPayloadType(CMD_LOAD_RESPONSE, DataType(0xbbbb, 1)))]
 
   # Expected.
   send_to_noc_store_pkt = [
@@ -238,7 +239,7 @@ def test_const_queue(cmdline_opts):
                    read_data,
                    write_addr,
                    write_data,
-                   noc_recv_load_data,
+                   noc_recv_load,
                    send_to_noc_load_request_pkt,
                    send_to_noc_store_pkt,
                    preload_data_per_bank)


### PR DESCRIPTION
Replace `addr/src_cgra/src_tile `of `load_request` with one NoC pkt to reduce the interfaces.

Will clean comments once all good. 
@tancheng , are we going to do same replacement for `store_request`?