### PR TITLE
Speedup synthesize

### DIFF
--- a/cgra/test/CgraTemplateRTL_test.py
+++ b/cgra/test/CgraTemplateRTL_test.py
@@ -183,8 +183,8 @@ def test_cgra_universal(cmdline_opts, paramCGRA = None):
   ctrl_mem_size = paramCGRA.configMemSize if paramCGRA != None else 6
   width = paramCGRA.rows if paramCGRA != None else 2
   height = paramCGRA.columns if paramCGRA != None else 2
-  data_mem_size_global = 512
-  data_mem_size_per_bank = 32
+  data_mem_size_global = 16
+  data_mem_size_per_bank = 4
   num_banks_per_cgra = 2
   num_cgra_columns = 4
   num_cgra_rows = 1

--- a/noc/CrossbarRTL.py
+++ b/noc/CrossbarRTL.py
@@ -139,13 +139,13 @@ class CrossbarRTL(Component):
       # Nested-loop to update the prologue counter, to avoid dynamic indexing to
       # work-around Yosys issue: https://github.com/tancheng/VectorCGRA/issues/148
       for i in range(num_inports):
-        s.prologue_counter_next[s.ctrl_addr_inport][i] @= s.prologue_counter[s.ctrl_addr_inport][i]
+        s.prologue_counter_next[0][i] @= s.prologue_counter[s.ctrl_addr_inport][i]
         for j in range(num_outports):
           if s.recv_opt.rdy & \
              (s.in_dir[j] > 0) & \
              (s.in_dir_local[j] == i) & \
              (s.prologue_counter[s.ctrl_addr_inport][i] < s.prologue_count_wire[s.ctrl_addr_inport][i]):
-            s.prologue_counter_next[s.ctrl_addr_inport][i] @= s.prologue_counter[s.ctrl_addr_inport][i] + 1
+            s.prologue_counter_next[0][i] @= s.prologue_counter[s.ctrl_addr_inport][i] + 1
 
     @update
     def update_prologue_allowing_vector():


### PR DESCRIPTION
1. Smaller mem size
2. Hardcode left hand index to `0`

Finally speedup synthesize to complete in `355.5`s.

--- If only smaller mem size, cannot complete even over `10,000`s.
--- If smaller mem size, and hardcode BOTH left hand and right hand as 0, completed in `332.7`s.

<img width="1600" height="1017" alt="image" src="https://github.com/user-attachments/assets/a9d5b2bc-f35c-459f-bb6d-747ee3def270" />

<img width="438" height="492" alt="image" src="https://github.com/user-attachments/assets/245852c3-cc9a-408d-8fe2-1032ea2755f0" />

