### PR TITLE
[feat] Add multi-cycle FUs

### DIFF
--- a/cgra/test/CgraRTL_test.py
+++ b/cgra/test/CgraRTL_test.py
@@ -32,7 +32,6 @@ from ...fu.vector.VectorAdderComboRTL import VectorAdderComboRTL
 from ...fu.vector.VectorMulComboRTL import VectorMulComboRTL
 from ...lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL
 from ...lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
-from ...lib.basic.val_rdy.queues import BypassQueueRTL
 from ...lib.messages import *
 from ...lib.opt_type import *
 
@@ -67,23 +66,14 @@ class TestHarness(Component):
                 data_mem_size_global, data_mem_size_per_bank,
                 num_banks_per_cgra, num_registers_per_reg_bank,
                 ctrl_steps, ctrl_steps, FunctionUnit,
-                FuList, topology, controller2addr_map, idTo2d_map)
+                FuList, topology, controller2addr_map, idTo2d_map,
+                is_multi_cgra = False)
 
-    # Uses a bypass queue here to enable the verilator simulation.
-    # Without bypass queue, the connection will not be translated and
-    # recognized.
-    s.bypass_queue = BypassQueueRTL(NocPktType, 1)
     cmp_fn = lambda a, b : a.payload.data == b.payload.data and a.payload.cmd == b.payload.cmd
     s.complete_signal_sink_out = TestSinkRTL(CtrlPktType, complete_signal_sink_out, cmp_fn = cmp_fn)
 
     # Connections
     s.dut.cgra_id //= cgra_id
-    # As we always first issue request pkt from CPU to NoC, 
-    # when there is no NoC for single CGRA test, 
-    # we have to connect from_noc and to_noc in testbench.
-    s.dut.send_to_inter_cgra_noc //= s.bypass_queue.recv
-    s.bypass_queue.send //= s.dut.recv_from_inter_cgra_noc
-
     s.complete_signal_sink_out.recv //= s.dut.send_to_cpu_pkt
 
     complete_count_value = \
@@ -681,4 +671,3 @@ def test_systolic_3x3(cmdline_opts):
                        'ALWCOMBORDER'])
   th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
   run_sim(th)
-

--- a/fu/flexible/FlexibleFuRTL.py
+++ b/fu/flexible/FlexibleFuRTL.py
@@ -23,7 +23,7 @@ class FlexibleFuRTL(Component):
 
   def construct(s, DataType, PredicateType, CtrlType,
                 num_inports, num_outports, data_mem_size,
-                num_tiles, FuList):
+                num_tiles, FuList, exec_lantency = {}):
 
     # Constant
     num_entries = 2
@@ -51,7 +51,8 @@ class FlexibleFuRTL(Component):
 
     # Components
     s.fu = [FuList[i](DataType, PredicateType, CtrlType, num_inports, num_outports,
-                      data_mem_size) for i in range(s.fu_list_size)]
+                      data_mem_size) if FuList[i] not in exec_lantency.keys() else FuList[i](DataType, PredicateType, CtrlType, num_inports, num_outports,
+                      data_mem_size, latency=exec_lantency[FuList[i]]) for i in range(s.fu_list_size) ]
 
     s.fu_recv_const_rdy_vector = Wire(s.fu_list_size)
     s.fu_recv_predicate_rdy_vector = Wire(s.fu_list_size)

--- a/fu/single/DivRTL.py
+++ b/fu/single/DivRTL.py
@@ -1,0 +1,101 @@
+"""
+==========================================================================
+DivRTL.py
+==========================================================================
+Divider for CGRA tile.
+
+Author : Cheng Tan
+  Date : November 28, 2019
+"""
+
+from pymtl3 import *
+from ..basic.Fu import Fu
+from ...lib.opt_type import *
+
+class DivRTL(Fu):
+
+  def construct(s, DataType, PredicateType, CtrlType,
+                num_inports, num_outports, data_mem_size,
+                vector_factor_power = 0):
+
+    super(DivRTL, s).construct(DataType, PredicateType, CtrlType,
+                               num_inports, num_outports, data_mem_size,
+                               1, vector_factor_power)
+
+    num_entries = 2
+    FuInType = mk_bits(clog2(num_inports + 1))
+    CountType = mk_bits(clog2(num_entries + 1))
+
+    s.in0 = Wire(FuInType)
+    s.in1 = Wire(FuInType)
+
+    idx_nbits = clog2(num_inports)
+    s.in0_idx = Wire(idx_nbits)
+    s.in1_idx = Wire(idx_nbits)
+
+    s.in0_idx //= s.in0[0:idx_nbits]
+    s.in1_idx //= s.in1[0:idx_nbits]
+
+    s.recv_all_val = Wire(1)
+
+    @update
+    def comb_logic():
+
+      s.recv_all_val @= 0
+      # For pick input register
+      s.in0 @= 0
+      s.in1 @= 0
+      for i in range(num_inports):
+        s.recv_in[i].rdy @= b1(0)
+      for i in range(num_outports):
+        s.send_out[i].val @= 0
+        s.send_out[i].msg @= DataType()
+
+      s.recv_const.rdy @= 0
+      s.recv_predicate.rdy @= b1(0)
+      s.recv_opt.rdy @= 0
+
+      if s.recv_opt.val:
+        if s.recv_opt.msg.fu_in[0] != 0:
+          s.in0 @= zext(s.recv_opt.msg.fu_in[0] - 1, FuInType)
+        if s.recv_opt.msg.fu_in[1] != 0:
+          s.in1 @= zext(s.recv_opt.msg.fu_in[1] - 1, FuInType)
+
+      if s.recv_opt.val:
+        if s.recv_opt.msg.operation == OPT_DIV:
+          s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload // s.recv_in[s.in1_idx].msg.payload
+          s.send_out[0].msg.predicate @= s.recv_in[s.in0_idx].msg.predicate & \
+                                         s.recv_in[s.in1_idx].msg.predicate & \
+                                         (~s.recv_opt.msg.predicate | \
+                                          s.recv_predicate.msg.predicate) & \
+                                         s.reached_vector_factor
+          s.recv_all_val @= s.recv_in[s.in0_idx].val & s.recv_in[s.in1_idx].val & \
+                            ((s.recv_opt.msg.predicate == b1(0)) | s.recv_predicate.val)
+          s.send_out[0].val @= s.recv_all_val
+          s.recv_in[s.in0_idx].rdy @= s.recv_all_val & s.send_out[0].rdy
+          s.recv_in[s.in1_idx].rdy @= s.recv_all_val & s.send_out[0].rdy
+          s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
+
+        elif s.recv_opt.msg.operation == OPT_DIV_CONST:
+          s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload // s.recv_const.msg.payload
+          s.send_out[0].msg.predicate @= s.recv_in[s.in0_idx].msg.predicate & \
+                                         (~s.recv_opt.msg.predicate | \
+                                          s.recv_predicate.msg.predicate) & \
+                                         s.reached_vector_factor
+          s.recv_all_val @= s.recv_in[s.in0_idx].val & s.recv_const.val & \
+                            ((s.recv_opt.msg.predicate == b1(0)) | s.recv_predicate.val)
+          s.send_out[0].val @= s.recv_all_val
+          s.recv_in[s.in0_idx].rdy @= s.recv_all_val & s.send_out[0].rdy
+          s.recv_const.rdy @= s.recv_all_val & s.send_out[0].rdy
+          s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
+
+        else:
+          for j in range(num_outports):
+            s.send_out[j].val @= b1(0)
+          s.recv_opt.rdy @= 0
+          s.recv_in[s.in0_idx].rdy @= 0
+          s.recv_in[s.in1_idx].rdy @= 0
+
+        if s.send_out[0].rdy & (s.recv_opt.msg.predicate == b1(1)):
+          s.recv_predicate.rdy @= s.recv_all_val & s.send_out[0].rdy
+

