### PR TITLE
Add Dockerfile for VectorCGRA

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ $ docker build -t vectorcgra:v1 .
 
 ### Run Docker container
 ```shell
-$ docker run --name mycontainer vectorcgra:v1 &
-$ docker exec -it mycontainer bash
+$ docker run --name myvectorcgra vectorcgra:v1 &
+$ docker exec -it myvectorcgra bash
 ```
 
 ### Run test in Docker container

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ VectorCGRA (vectorizable Coarse-Grained Reconfigurable Accelerator) generator is
 Installation
 --------------------------------------------------------
 
-VectorCGRA should work well on Python 3.7/3.8/3.9/3.10 with the following additional prerequisites:
+VectorCGRA should work well on Python 3.7/3.8/3.9/3.10/3.12 with the following additional prerequisites:
 
  - graphviz, verilator
  - git, Python headers, and libffi
@@ -25,7 +25,7 @@ VectorCGRA should work well on Python 3.7/3.8/3.9/3.10 with the following additi
 
 The steps for installing these prerequisites and VectorCGRA on a fresh Ubuntu
 distribution are shown below. They have been tested with Ubuntu Trusty
-14.04 ~ 20.04.
+14.04 ~ 22.04.
 
 ### Install python3
 
@@ -127,6 +127,34 @@ When you're done testing/developing, you can deactivate the virtualenv::
 
 ```
  % deactivate
+```
+
+Docker
+--------------------------------------------------------
+### Clone VectorCGRA repo
+```shell
+$ mkdir -p ${HOME}/cgra
+$ cd ${HOME}/cgra
+$ git clone https://github.com/tancheng/VectorCGRA.git
+$ cd VectorCGRA/docker/
+```
+
+### Build Docker image
+```shell
+$ docker build -t vectorcgra:v1 .
+```
+
+### Run Docker container
+```shell
+$ docker run --name mycontainer vectorcgra:v1 &
+$ docker exec -it mycontainer bash
+```
+
+### Run test in Docker container
+```shell
+root@host:/# source ${HOME}/venv/bin/activate
+root@host:/# cd ${HOME}/cgra/VectorCGRA/build
+(venv) root@host:~/cgra/VectorCGRA/build# pytest ../tile/test/TileRTL_test.py -xvs --test-verilog --dump-vtb --dump-vcd
 ```
 
 Publication

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,11 +20,10 @@ RUN mkdir ${HOME}/cgra \
     && pip install hypothesis \
     && pip install pytest \
     && pip install py-markdown-table \
-    && pip list \
     && git clone https://github.com/tancheng/VectorCGRA.git \
     && cd VectorCGRA \
     && git submodule update --init \
-    && mkdir -p build && cd build
+    && mkdir -p build
 
 ENV PATH="/root/verilator/bin:$PATH"
 ENV VERILATOR_ROOT=/root/verilator

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,8 +23,11 @@ RUN mkdir ${HOME}/cgra \
     && pip list \
     && git clone https://github.com/tancheng/VectorCGRA.git \
     && cd VectorCGRA \
-    && git submodule update --init
+    && git submodule update --init \
+    && mkdir -p build && cd build
 
-COPY run_docker.bash /script/
+ENV PATH="/root/verilator/bin:$PATH"
+ENV VERILATOR_ROOT=/root/verilator
+ENV PYMTL_VERILATOR_INCLUDE_DIR=/root/verilator/share/verilator/include
 
-CMD ["/bin/bash", "/script/run_docker.bash"]
+CMD ["tail", "-f", "/dev/null"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:22.04
+
+RUN mkdir ${HOME}/cgra \
+    && cd ${HOME}/cgra \
+    && apt-get -y update \
+    && apt-get -y install git \
+    && apt-get -y install python3.10 \
+    && apt-get -y install python3-pip \
+    && apt-get -y install wget \
+    && wget https://github.com/tancheng/pymtl-verilator/raw/master/verilator-travis-4.036.tar.gz \
+    && tar -C ${HOME} -xzf verilator-travis-4.036.tar.gz \
+    && rm -f ${HOME}/verilator-travis-4.036.tar.gz \
+    && apt-get -y install graphviz \
+    && apt-get -y install git libffi-dev \
+    && apt-get -y install python3.10-venv \
+    && python3 -m venv ${HOME}/venv \
+    && pip install py==1.11.0 \
+    && pip install wheel \
+    && pip install -U git+https://github.com/tancheng/pymtl3.1@yo-struct-list-fix \
+    && pip install hypothesis \
+    && pip install pytest \
+    && pip install py-markdown-table \
+    && pip list \
+    && git clone https://github.com/tancheng/VectorCGRA.git \
+    && cd VectorCGRA \
+    && git submodule update --init
+
+COPY run_docker.bash /script/
+
+CMD ["/bin/bash", "/script/run_docker.bash"]

--- a/docker/run_docker.bash
+++ b/docker/run_docker.bash
@@ -1,14 +1,8 @@
 #!/bin/bash
 
-export PATH="${HOME}/verilator/bin:$PATH"
-export VERILATOR_ROOT=${HOME}/verilator
-export PYMTL_VERILATOR_INCLUDE_DIR=${HOME}/verilator/share/verilator/include
 echo ${VERILATOR_ROOT}
 echo ${PYMTL_VERILATOR_INCLUDE_DIR}
 verilator --version
 
-cd ${HOME}/cgra/VectorCGRA
-mkdir -p build && cd build
+cd ${HOME}/cgra/VectorCGRA/build
 source ${HOME}/venv/bin/activate
-
-tail -f /dev/null

--- a/docker/run_docker.bash
+++ b/docker/run_docker.bash
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-echo ${VERILATOR_ROOT}
-echo ${PYMTL_VERILATOR_INCLUDE_DIR}
-verilator --version
-
-cd ${HOME}/cgra/VectorCGRA/build
-source ${HOME}/venv/bin/activate

--- a/docker/run_docker.bash
+++ b/docker/run_docker.bash
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+export PATH="${HOME}/verilator/bin:$PATH"
+export VERILATOR_ROOT=${HOME}/verilator
+export PYMTL_VERILATOR_INCLUDE_DIR=${HOME}/verilator/share/verilator/include
+echo ${VERILATOR_ROOT}
+echo ${PYMTL_VERILATOR_INCLUDE_DIR}
+verilator --version
+
+cd ${HOME}/cgra/VectorCGRA
+mkdir -p build && cd build
+source ${HOME}/venv/bin/activate
+
+tail -f /dev/null


### PR DESCRIPTION
`Dockerfile` can help users to build image themselves and keep minimal size image, currently 986M, don't need download the large image.

For now, this Dockerfile is for VectorCGRA, will add other contents for Flow and Mapper for UI&backend integration based on this.

_New image build by Dockerfile:_
![image](https://github.com/user-attachments/assets/07afa8dd-c894-4e7e-bff4-51f019dcc599)

_Before:_
![image](https://github.com/user-attachments/assets/ab3c543f-9aef-454e-9400-952921ffd23e)
