### PR TITLE
Provide more prologue counters for ctrl_mem and crossbars

### DIFF
--- a/cgra/test/CgraRTL_fir_test.py
+++ b/cgra/test/CgraRTL_fir_test.py
@@ -506,7 +506,7 @@ def test_homogeneous_4x4_fir(cmdline_opts):
                                                                       [FuOutType(0), FuOutType(0), FuOutType(0), FuOutType(0),
                                                                        FuOutType(0), FuOutType(0), FuOutType(0), FuOutType(0)]))),
           IntraCgraPktType(0, 1,
-                           payload = CgraPayloadType(CMD_CONFIG_PROLOGUE_ROUTING_CROSSBAR, ctrl_addr = 0,
+                           payload = CgraPayloadType(CMD_CONFIG_PROLOGUE_ROUTING_CROSSBAR, ctrl_addr = 1,
                                                      ctrl = CtrlType(routing_xbar_outport = [
                                                         TileInType(2), TileInType(0), TileInType(0), TileInType(0),
                                                         TileInType(0), TileInType(0), TileInType(0), TileInType(0)]),

--- a/fu/flexible/FlexibleFuRTL.py
+++ b/fu/flexible/FlexibleFuRTL.py
@@ -21,9 +21,16 @@ from ...lib.util.common import *
 
 class FlexibleFuRTL(Component):
 
-  def construct(s, DataType, PredicateType, CtrlType,
-                num_inports, num_outports, data_mem_size,
-                num_tiles, FuList, exec_lantency = {}):
+  def construct(s,
+                DataType,
+                PredicateType,
+                CtrlType,
+                num_inports,
+                num_outports,
+                data_mem_size,
+                num_tiles,
+                FuList,
+                exec_lantency = {}):
 
     # Constant
     num_entries = 2

--- a/noc/CrossbarRTL.py
+++ b/noc/CrossbarRTL.py
@@ -138,14 +138,16 @@ class CrossbarRTL(Component):
     def update_prologue_counter_next():
       # Nested-loop to update the prologue counter, to avoid dynamic indexing to
       # work-around Yosys issue: https://github.com/tancheng/VectorCGRA/issues/148
-      for i in range(num_inports):
-        s.prologue_counter_next[s.ctrl_addr_inport][i] @= s.prologue_counter[s.ctrl_addr_inport][i]
-        for j in range(num_outports):
-          if s.recv_opt.rdy & \
-             (s.in_dir[j] > 0) & \
-             (s.in_dir_local[j] == i) & \
-             (s.prologue_counter[s.ctrl_addr_inport][i] < s.prologue_count_wire[s.ctrl_addr_inport][i]):
-            s.prologue_counter_next[s.ctrl_addr_inport][i] @= s.prologue_counter[s.ctrl_addr_inport][i] + 1
+      for addr in range(ctrl_mem_size):
+        for i in range(num_inports):
+          s.prologue_counter_next[addr][i] @= s.prologue_counter[addr][i]
+          for j in range(num_outports):
+            if s.recv_opt.rdy & \
+              (s.in_dir[j] > 0) & \
+              (s.in_dir_local[j] == i) & \
+              (addr == s.ctrl_addr_inport) & \
+              (s.prologue_counter[addr][i] < s.prologue_count_wire[addr][i]):
+              s.prologue_counter_next[addr][i] @= s.prologue_counter[addr][i] + 1
 
     @update
     def update_prologue_allowing_vector():

--- a/noc/test/CrossbarRTL_test.py
+++ b/noc/test/CrossbarRTL_test.py
@@ -26,6 +26,8 @@ class TestHarness(Component):
                 num_inports, num_outports, src_data, src_routing,
                 sink_out):
 
+    num_tiles = 1
+    ctrl_mem_size = 6
     s.num_inports  = num_inports
     s.num_outports = num_outports
 
@@ -36,12 +38,13 @@ class TestHarness(Component):
                   for i in range(num_outports)]
 
     s.dut = CrossbarUnit(DataType, PredicateType, CtrlType, num_inports,
-                         num_outports, 1)
+                         num_outports, num_tiles, ctrl_mem_size)
 
     for i in range(num_inports):
       s.src_data[i].send //= s.dut.recv_data[i]
       s.dut.send_data[i] //= s.sink_out[i].recv