--- a/fu/single/DivRTL.py
+++ b/fu/single/DivRTL.py
@@ -2,10 +2,10 @@
 ==========================================================================
 DivRTL.py
 ==========================================================================
-Divider for CGRA tile.
+Integer divider for CGRA tile.
 
-Author : Cheng Tan
-  Date : November 28, 2019
+Author : Jiajun Qin
+  Date : May 2, 2025
 """
 
 from pymtl3 import *

--- a/fu/single/ExclusiveDivRTL.py
+++ b/fu/single/ExclusiveDivRTL.py
@@ -33,7 +33,7 @@ class ExclusiveDivRTL(Fu):
     s.in1 = Wire(FuInType)
 
     # TODO: how to parameterize the bit widths
-    s.div = Div(WIDTH=32, CYCLE=num_cycles)
+    s.div = Div(WIDTH = 32, CYCLE = num_cycles)
 
     idx_nbits = clog2(num_inports)
     s.in0_idx = Wire(idx_nbits)

--- a/fu/single/ExclusiveDivRTL.py
+++ b/fu/single/ExclusiveDivRTL.py
@@ -1,0 +1,138 @@
+"""
+==========================================================================
+ExclusiveDivRTL.py
+==========================================================================
+Exclusive divisor for CGRA tile.
+
+Author : Cheng Tan
+  Date : November 28, 2019
+"""
+
+from pymtl3 import *
+from ..basic.Fu import Fu
+from ...lib.opt_type import *
+from pymtl3.passes.backends.verilog import *
+
+class ExclusiveDivRTL(Fu):
+
+  def construct(s, DataType, PredicateType, CtrlType,
+                num_inports, num_outports, data_mem_size,
+                latency = 8, vector_factor_power = 0):
+
+    super(ExclusiveDivRTL, s).construct(DataType, PredicateType, CtrlType,
+                               num_inports, num_outports, data_mem_size,
+                               latency, vector_factor_power)
+
+    num_entries = 2
+    num_cycles = latency
+
+    FuInType = mk_bits(clog2(num_inports + 1))
+    CountType = mk_bits(clog2(num_entries + 1))
+
+    s.in0 = Wire(FuInType)
+    s.in1 = Wire(FuInType)
+
+    # TODO: how to parameterize the bit widths
+    s.div = Div(WIDTH=32, CYCLE=num_cycles)
+
+    idx_nbits = clog2(num_inports)
+    s.in0_idx = Wire(idx_nbits)
+    s.in1_idx = Wire(idx_nbits)
+    LatencyType = mk_bits(clog2(latency) + 1)
+    s.now_cycle = Wire(LatencyType)
+
+    s.in0_idx //= s.in0[0:idx_nbits]
+    s.in1_idx //= s.in1[0:idx_nbits]
+
+    s.recv_all_val = Wire(1)
+
+    @update_ff
+    def comb_ff():
+      if (s.now_cycle == latency - 1) & s.send_out[0].rdy:
+          s.now_cycle <<= 0
+      elif s.now_cycle == latency - 1:
+        s.now_cycle <<= s.now_cycle
+      elif s.recv_all_val & (s.recv_opt.msg.operation == OPT_DIV):
+        s.now_cycle <<= s.now_cycle + 1
+      else:
+        s.now_cycle <<= 0
+
+    @update
+    def comb_logic():
+
+      s.recv_all_val @= 0
+      # For pick input register
+      s.in0 @= 0
+      s.in1 @= 0
+      for i in range(num_inports):
+        s.recv_in[i].rdy @= b1(0)
+      for i in range(num_outports):
+        s.send_out[i].val @= 0
+        s.send_out[i].msg @= DataType()
+
+      s.recv_const.rdy @= 0
+      s.recv_predicate.rdy @= b1(0)
+      s.recv_opt.rdy @= 0
+
+      if s.recv_opt.val:
+        if s.recv_opt.msg.fu_in[0] != 0:
+          s.in0 @= zext(s.recv_opt.msg.fu_in[0] - 1, FuInType)
+        if s.recv_opt.msg.fu_in[1] != 0:
+          s.in1 @= zext(s.recv_opt.msg.fu_in[1] - 1, FuInType)
+
+      if s.recv_opt.val:
+        if s.recv_opt.msg.operation == OPT_DIV:
+          s.div.dividend @= s.recv_in[s.in0_idx].msg.payload
+          s.div.divisor @= s.recv_in[s.in1_idx].msg.payload
+          s.send_out[0].msg.payload @= s.div.quotient
+          s.send_out[1].msg.payload @= s.div.remainder
+          s.send_out[0].msg.predicate @= s.recv_in[s.in0_idx].msg.predicate & \
+                                         s.recv_in[s.in1_idx].msg.predicate & \
+                                         (~s.recv_opt.msg.predicate | \
+                                          s.recv_predicate.msg.predicate) & \
+                                         s.reached_vector_factor
+          s.send_out[1].msg.predicate @= s.send_out[0].msg.predicate
+          s.recv_all_val @= s.recv_in[s.in0_idx].val & s.recv_in[s.in1_idx].val & ((s.recv_opt.msg.predicate == b1(0)) | s.recv_predicate.val)
+          s.send_out[0].val @= (latency - 1 == s.now_cycle)
+          s.send_out[1].val @= (latency - 1 == s.now_cycle)
+          s.recv_in[s.in0_idx].rdy @= s.recv_all_val & s.send_out[0].rdy
+          s.recv_in[s.in1_idx].rdy @= s.recv_all_val & s.send_out[0].rdy
+          # TODO: if single-cycle?
+          s.recv_opt.rdy @= (latency - 1 == s.now_cycle) & s.send_out[0].rdy
+
+        else:
+          for j in range(num_outports):
+            s.send_out[j].val @= b1(0)
+          s.recv_opt.rdy @= 0
+          s.recv_in[s.in0_idx].rdy @= 0
+          s.recv_in[s.in1_idx].rdy @= 0
+
+        if s.send_out[0].rdy & (s.recv_opt.msg.predicate == b1(1)):
+          s.recv_predicate.rdy @= s.recv_all_val & s.send_out[0].rdy
+
+class Div( VerilogPlaceholder, Component ):
+
+  # Constructor
+
+  def construct( s, WIDTH = 32, CYCLE = 8 ):
+
+    # Interface
+
+    s.dividend              = InPort ( WIDTH )
+    s.divisor              = InPort ( WIDTH )
+
+    s.quotient            = OutPort ( WIDTH )
+    s.remainder            = OutPort ( WIDTH )
+
+    # Configurations
+
+    from os import path
+    srcdir = path.dirname(__file__) + path.sep
+
+    s.set_metadata( VerilogPlaceholderPass.src_file, srcdir + 'division.v' )
+    s.set_metadata( VerilogPlaceholderPass.top_module, 'pipeline_division' )
+    # s.set_metadata( VerilogPlaceholderPass.v_include, [ srcdir ] )
+    s.set_metadata( VerilogPlaceholderPass.has_clk, True )
+    s.set_metadata( VerilogPlaceholderPass.has_reset, True )
+
+    s.set_metadata( VerilogVerilatorImportPass.vl_Wno_list, ['WIDTH'] )

--- a/fu/single/ExclusiveDivRTL.py
+++ b/fu/single/ExclusiveDivRTL.py
@@ -17,7 +17,7 @@ class ExclusiveDivRTL(Fu):
 
   def construct(s, DataType, PredicateType, CtrlType,
                 num_inports, num_outports, data_mem_size,
-                latency = 8, vector_factor_power = 0):
+                latency = 4, vector_factor_power = 0):
 
     super(ExclusiveDivRTL, s).construct(DataType, PredicateType, CtrlType,
                                num_inports, num_outports, data_mem_size,
@@ -83,7 +83,6 @@ class ExclusiveDivRTL(Fu):
         if s.recv_opt.msg.fu_in[1] != 0:
           s.in1 @= zext(s.recv_opt.msg.fu_in[1] - 1, FuInType)
 
-      # print(s.recv_opt.msg.operation, OPT_DIV)
       if s.recv_opt.val:
         if (s.recv_opt.msg.operation == OPT_DIV) | (s.recv_opt.msg.operation == OPT_REM):
           s.div.dividend @= s.recv_in[s.in0_idx].msg.payload
@@ -102,6 +101,7 @@ class ExclusiveDivRTL(Fu):
           s.recv_in[s.in0_idx].rdy @= s.send_out[0].val & s.send_out[0].rdy
           s.recv_in[s.in1_idx].rdy @= s.send_out[0].val & s.send_out[0].rdy
           s.do_div @= 1
+          s.recv_opt.rdy @= s.send_out[0].val & s.send_out[0].rdy
           # TODO: if single-cycle?
           if s.send_out[0].rdy & (s.recv_opt.msg.predicate == b1(1)):
             s.recv_predicate.rdy @= s.send_out[0].val & s.send_out[0].rdy

--- a/fu/single/InclusiveDivRTL.py
+++ b/fu/single/InclusiveDivRTL.py
@@ -1,0 +1,143 @@
+"""
+==========================================================================
+InclusiveDivRTL.py
+==========================================================================
+Inclusive divisor for CGRA tile.
+
+Author : Cheng Tan
+  Date : November 28, 2019
+"""
+
+from pymtl3 import *
+from ..basic.Fu import Fu
+from ...lib.opt_type import *
+from pymtl3.passes.backends.verilog import *
+
+class InclusiveDivRTL(Fu):
+
+  def construct(s, DataType, PredicateType, CtrlType,
+                num_inports, num_outports, data_mem_size,
+                latency = 8, vector_factor_power = 0):
+
+    super(InclusiveDivRTL, s).construct(DataType, PredicateType, CtrlType,
+                               num_inports, num_outports, data_mem_size,
+                               latency, vector_factor_power)
+
+    num_entries = 2
+    num_cycles = latency
+    FuInType = mk_bits(clog2(num_inports + 1))
+    CountType = mk_bits(clog2(num_entries + 1))
+    OPT_DIV_START = 10
+    OPT_DIV_END   = 11
+
+    s.in0 = Wire(FuInType)
+    s.in1 = Wire(FuInType)
+
+    # TODO: how to parameterize the bit widths
+    s.div = Div(WIDTH=32, CYCLE=num_cycles)
+
+    idx_nbits = clog2(num_inports)
+    s.in0_idx = Wire(idx_nbits)
+    s.in1_idx = Wire(idx_nbits)
+
+    s.in0_idx //= s.in0[0:idx_nbits]
+    s.in1_idx //= s.in1[0:idx_nbits]
+
+    s.recv_all_val = Wire(1)
+
+    @update
+    def comb_logic():
+
+      s.recv_all_val @= 0
+      # For pick input register
+      s.in0 @= 0
+      s.in1 @= 0
+      for i in range(num_inports):
+        s.recv_in[i].rdy @= b1(0)
+      for i in range(num_outports):
+        s.send_out[i].val @= 0
+        s.send_out[i].msg @= DataType()
+
+      s.recv_const.rdy @= 0
+      s.recv_predicate.rdy @= b1(0)
+      s.recv_opt.rdy @= 0
+
+      if s.recv_opt.val:
+        if s.recv_opt.msg.fu_in[0] != 0:
+          s.in0 @= zext(s.recv_opt.msg.fu_in[0] - 1, FuInType)
+        if s.recv_opt.msg.fu_in[1] != 0:
+          s.in1 @= zext(s.recv_opt.msg.fu_in[1] - 1, FuInType)
+
+      if s.recv_opt.val:
+        if (s.recv_opt.msg.operation == OPT_DIV_START):
+          s.div.dividend @= s.recv_in[s.in0_idx].msg.payload
+          s.div.divisor @= s.recv_in[s.in1_idx].msg.payload
+          s.send_out[0].msg.payload @= 0
+          s.send_out[1].msg.payload @= 0
+          s.send_out[0].msg.predicate @= s.recv_in[s.in0_idx].msg.predicate & \
+                                         s.recv_in[s.in1_idx].msg.predicate & \
+                                         (~s.recv_opt.msg.predicate | \
+                                          s.recv_predicate.msg.predicate) & \
+                                         s.reached_vector_factor
+          s.send_out[1].msg.predicate @= s.send_out[0].msg.predicate
+          s.recv_all_val @= s.recv_in[s.in0_idx].val & s.recv_in[s.in1_idx].val & \
+                            ((s.recv_opt.msg.predicate == b1(0)) | s.recv_predicate.val)
+          s.send_out[0].val @= s.recv_all_val
+          s.send_out[1].val @= s.recv_all_val
+          s.recv_in[s.in0_idx].rdy @= s.recv_all_val
+          s.recv_in[s.in1_idx].rdy @= s.recv_all_val
+          s.recv_opt.rdy @= s.recv_all_val
+        elif s.recv_opt.msg.operation == OPT_DIV_END:
+          s.send_out[0].msg.payload @= s.div.quotient
+          s.send_out[1].msg.payload @= s.div.remainder
+          s.send_out[0].msg.predicate @= s.recv_in[s.in0_idx].msg.predicate & \
+                                         s.recv_in[s.in1_idx].msg.predicate & \
+                                         (~s.recv_opt.msg.predicate | \
+                                          s.recv_predicate.msg.predicate) & \
+                                         s.reached_vector_factor
+          s.send_out[1].msg.predicate @= s.send_out[0].msg.predicate
+          s.recv_all_val @= s.recv_in[s.in0_idx].val & s.recv_in[s.in1_idx].val & \
+                            ((s.recv_opt.msg.predicate == b1(0)) | s.recv_predicate.val)
+          s.send_out[0].val @= s.recv_all_val
+          s.send_out[1].val @= s.recv_all_val
+          s.recv_in[s.in0_idx].rdy @= s.recv_all_val & s.send_out[0].rdy
+          s.recv_in[s.in1_idx].rdy @= s.recv_all_val & s.send_out[0].rdy
+          s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
+
+        else:
+          for j in range(num_outports):
+            s.send_out[j].val @= b1(0)
+          s.recv_opt.rdy @= 0
+          s.recv_in[s.in0_idx].rdy @= 0
+          s.recv_in[s.in1_idx].rdy @= 0
+
+        if s.send_out[0].rdy & (s.recv_opt.msg.predicate == b1(1)):
+          s.recv_predicate.rdy @= s.recv_all_val & s.send_out[0].rdy
+
+class Div( VerilogPlaceholder, Component ):
+
+  # Constructor
+
+  def construct( s, WIDTH = 32, CYCLE = 8 ):
+
+    # Interface
+
+    
+    s.dividend              = InPort ( WIDTH )
+    s.divisor              = InPort ( WIDTH )
+
+    s.quotient            = OutPort ( WIDTH )
+    s.remainder            = OutPort ( WIDTH )
+
+    # Configurations
+
+    from os import path
+    srcdir = path.dirname(__file__) + path.sep
+
+    s.set_metadata( VerilogPlaceholderPass.src_file, srcdir + 'division.v' )
+    s.set_metadata( VerilogPlaceholderPass.top_module, 'pipeline_division' )
+    # s.set_metadata( VerilogPlaceholderPass.v_include, [ srcdir ] )
+    s.set_metadata( VerilogPlaceholderPass.has_clk, True )
+    s.set_metadata( VerilogPlaceholderPass.has_reset, True )
+
+    s.set_metadata( VerilogVerilatorImportPass.vl_Wno_list, ['WIDTH'] )

--- a/fu/single/InclusiveDivRTL.py
+++ b/fu/single/InclusiveDivRTL.py
@@ -27,8 +27,6 @@ class InclusiveDivRTL(Fu):
     num_cycles = latency
     FuInType = mk_bits(clog2(num_inports + 1))
     CountType = mk_bits(clog2(num_entries + 1))
-    OPT_DIV_START = 10
-    OPT_DIV_END   = 11
 
     s.in0 = Wire(FuInType)
     s.in1 = Wire(FuInType)

--- a/fu/single/InclusiveDivRTL.py
+++ b/fu/single/InclusiveDivRTL.py
@@ -32,7 +32,7 @@ class InclusiveDivRTL(Fu):
     s.in1 = Wire(FuInType)
 
     # TODO: how to parameterize the bit widths
-    s.div = Div(WIDTH=32, CYCLE=num_cycles)
+    s.div = Div(WIDTH = 32, CYCLE = num_cycles)
 
     idx_nbits = clog2(num_inports)
     s.in0_idx = Wire(idx_nbits)

--- a/fu/single/InclusiveDivRTL.py
+++ b/fu/single/InclusiveDivRTL.py
@@ -17,7 +17,7 @@ class InclusiveDivRTL(Fu):
 
   def construct(s, DataType, PredicateType, CtrlType,
                 num_inports, num_outports, data_mem_size,
-                latency = 8, vector_factor_power = 0):
+                latency = 2, vector_factor_power = 0):
 
     super(InclusiveDivRTL, s).construct(DataType, PredicateType, CtrlType,
                                num_inports, num_outports, data_mem_size,

--- a/fu/single/division.v
+++ b/fu/single/division.v
@@ -1,0 +1,105 @@
+module division #(
+    parameter WIDTH = 32,
+    parameter ITER_BEGIN = 0,
+    parameter ITER_END = 32
+) (
+    input  clk,
+    input  reset,
+    input  [WIDTH-1:0] dividend,
+    input  [WIDTH-1:0] divisor,
+    input  [WIDTH:0]   r_i,
+    input  [WIDTH-1:0] q_i,
+    output  [WIDTH:0]   r_o,
+    output  [WIDTH-1:0] q_o
+);
+
+    reg [WIDTH:0] r;      // 33-bit remainder (extra bit for overflow)
+    reg [WIDTH-1:0] q;    // Quotient
+
+    always @(*) begin
+        integer i;
+
+        r = r_i;
+        q = q_i;
+
+        for (i = ITER_BEGIN; i < ITER_END; i = i + 1) begin
+            // Shift remainder left and insert next bit of dividend
+            r = (r << 1) | ((dividend >> (31 - i)) & 1'b1);
+            
+            // Compare and subtract if possible
+            if (r >= divisor) begin
+                r = r - divisor;
+                q[31 - i] = 1'b1;  // Set current quotient bit
+            end else begin
+                q[31 - i] = 1'b0;
+            end
+        end
+    end
+
+    assign r_o = r;
+    assign q_o = q;
+
+endmodule
+
+module pipeline_division #(
+    parameter WIDTH = 32,
+    parameter CYCLE = 9
+) (
+    input  clk,
+    input  reset,
+    input  [WIDTH-1:0] dividend,
+    input  [WIDTH-1:0] divisor,
+    output [WIDTH-1:0] quotient,
+    output [WIDTH-1:0] remainder
+);
+
+    parameter num_div = WIDTH / CYCLE;
+    parameter res_div = WIDTH - CYCLE * num_div;
+
+    reg [WIDTH-1:0] qq[0:CYCLE-1] ;
+    reg [WIDTH:0] rr[0:CYCLE-1] ;
+    wire [WIDTH-1:0] q[0:CYCLE-1] ;
+    wire [WIDTH:0] r[0:CYCLE-1] ;
+
+    genvar i; 
+    generate
+            for (i = 0; i < CYCLE - 1; i++) begin
+                always @(posedge clk) begin
+                    qq[i+1] = q[i];
+                    rr[i+1] = r[i];
+                end
+
+            always @(posedge reset) begin
+                if (reset) begin
+                    for (integer i = 0; i < CYCLE; i++) begin
+                        qq[i] = 0;
+                        rr[i] = 0;
+                    end
+                end
+            end
+        end
+    endgenerate
+
+    generate
+        for (i = 0; i < CYCLE; i++) begin
+            division #(
+                .WIDTH(WIDTH),
+                .ITER_BEGIN(i*num_div),
+                .ITER_END((i+1)*num_div)
+            ) u0 (
+                .clk(clk),
+                .reset(reset),
+                .dividend(dividend),
+                .divisor(divisor),
+                .q_i(qq[i]),
+                .r_i(rr[i]),
+                .q_o(q[i]),
+                .r_o(r[i])
+            );
+        end
+    endgenerate
+
+    assign quotient  = q[CYCLE-1];
+    assign remainder = r[CYCLE-1][WIDTH-1:0];
+
+endmodule

--- a/fu/single/division.v
+++ b/fu/single/division.v
@@ -1,3 +1,13 @@
+/*
+==========================================================================
+division.v
+==========================================================================
+Integer division module for VectorCGRA.
+
+Author : Jiajun Qin
+  Date : 9 July, 2025
+*/
+
 module division #(
     parameter WIDTH      = 32,
     parameter ITER_BEGIN = 0,
@@ -59,12 +69,16 @@ module pipeline_division #(
     parameter res_div = WIDTH - CYCLE * num_div;
 
     // Pipeline registers between stages
-    reg [WIDTH-1:0] q_i[0:CYCLE-1];                 
-    reg [WIDTH:0]   r_i[0:CYCLE-1];
-    reg [WIDTH-1:0] dividend_reg[0:CYCLE-1];
-    reg [WIDTH-1:0] divisor_reg [0:CYCLE-1];
+    reg [WIDTH-1:0] q_i[0:CYCLE-1];             // Temporal quotient          
+    reg [WIDTH:0]   r_i[0:CYCLE-1];             // Temporal remainder
     wire [WIDTH-1:0] q_o[0:CYCLE-1];
     wire [WIDTH:0]   r_o[0:CYCLE-1];
+
+    // Pipeline registers for dividend and divisor
+    // Since there could be CYCLE divisions in parallel,
+    // we need to store the dividend and divisor for each stage.
+    reg [WIDTH-1:0] dividend_reg[0:CYCLE-1];    
+    reg [WIDTH-1:0] divisor_reg [0:CYCLE-1];
 
     genvar i; 
 
@@ -82,7 +96,7 @@ module pipeline_division #(
                     dividend_reg[i] <= 0;
                     divisor_reg[i]  <= 0;
                 end
-                else if (i > 0) begin           // Propagate values through pipeline
+                else if (i > 0) begin             // Propagate values through pipeline
                     q_i[i] <= q_i[i-1];           // Temporal quotient to next stage
                     r_i[i] <= r_i[i-1];           // Temporal remainder to next stage
                     dividend_reg[i] <= dividend_reg[i-1];       // Forward dividend

--- a/fu/single/division.v
+++ b/fu/single/division.v
@@ -41,9 +41,9 @@ module division #(
             // Compare and subtract if possible
             if (r >= divisor) begin
                 r = r - divisor;
-                q[31 - i] = 1'b1;  // Set cur_ient quotient bit
+                q[HIGHEST_BIT - i] = 1'b1;  // Set cur_ient quotient bit
             end else begin
-                q[31 - i] = 1'b0;
+                q[HIGHEST_BIT - i] = 1'b0;
             end
         end
     end

--- a/fu/single/division.v
+++ b/fu/single/division.v
@@ -13,7 +13,7 @@ module division #(
     output  [WIDTH-1:0] q_o
 );
 
-    reg [WIDTH:0] r;      // 33-bit remainder (extra bit for overflow)
+    reg [WIDTH:0]   r;      // 33-bit remainder (extra bit for overflow)
     reg [WIDTH-1:0] q;    // Quotient
 
     always @(*) begin
@@ -43,7 +43,7 @@ endmodule
 
 module pipeline_division #(
     parameter WIDTH = 32,
-    parameter CYCLE = 9
+    parameter CYCLE = 8
 ) (
     input  clk,
     input  reset,
@@ -56,25 +56,26 @@ module pipeline_division #(
     parameter num_div = WIDTH / CYCLE;
     parameter res_div = WIDTH - CYCLE * num_div;
 
-    reg [WIDTH-1:0] qq[0:CYCLE-1] ;
-    reg [WIDTH:0] rr[0:CYCLE-1] ;
-    wire [WIDTH-1:0] q[0:CYCLE-1] ;
-    wire [WIDTH:0] r[0:CYCLE-1] ;
+    reg [WIDTH-1:0] qq[0:CYCLE-1];
+    reg [WIDTH:0]   rr[0:CYCLE-1];
+    wire [WIDTH-1:0] q[0:CYCLE-1];
+    wire [WIDTH:0]   r[0:CYCLE-1];
 
     genvar i; 
     generate
-            for (i = 0; i < CYCLE - 1; i++) begin
-                always @(posedge clk) begin
+        for (i = 0; i < CYCLE; i++) begin
+            always @(posedge clk or posedge reset) begin
+                if (reset) begin
+                    qq[i] = 0;
+                    rr[i] = 0;
+                end
+                else if (i < CYCLE - 1) begin
                     qq[i+1] = q[i];
                     rr[i+1] = r[i];
                 end
-
-            always @(posedge reset) begin
-                if (reset) begin
-                    for (integer i = 0; i < CYCLE; i++) begin
-                        qq[i] = 0;
-                        rr[i] = 0;
-                    end
+                else begin
+                    qq[i] = 0;
+                    rr[i] = 0;
                 end
             end
         end

--- a/fu/single/test/DivRTL_test.py
+++ b/fu/single/test/DivRTL_test.py
@@ -1,0 +1,106 @@
+"""
+==========================================================================
+ExclusiveDivRTL_test.py
+==========================================================================
+Test cases for Divider.
+
+Author : Cheng Tan
+  Date : November 27, 2019
+"""
+
+import pytest
+import hypothesis
+from hypothesis import strategies as st
+from itertools import product
+from pymtl3 import *
+from ..DivRTL import DivRTL
+from ....lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL
+from ....lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
+from ....lib.opt_type import *
+from ....lib.messages import *
+from ....mem.const.ConstQueueRTL import ConstQueueRTL
+
+#-------------------------------------------------------------------------
+# Test harness
+#-------------------------------------------------------------------------
+
+class TestHarness(Component):
+
+  def construct(s, FunctionUnit, DataType, PredicateType, ConfigType,
+                num_inports, num_outports, data_mem_size,
+                src0_msgs, src1_msgs, src_predicate, src_const,
+                ctrl_msgs, sink_msgs):
+
+    s.src_in0 = TestSrcRTL(DataType, src0_msgs)
+    s.src_in1 = TestSrcRTL(DataType, src1_msgs)
+    s.src_in2 = TestSrcRTL(DataType, src1_msgs)
+    s.src_predicate = TestSrcRTL(PredicateType, src_predicate)
+    s.src_opt = TestSrcRTL(ConfigType, ctrl_msgs)
+    s.sink_out = TestSinkRTL(DataType, sink_msgs)
+
+    s.const_queue = ConstQueueRTL(DataType, src_const)
+    s.dut = FunctionUnit(DataType, PredicateType, ConfigType,
+                         num_inports, num_outports, data_mem_size)
+
+    connect(s.src_in0.send, s.dut.recv_in[0])
+    connect(s.src_in1.send, s.dut.recv_in[1])
+    connect(s.src_in2.send, s.dut.recv_in[2])
+    connect(s.src_predicate.send, s.dut.recv_predicate)
+    connect(s.dut.recv_const, s.const_queue.send_const)
+    connect(s.src_opt.send, s.dut.recv_opt)
+    connect(s.dut.send_out[0], s.sink_out.recv)
+
+  def done(s):
+    return s.src_in0.done() and s.src_in2.done() and \
+           s.src_opt.done() and s.sink_out.done()
+
+  def line_trace(s):
+    return s.dut.line_trace()
+
+def run_sim(test_harness, max_cycles = 20):
+  test_harness.elaborate()
+  test_harness.apply(DefaultPassGroup())
+  test_harness.sim_reset()
+
+  # Run simulation
+  ncycles = 0
+  print()
+  print("{}:{}".format( ncycles, test_harness.line_trace()))
+  while not test_harness.done() and ncycles < max_cycles:
+    test_harness.sim_tick()
+    ncycles += 1
+    print("{}:{}".format( ncycles, test_harness.line_trace()))
+
+  # Check timeout
+  assert ncycles < max_cycles
+
+  test_harness.sim_tick()
+  test_harness.sim_tick()
+  test_harness.sim_tick()
+
+@pytest.mark.parametrize(
+  'input_a, input_b',
+  product(range(5, 8), range(2, 4))
+)
+def test_div0(input_a, input_b):
+  FU = DivRTL
+  DataType = mk_data(32, 1)
+  PredicateType = mk_predicate(1, 1)
+  num_inports = 4
+  num_outports = 2
+  ConfigType = mk_ctrl(num_inports, num_outports)
+  FuInType = mk_bits(clog2(num_inports + 1))
+  data_mem_size = 8
+  src_in0 = [DataType(input_a, 1)]
+  src_in1 = [DataType(input_b, 1)]
+  src_predicate = [PredicateType(1,1)]
+  src_const = [DataType(0, 1) ]
+  sink_out = [DataType(input_a // input_b, 1)]
+  src_opt = [ConfigType(OPT_DIV, b1(0),
+             [FuInType(1), FuInType(3), FuInType(0), FuInType(0)])]
+  th = TestHarness(FU, DataType, PredicateType, ConfigType,
+                   num_inports, num_outports, data_mem_size,
+                   src_in0, src_in1, src_predicate, src_const,
+                   src_opt, sink_out)
+  run_sim(th)
+

--- a/fu/single/test/InclusiveDivRTL_test.py
+++ b/fu/single/test/InclusiveDivRTL_test.py
@@ -1,6 +1,6 @@
 """
 ==========================================================================