-      s.dut.prologue_count_inport[i] //= 0
+      for addr in range(ctrl_mem_size):
+        s.dut.prologue_count_inport[addr][i] //= 0
     s.src_opt.send //= s.dut.recv_opt
 
     for i in range(num_outports):

--- a/tile/TileRTL.py
+++ b/tile/TileRTL.py
@@ -76,17 +76,21 @@ class TileRTL(Component):
                               num_fu_inports, num_fu_outports,
                               data_mem_size, num_tiles, FuList)
     s.const_mem = ConstQueueDynamicRTL(DataType, ctrl_mem_size)
-    s.routing_crossbar = CrossbarRTL(DataType, PredicateType,
+    s.routing_crossbar = CrossbarRTL(DataType,
+                                     PredicateType,
                                      CtrlSignalType,
                                      num_routing_xbar_inports,
                                      num_routing_xbar_outports,
                                      num_tiles,
+                                     ctrl_mem_size,
                                      num_tile_outports)
-    s.fu_crossbar = CrossbarRTL(DataType, PredicateType,
+    s.fu_crossbar = CrossbarRTL(DataType,
+                                PredicateType,
                                 CtrlSignalType,
                                 num_fu_xbar_inports,
                                 num_fu_xbar_outports,
                                 num_tiles,
+                                ctrl_mem_size,
                                 num_tile_outports)
     s.register_cluster = \
         RegisterClusterRTL(DataType, CtrlSignalType, num_fu_inports,
@@ -139,14 +143,19 @@ class TileRTL(Component):
     # Constant queue.
     s.element.recv_const //= s.const_mem.send_const
 
+    # Ctrl address port.
+    s.routing_crossbar.ctrl_addr_inport //= s.ctrl_mem.ctrl_addr_outport
+    s.fu_crossbar.ctrl_addr_inport //= s.ctrl_mem.ctrl_addr_outport
+
     # Prologue port.
     s.element.prologue_count_inport //= s.ctrl_mem.prologue_count_outport_fu
-    for i in range(num_routing_xbar_inports):
-      s.routing_crossbar.prologue_count_inport[i] //= \
-          s.ctrl_mem.prologue_count_outport_routing_crossbar[i]
-    for i in range(num_fu_xbar_inports):
-      s.fu_crossbar.prologue_count_inport[i] //= \
-          s.ctrl_mem.prologue_count_outport_fu_crossbar[i]
+    for addr in range(ctrl_mem_size):
+      for i in range(num_routing_xbar_inports):
+        s.routing_crossbar.prologue_count_inport[addr][i] //= \
+            s.ctrl_mem.prologue_count_outport_routing_crossbar[addr][i]
+      for i in range(num_fu_xbar_inports):
+        s.fu_crossbar.prologue_count_inport[addr][i] //= \
+            s.ctrl_mem.prologue_count_outport_fu_crossbar[addr][i]
 
     for i in range(len(FuList)):
       if FuList[i] == MemUnitRTL:


### PR DESCRIPTION
More prologue counters enable flexible control of FUs, and routing/FU xbars.
 - Before this PR, one tile has only one counter, which lacks support for different operations in time domain

This PR can close https://github.com/tancheng/VectorCGRA/issues/27 and https://github.com/tancheng/VectorCGRA/issues/156

TODO in this PR:
 - ~~Refactor `phi_const` to avoid retrieving data from the input channel: https://github.com/tancheng/VectorCGRA/blob/a32783d338c280db0ad89f6b6c6cc3f95c211a35/fu/single/PhiRTL.py#L110~~
   - We are not able to do this, as the `phi_const` or `first` cannot/shouldn't be seen by the `routing_xbar`