-DivRTL_test.py
+InclusiveDivRTL_test.py
 ==========================================================================
 Test cases for Divider.
 
@@ -8,17 +8,21 @@ Author : Jiajun Qin
   Date : May 2, 2025
 """
 
+
 import pytest
 import hypothesis
 from hypothesis import strategies as st
 from itertools import product
 from pymtl3 import *
-from ..DivRTL import DivRTL
+from pymtl3.stdlib.test_utils import (run_sim,
+                                      config_model_with_cmdline_opts)
+from ..InclusiveDivRTL import InclusiveDivRTL
 from ....lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL
 from ....lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
-from ....lib.opt_type import *
 from ....lib.messages import *
+from ....lib.opt_type import *
 from ....mem.const.ConstQueueRTL import ConstQueueRTL
+
 
 #-------------------------------------------------------------------------
 # Test harness
@@ -40,7 +44,7 @@ class TestHarness(Component):
 
     s.const_queue = ConstQueueRTL(DataType, src_const)
     s.dut = FunctionUnit(DataType, PredicateType, ConfigType,
-                         num_inports, num_outports, data_mem_size)
+                         num_inports, num_outports, data_mem_size, latency=4)
 
     connect(s.src_in0.send, s.dut.recv_in[0])
     connect(s.src_in1.send, s.dut.recv_in[1])
@@ -51,39 +55,14 @@ class TestHarness(Component):
     connect(s.dut.send_out[0], s.sink_out.recv)
 
   def done(s):
-    return s.src_in0.done() and s.src_in2.done() and \
-           s.src_opt.done() and s.sink_out.done()
+    return s.sink_out.done()
 
   def line_trace(s):
     return s.dut.line_trace()
 
-def run_sim(test_harness, max_cycles = 20):
-  test_harness.elaborate()
-  test_harness.apply(DefaultPassGroup())
-  test_harness.sim_reset()
 
-  # Run simulation
-  ncycles = 0
-  print()
-  print("{}:{}".format( ncycles, test_harness.line_trace()))
-  while not test_harness.done() and ncycles < max_cycles:
-    test_harness.sim_tick()
-    ncycles += 1
-    print("{}:{}".format( ncycles, test_harness.line_trace()))
-
-  # Check timeout
-  assert ncycles < max_cycles
-
-  test_harness.sim_tick()
-  test_harness.sim_tick()
-  test_harness.sim_tick()
-
-@pytest.mark.parametrize(
-  'input_a, input_b',
-  product(range(5, 8), range(2, 4))
-)
-def test_div0(input_a, input_b):
-  FU = DivRTL
+def test_mul():
+  FU            = InclusiveDivRTL
   DataType = mk_data(32, 1)
   PredicateType = mk_predicate(1, 1)
   num_inports = 4
@@ -91,13 +70,19 @@ def test_div0(input_a, input_b):
   ConfigType = mk_ctrl(num_inports, num_outports)
   FuInType = mk_bits(clog2(num_inports + 1))
   data_mem_size = 8
-  src_in0 = [DataType(input_a, 1)]
-  src_in1 = [DataType(input_b, 1)]
-  src_predicate = [PredicateType(1,1)]
-  src_const = [DataType(0, 1) ]
-  sink_out = [DataType(input_a // input_b, 1)]
-  src_opt = [ConfigType(OPT_DIV, b1(0),
-             [FuInType(1), FuInType(3), FuInType(0), FuInType(0)])]
+  PredType      = mk_predicate(1, 1)
+  src_predicate = [ PredType(1, 0), PredType(1, 0), PredType(1, 0), PredType(1, 1), PredType(1, 1), PredType(1, 1) ]
+  src_in0       = [ DataType(13,  1), DataType(9,  1), DataType(7,   1), DataType(2,   1), DataType(0,   1), DataType(0,   1) ]
+  src_in1       = [               DataType(3,  1)                ]
+  src_const     = [ DataType(1,  1), DataType(1,  1),DataType(1,  1), DataType(2,   1), DataType(0,   1), DataType(0,   1) ]
+  sink_out      = [ DataType(0, 0), DataType(0, 0), DataType(0, 0), DataType(4, 1), DataType(3, 1), DataType(2, 1) ] 
+  pick_register = [ FuInType(x + 1) for x in range(num_inports) ]
+  src_opt       = [ ConfigType( OPT_DIV_INCLUSIVE_START, b1(1), pick_register ),
+                    ConfigType( OPT_DIV_INCLUSIVE_START, b1(1), pick_register ),
+                    ConfigType( OPT_DIV_INCLUSIVE_START, b1(1), pick_register ),
+                    ConfigType( OPT_DIV_INCLUSIVE_END,   b1(1), pick_register ),
+                    ConfigType( OPT_DIV_INCLUSIVE_END,   b1(1), pick_register ),
+                    ConfigType( OPT_DIV_INCLUSIVE_END,   b1(1), pick_register ) ]
   th = TestHarness(FU, DataType, PredicateType, ConfigType,
                    num_inports, num_outports, data_mem_size,
                    src_in0, src_in1, src_predicate, src_const,

--- a/fu/single/translate/ExclusiveDivRTL_test.py
+++ b/fu/single/translate/ExclusiveDivRTL_test.py
@@ -28,18 +28,15 @@ ConfigType = mk_ctrl(4, 2)
 data_mem_size = 8
 latency       = 4
 
-def test_elaborate():
+def test_elaborate(cmdline_opts):
   dut = ExclusiveDivRTL( DataType, PredicateType, ConfigType,
-                 num_inports, num_outports, data_mem_size )
-  dut.apply( DefaultPassGroup(linetrace=True) )
-  dut.sim_reset()
-  dut.sim_tick()
-  dut.sim_tick()
+                 num_inports, num_outports, data_mem_size, latency = latency)
+  dut = config_model_with_cmdline_opts(dut, cmdline_opts, duts = [])
 
 # TODO: fix import by either suppressing warnings or address them
 def test_translate( cmdline_opts ):
   dut = ExclusiveDivRTL( DataType, PredicateType, ConfigType,
-                 num_inports, num_outports, data_mem_size, latency )
+                 num_inports, num_outports, data_mem_size, latency = latency)
   dut.set_metadata( VerilogTranslationPass.explicit_module_name,
                     f'ExclusiveDivRTL' )
   config_model_with_cmdline_opts( dut, cmdline_opts, duts=[] )

--- a/fu/single/translate/ExclusiveDivRTL_test.py
+++ b/fu/single/translate/ExclusiveDivRTL_test.py
@@ -1,0 +1,46 @@
+'''
+==========================================================================
+ExclusiveDivRTL_test.py
+==========================================================================
+
+Author: Jiajun Qin
+  Date: June 2, 2025
+'''
+
+
+from pymtl3 import *
+from pymtl3.passes.backends.verilog import VerilogTranslationPass
+from pymtl3.stdlib.test_utils import (run_sim,
+                                      config_model_with_cmdline_opts)
+from ..CompRTL import CompRTL
+from ..MemUnitRTL import MemUnitRTL
+from ..MulRTL import MulRTL
+from ..ExclusiveDivRTL import ExclusiveDivRTL
+from ....lib.messages import *
+from ....lib.opt_type import *
+
+
+DataType      = mk_data( 32, 1 )
+PredicateType = mk_predicate( 1, 1 )
+num_inports   = 4
+num_outports  = 2
+ConfigType = mk_ctrl(4, 2)
+data_mem_size = 8
+latency       = 4
+
+def test_elaborate():
+  dut = ExclusiveDivRTL( DataType, PredicateType, ConfigType,
+                 num_inports, num_outports, data_mem_size )
+  dut.apply( DefaultPassGroup(linetrace=True) )
+  dut.sim_reset()
+  dut.sim_tick()
+  dut.sim_tick()
+
+# TODO: fix import by either suppressing warnings or address them
+def test_translate( cmdline_opts ):
+  dut = ExclusiveDivRTL( DataType, PredicateType, ConfigType,
+                 num_inports, num_outports, data_mem_size, latency )
+  dut.set_metadata( VerilogTranslationPass.explicit_module_name,
+                    f'ExclusiveDivRTL' )
+  config_model_with_cmdline_opts( dut, cmdline_opts, duts=[] )
+

--- a/fu/single/translate/InclusiveDivRTL_test.py
+++ b/fu/single/translate/InclusiveDivRTL_test.py
@@ -28,13 +28,10 @@ ConfigType = mk_ctrl(4, 2)
 data_mem_size = 8
 latency       = 4
 
-def test_elaborate():
-  dut = InclusiveDivRTL( DataType, PredicateType, ConfigType,
-                 num_inports, num_outports, data_mem_size )
-  dut.apply( DefaultPassGroup(linetrace=True) )
-  dut.sim_reset()
-  dut.sim_tick()
-  dut.sim_tick()
+def test_elaborate(cmdline_opts):
+  dut = InclusiveDivRTL(DataType, PredicateType, ConfigType, num_inports,
+                 num_outports, data_mem_size, latency = 4)
+  dut = config_model_with_cmdline_opts(dut, cmdline_opts, duts = [])
 
 # TODO: fix import by either suppressing warnings or address them
 def test_translate( cmdline_opts ):

--- a/fu/single/translate/InclusiveDivRTL_test.py
+++ b/fu/single/translate/InclusiveDivRTL_test.py
@@ -1,0 +1,46 @@
+'''
+==========================================================================
+InclusiveDivRTL_test.py
+==========================================================================
+
+Author: Jiajun Qin
+  Date: June 2, 2025
+'''
+
+
+from pymtl3 import *
+from pymtl3.passes.backends.verilog import VerilogTranslationPass
+from pymtl3.stdlib.test_utils import (run_sim,
+                                      config_model_with_cmdline_opts)
+from ..CompRTL import CompRTL
+from ..MemUnitRTL import MemUnitRTL
+from ..MulRTL import MulRTL
+from ..InclusiveDivRTL import InclusiveDivRTL
+from ....lib.messages import *
+from ....lib.opt_type import *
+
+
+DataType      = mk_data( 32, 1 )
+PredicateType = mk_predicate( 1, 1 )
+num_inports   = 4
+num_outports  = 2
+ConfigType = mk_ctrl(4, 2)
+data_mem_size = 8
+latency       = 4
+
+def test_elaborate():
+  dut = InclusiveDivRTL( DataType, PredicateType, ConfigType,
+                 num_inports, num_outports, data_mem_size )
+  dut.apply( DefaultPassGroup(linetrace=True) )
+  dut.sim_reset()
+  dut.sim_tick()
+  dut.sim_tick()
+
+# TODO: fix import by either suppressing warnings or address them
+def test_translate( cmdline_opts ):
+  dut = InclusiveDivRTL( DataType, PredicateType, ConfigType,
+                 num_inports, num_outports, data_mem_size, latency )
+  dut.set_metadata( VerilogTranslationPass.explicit_module_name,
+                    f'InclusiveDivRTL_test' )
+  config_model_with_cmdline_opts( dut, cmdline_opts, duts=[] )
+

--- a/lib/opt_type.py
+++ b/lib/opt_type.py
@@ -75,6 +75,9 @@ OPT_GTE = Bits6( 61 )
 OPT_GT  = Bits6( 62 )
 OPT_LTE = Bits6( 63 )
 
+OPT_DIV_START = Bits6( 48 )
+OPT_DIV_END   = Bits6( 49 )
+
 OPT_SYMBOL_DICT = {
   OPT_START         : "(start)",
   OPT_NAH           : "(NAH)",

--- a/lib/opt_type.py
+++ b/lib/opt_type.py
@@ -28,6 +28,8 @@ OPT_LLS                   = Bits6( 5  )
 OPT_LRS                   = Bits6( 6  )
 OPT_MUL                   = Bits6( 7  )
 OPT_DIV                   = Bits6( 26 )
+OPT_DIV_CONST             = Bits6( 26 )
+OPT_REM                   = Bits6( 44 )
 OPT_OR                    = Bits6( 8  )
 OPT_XOR                   = Bits6( 9  )
 OPT_AND                   = Bits6( 10 )
@@ -75,8 +77,10 @@ OPT_GTE = Bits6( 61 )
 OPT_GT  = Bits6( 62 )
 OPT_LTE = Bits6( 63 )
 
-OPT_DIV_START = Bits6( 48 )
-OPT_DIV_END   = Bits6( 49 )
+OPT_DIV_INCLUSIVE_START = Bits6( 48 )
+OPT_DIV_INCLUSIVE_END   = Bits6( 49 )
+OPT_REM_INCLUSIVE_START = Bits6( 59 )
+OPT_REM_INCLUSIVE_END   = Bits6( 15 )
 
 OPT_SYMBOL_DICT = {
   OPT_START         : "(start)",
@@ -90,6 +94,7 @@ OPT_SYMBOL_DICT = {
   OPT_LRS           : "(>>)",
   OPT_MUL           : "(*)",
   OPT_DIV           : "(/)",
+  OPT_REM           : "(%)",
   OPT_OR            : "(|)",
   OPT_XOR           : "(^)",
   OPT_AND           : "(&)",
@@ -137,7 +142,9 @@ OPT_SYMBOL_DICT = {
   OPT_GT  : "(?>)",
   OPT_LTE : "(?<=)",
 
-  OPT_DIV_START  : "(/st)",
-  OPT_DIV_END    : "(/ed)",
+  OPT_DIV_INCLUSIVE_START   : "(/st)",
+  OPT_REM_INCLUSIVE_START   : "(%st)",
+  OPT_DIV_INCLUSIVE_END     : "(/ed)",
+  OPT_REM_INCLUSIVE_END     : "(%ed)",
 
 }

--- a/lib/opt_type.py
+++ b/lib/opt_type.py
@@ -137,4 +137,7 @@ OPT_SYMBOL_DICT = {
   OPT_GT  : "(?>)",
   OPT_LTE : "(?<=)",
 
+  OPT_DIV_START  : "(/st)",
+  OPT_DIV_END    : "(/ed)",
+
 }


### PR DESCRIPTION
[Isssue 57](https://github.com/tancheng/VectorCGRA/issues/57) and [Issue 138](https://github.com/tancheng/VectorCGRA/issues/138).

This PR contains 

* A seperate FU for division, which directly implements division through `/`. (`DivRTL.py`)
* An exclusive and inclusive FU for division (`ExclusiveDivRTL.py` and `InclusiveDiveRTL.py`) I implement the division in a pipelined manner in Verilog, and then wrapper the verilog codes in pymtl. The cycle of multi-cycle FU can be configured by the parameter `latency`. For distributed FU, we can just modify the cycles of exclusive FU to reduce hardware cost.

Besides, I have verified that exclusive and inclusive FUs are synthesizable via Vivado.