### PR TITLE
Implementation of context switch module and its testcase.

### DIFF
--- a/lib/cmd_type.py
+++ b/lib/cmd_type.py
@@ -31,6 +31,7 @@ CMD_LOAD_RESPONSE                    = 11
 CMD_STORE_REQUEST                    = 12
 CMD_CONST                            = 13
 CMD_COMPLETE                         = 14
+CMD_RESUME                           = 15
 
 CMD_SYMBOL_DICT = {
   CMD_LAUNCH:                           "(LAUNCH_KERNEL)",
@@ -47,6 +48,7 @@ CMD_SYMBOL_DICT = {
   CMD_LOAD_RESPONSE:                    "(LOAD_RESPONSE)",
   CMD_STORE_REQUEST:                    "(STORE_REQUEST)",
   CMD_CONST:                            "(CONST_DATA)",
-  CMD_COMPLETE:                         "(COMPLETE_EXECUTION)"
+  CMD_COMPLETE:                         "(COMPLETE_EXECUTION)",
+  CMD_RESUME:                           "(RESUME_EXECUTION)"
 }
 

--- a/lib/cmd_type.py
+++ b/lib/cmd_type.py
@@ -14,7 +14,7 @@ from pymtl3 import *
 
 # Total number of commands that are supported/recognized by controller.
 # Needs to be updated once more commands are added/supported.
-NUM_CMDS = 14
+NUM_CMDS = 16
 
 CMD_LAUNCH                           = 0
 CMD_PAUSE                            = 1

--- a/lib/status_type.py
+++ b/lib/status_type.py
@@ -1,0 +1,22 @@
+#=========================================================================
+# status_type.py
+#=========================================================================
+# Status types for CGRA.
+#
+# Author : Yufei Yang
+#   Date : Aug 13, 2025
+
+#-------------------------------------------------------------------------
+# Constants
+#-------------------------------------------------------------------------
+
+from pymtl3 import *
+
+# Total number of status.
+# Needs to be updated once more status are added/supported.
+NUM_STATUS = 4
+
+STATUS_IDLE                       = 0
+STATUS_RUNNING                    = 1
+STATUS_RESUMING                   = 2
+STATUS_PAUSING                    = 3

--- a/mem/ctrl/ContextSwitchRTL.py
+++ b/mem/ctrl/ContextSwitchRTL.py
@@ -22,7 +22,7 @@ class ContextSwitchRTL(Component):
     # Constant
     CmdType = mk_bits(clog2(NUM_CMDS))
     StatusType = mk_bits(clog2(NUM_STATUS))
-    DataType = mk_bits(clog2(data_nbits))
+    DataType = mk_bits(data_nbits)
     OptType = mk_bits(clog2(NUM_OPTS))
 
     # Interface
@@ -51,11 +51,12 @@ class ContextSwitchRTL(Component):
       s.is_executing_phi @= (s.recv_opt == OPT_PHI_CONST)
 
       # Updates progress_out with the recorded progress.
-      s.progress_out @= s.progress_reg
       if (~s.progress_is_null & s.is_resuming & s.is_executing_phi):
         s.progress_out_vld @= 1
+        s.progress_out @= s.progress_reg
       else:
         s.progress_out_vld @= 0
+        s.progress_out @= DataType(0)
 
     @update_ff
     def update_regs():

--- a/mem/ctrl/ContextSwitchRTL.py
+++ b/mem/ctrl/ContextSwitchRTL.py
@@ -28,6 +28,8 @@ class ContextSwitchRTL(Component):
     # Interface
     s.recv_cmd = InPort(CmdType)
     s.recv_cmd_vld = InPort(b1)
+    # We don't need recv_opt_vld as progress_in_vld is enough 
+    # to tell whether the opt is valid.
     s.recv_opt = InPort(OptType)
     s.progress_in = InPort(DataType)
     s.progress_in_vld = InPort(b1)

--- a/mem/ctrl/ContextSwitchRTL.py
+++ b/mem/ctrl/ContextSwitchRTL.py
@@ -1,0 +1,95 @@
+"""
+==========================================================================
+ContextSwitchRTL.py
+==========================================================================
+Records/resumes progress (itertion) for functional unit (FU).
+
+Author : Yufei Yang
+  Date : Aug 11, 2025
+"""
+from pymtl3.stdlib.primitive import *
+from ...lib.basic.val_rdy.ifcs import ValRdyRecvIfcRTL as RecvIfcRTL
+from ...lib.basic.val_rdy.ifcs import ValRdySendIfcRTL as SendIfcRTL
+from ...lib.cmd_type import *
+from ...lib.opt_type import *
+from ...lib.util.common import *
+
+class ContextSwitchRTL(Component):
+
+  def construct(s, CgraPayloadType, DataType, CtrlType, num_status = 3):
+
+    # Constant
+    StatusType = mk_bits(clog2(num_status))
+
+    # Interface
+    s.recv_cmd = RecvIfcRTL(CgraPayloadType)
+    s.recv_opt = RecvIfcRTL(CtrlType)
+    s.progress_in = RecvIfcRTL(DataType)
+    s.progress_out = SendIfcRTL(DataType)
+   
+    # Component
+    s.progress_reg = Reg(DataType)
+    s.status_reg = Reg(StatusType)
+    #s.condition = Wire(Bits3)
+    # How to create a wire that can be bit sliced?
+    s.condition_2 = Wire(b1)
+    s.condition_1 = Wire(b1)
+    s.condition_0 = Wire(b1)
+
+    @update
+    def update_msg():
+      # Update condition.
+      # condition = 3'b111 (3'd7): Records the progress.
+      # condition = 3'b001 (3'd1): Resumes the progress.
+      s.condition_2 @= (s.progress_reg.out == DataType(0))
+      s.condition_1 @= (s.status_reg.out == StatusType(3))
+      s.condition_0 @= s.recv_opt.val & (s.recv_opt.msg.operation == OPT_PHI_CONST)
+
+      # Updates recv_opt.
+      s.recv_opt.rdy @= 1
+
+      # Updates recv_cmd
+      s.recv_cmd.rdy @= 1
+
+      # Updates the status register.
+      if (s.recv_cmd.val & (s.recv_cmd.msg.cmd == CMD_PAUSE)):
+        # PAUSING: 2'b11
+        s.status_reg.in_ @= StatusType(3)
+      elif (s.recv_cmd.val & (s.recv_cmd.msg.cmd == CMD_RESUME)):
+        # RESUMING: 2'b10
+        s.status_reg.in_ @= StatusType(2)
+      elif (s.recv_cmd.val & (s.recv_cmd.msg.cmd == CMD_LAUNCH)):
+        # RUNNING: 2'b00
+        s.status_reg.in_ @= StatusType(0)
+      else:
+        # Keeps unchanged.
+        s.status_reg.in_ @= s.status_reg.out
+
+      # Updates the progress register.
+      s.progress_in.rdy @= 1
+      if (s.condition_2 & s.condition_1 & s.condition_0 & s.progress_in.val):
+        # Records the progress.
+        s.progress_reg.in_ @= s.progress_in.msg
+      elif (~s.condition_2 & ~s.condition_1 & s.condition_0 & s.progress_in.val & s.progress_out.rdy):
+        # Resumes the progress.
+        s.progress_reg.in_ @= DataType(0)
+      else:
+        # Keeps the progress.
+        s.progress_reg.in_ @= s.progress_reg.out
+
+      # Updates progress_out
+      if (~s.condition_2 & ~s.condition_1 & s.condition_0 & s.progress_in.val & s.progress_out.rdy):
+        s.progress_out.val @= 1
+        s.progress_out.msg @= s.progress_reg.out
+      else:
+        s.progress_out.val @= 1
+        s.progress_out.msg @= DataType(0,0)
+
+  def line_trace(s):
+    recv_cmd_str = f'|| recv_cmd.val: {s.recv_cmd.val} | recv_cmd.msg.cmd: {s.recv_cmd.msg.cmd} | recv_cmd.rdy: {s.recv_cmd.rdy} '
+    recv_opt_str = f'|| recv_opt.val: {s.recv_opt.val} | recv_opt.msg: {s.recv_opt.msg} | recv_opt.rdy: {s.recv_opt.rdy} '
+    progress_in_str = f'|| progress_in.val: {s.progress_in.val} | progress_in.msg: {s.progress_in.msg} | progress_in.rdy: {s.progress_in.rdy} '
+    progress_out_str = f'|| progress_out.val: {s.progress_out.val} | progress_out.msg: {s.progress_out.msg} | progress_out.rdy: {s.progress_out.rdy} '
+    register_content_str = f'|| progress_reg: {s.progress_reg.out} | status_reg: {s.status_reg.out} '
+    condition_str = f'|| condition: {s.condition_2}{s.condition_1}{s.condition_0} '
+    return recv_cmd_str + recv_opt_str + progress_in_str + progress_out_str + register_content_str + condition_str

--- a/mem/ctrl/ContextSwitchRTL.py
+++ b/mem/ctrl/ContextSwitchRTL.py
@@ -12,84 +12,79 @@ from ...lib.basic.val_rdy.ifcs import ValRdyRecvIfcRTL as RecvIfcRTL
 from ...lib.basic.val_rdy.ifcs import ValRdySendIfcRTL as SendIfcRTL
 from ...lib.cmd_type import *
 from ...lib.opt_type import *
+from ...lib.status_type import *
 from ...lib.util.common import *
 
 class ContextSwitchRTL(Component):
 
-  def construct(s, CgraPayloadType, DataType, CtrlType, num_status = 3):
+  def construct(s, data_nbits):
 
     # Constant
-    StatusType = mk_bits(clog2(num_status))
+    CmdType = mk_bits(clog2(NUM_CMDS))
+    StatusType = mk_bits(clog2(NUM_STATUS))
+    DataType = mk_bits(clog2(data_nbits))
+    OptType = mk_bits(clog2(NUM_OPTS))
 
     # Interface
-    s.recv_cmd = RecvIfcRTL(CgraPayloadType)
-    s.recv_opt = RecvIfcRTL(CtrlType)
-    s.progress_in = RecvIfcRTL(DataType)
-    s.progress_out = SendIfcRTL(DataType)
+    s.recv_cmd = InPort(CmdType)
+    s.recv_cmd_vld = InPort(b1)
+    s.recv_opt = InPort(OptType)
+    s.progress_in = InPort(DataType)
+    s.progress_in_vld = InPort(b1)
+    s.progress_out = OutPort(DataType)
+    s.progress_out_vld = OutPort(b1)
    
     # Component
-    s.progress_reg = Reg(DataType)
-    s.status_reg = Reg(StatusType)
-    #s.condition = Wire(Bits3)
-    # How to create a wire that can be bit sliced?
-    s.condition_2 = Wire(b1)
-    s.condition_1 = Wire(b1)
-    s.condition_0 = Wire(b1)
+    s.progress_reg = Wire(DataType)
+    s.status_reg = Wire(StatusType)
+    s.progress_is_null = Wire(b1)
+    s.is_pausing = Wire(b1)
+    s.is_resuming = Wire(b1)
+    s.is_executing_phi = Wire(b1)
 
     @update
     def update_msg():
       # Update condition.
-      # condition = 3'b111 (3'd7): Records the progress.
-      # condition = 3'b001 (3'd1): Resumes the progress.
-      s.condition_2 @= (s.progress_reg.out == DataType(0))
-      s.condition_1 @= (s.status_reg.out == StatusType(3))
-      s.condition_0 @= s.recv_opt.val & (s.recv_opt.msg.operation == OPT_PHI_CONST)
+      s.progress_is_null @= (s.progress_reg == DataType(0))
+      s.is_pausing @= (s.status_reg == STATUS_PAUSING)
+      s.is_resuming @= (s.status_reg == STATUS_RESUMING)
+      s.is_executing_phi @= (s.recv_opt == OPT_PHI_CONST)
 
-      # Updates recv_opt.
-      s.recv_opt.rdy @= 1
-
-      # Updates recv_cmd
-      s.recv_cmd.rdy @= 1
-
-      # Updates the status register.
-      if (s.recv_cmd.val & (s.recv_cmd.msg.cmd == CMD_PAUSE)):
-        # PAUSING: 2'b11
-        s.status_reg.in_ @= StatusType(3)
-      elif (s.recv_cmd.val & (s.recv_cmd.msg.cmd == CMD_RESUME)):
-        # RESUMING: 2'b10
-        s.status_reg.in_ @= StatusType(2)
-      elif (s.recv_cmd.val & (s.recv_cmd.msg.cmd == CMD_LAUNCH)):
-        # RUNNING: 2'b00
-        s.status_reg.in_ @= StatusType(0)
+      # Updates progress_out with the recorded progress.
+      s.progress_out @= s.progress_reg
+      if (~s.progress_is_null & s.is_resuming & s.is_executing_phi):
+        s.progress_out_vld @= 1
       else:
-        # Keeps unchanged.
-        s.status_reg.in_ @= s.status_reg.out
+        s.progress_out_vld @= 0
+
+    @update_ff
+    def update_regs():
+      # Updates the status register.
+      if (s.recv_cmd_vld & (s.recv_cmd == CMD_PAUSE)):
+        s.status_reg <<= STATUS_PAUSING
+      elif (s.recv_cmd_vld & (s.recv_cmd == CMD_RESUME)):
+        s.status_reg <<= STATUS_RESUMING
+      elif (s.recv_cmd_vld & (s.recv_cmd == CMD_LAUNCH)):
+        s.status_reg <<= STATUS_RUNNING
+      else:
+        s.status_reg <<= s.status_reg
 
       # Updates the progress register.
-      s.progress_in.rdy @= 1
-      if (s.condition_2 & s.condition_1 & s.condition_0 & s.progress_in.val):
+      if (s.progress_is_null & s.is_pausing & s.is_executing_phi & s.progress_in_vld):
         # Records the progress.
-        s.progress_reg.in_ @= s.progress_in.msg
-      elif (~s.condition_2 & ~s.condition_1 & s.condition_0 & s.progress_in.val & s.progress_out.rdy):
-        # Resumes the progress.
-        s.progress_reg.in_ @= DataType(0)
+        s.progress_reg <<= s.progress_in
+      elif (~s.progress_is_null & s.is_resuming & s.is_executing_phi):
+        # Clears the progress at next clock cycle.
+        s.progress_reg <<= DataType(0)
       else:
         # Keeps the progress.
-        s.progress_reg.in_ @= s.progress_reg.out
-
-      # Updates progress_out
-      if (~s.condition_2 & ~s.condition_1 & s.condition_0 & s.progress_in.val & s.progress_out.rdy):
-        s.progress_out.val @= 1
-        s.progress_out.msg @= s.progress_reg.out
-      else:
-        s.progress_out.val @= 1
-        s.progress_out.msg @= DataType(0,0)
+        s.progress_reg <<= s.progress_reg
 
   def line_trace(s):
-    recv_cmd_str = f'|| recv_cmd.val: {s.recv_cmd.val} | recv_cmd.msg.cmd: {s.recv_cmd.msg.cmd} | recv_cmd.rdy: {s.recv_cmd.rdy} '
-    recv_opt_str = f'|| recv_opt.val: {s.recv_opt.val} | recv_opt.msg: {s.recv_opt.msg} | recv_opt.rdy: {s.recv_opt.rdy} '
-    progress_in_str = f'|| progress_in.val: {s.progress_in.val} | progress_in.msg: {s.progress_in.msg} | progress_in.rdy: {s.progress_in.rdy} '
-    progress_out_str = f'|| progress_out.val: {s.progress_out.val} | progress_out.msg: {s.progress_out.msg} | progress_out.rdy: {s.progress_out.rdy} '
-    register_content_str = f'|| progress_reg: {s.progress_reg.out} | status_reg: {s.status_reg.out} '
-    condition_str = f'|| condition: {s.condition_2}{s.condition_1}{s.condition_0} '
+    recv_cmd_str = f'|| recv_cmd_vld: {s.recv_cmd_vld} | recv_cmd: {s.recv_cmd} '
+    recv_opt_str = f'|| recv_opt: {s.recv_opt} '
+    progress_in_str = f'|| progress_in_vld: {s.progress_in_vld} | progress_in: {s.progress_in} '
+    progress_out_str = f'|| progress_out_vld: {s.progress_out_vld} | progress_out: {s.progress_out} '
+    register_content_str = f'|| progress_reg: {s.progress_reg} | status_reg: {s.status_reg} '
+    condition_str = f'|| condition: {s.progress_is_null}{s.is_pausing}{s.is_executing_phi} '
     return recv_cmd_str + recv_opt_str + progress_in_str + progress_out_str + register_content_str + condition_str

--- a/mem/ctrl/test/ContextSwitchRTL_test.py
+++ b/mem/ctrl/test/ContextSwitchRTL_test.py
@@ -1,0 +1,162 @@
+"""
+==========================================================================
+ContextSwitchRTL_test.py
+==========================================================================
+Test cases for context switch module.
+
+Author : Yufei Yang
+  Date : Aug 11, 2025
+"""
+from ..ContextSwitchRTL import ContextSwitchRTL
+from ....lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL
+from ....lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
+from ....lib.cmd_type import *
+from ....lib.messages import *
+from ....lib.opt_type import *
+
+#-------------------------------------------------------------------------
+# Test harness
+#-------------------------------------------------------------------------
+
+class TestHarness(Component):
+
+  def construct(s, Module, DataType, CtrlType, CgraPayloadType, src_cmds, src_opts, src_progress_in, sink_progress_out, num_status = 3):
+
+    s.src_cmds = TestSrcRTL(CgraPayloadType, src_cmds)
+    s.src_opts = TestSrcRTL(CtrlType, src_opts)
+    s.src_progress_in = TestSrcRTL(DataType, src_progress_in)
+    s.sink_progress_out = TestSinkRTL(DataType, sink_progress_out)
+
+    s.context_switch = Module(CgraPayloadType, DataType, CtrlType, num_status)
+
+    s.src_cmds.send //= s.context_switch.recv_cmd
+    s.src_opts.send //= s.context_switch.recv_opt
+    s.src_progress_in.send //= s.context_switch.progress_in
+    s.sink_progress_out.recv //= s.context_switch.progress_out
+
+  def done(s):
+    return s.src_cmds.done() and s.src_opts.done() and \
+        s.src_progress_in.done() and s.sink_progress_out.done()
+
+  def line_trace(s):
+    return s.context_switch.line_trace()
+
+def run_sim(test_harness, max_cycles = 20):
+  test_harness.elaborate()
+  test_harness.apply(DefaultPassGroup())
+  #test_harness.sim_reset()
+
+  # Run simulation
+
+  ncycles = 0
+  print()
+  print("{}:{}".format(ncycles, test_harness.line_trace()))
+  while not test_harness.done() and ncycles < max_cycles:
+    test_harness.sim_tick()
+    ncycles += 1
+    print( "{}:{}".format(ncycles, test_harness.line_trace()))
+
+  # Check timeout
+
+  assert ncycles < max_cycles
+
+  test_harness.sim_tick()
+  test_harness.sim_tick()
+  test_harness.sim_tick()
+
+def test():
+  Module = ContextSwitchRTL
+  DataType = mk_data(16, 1)
+  ctrl_mem_size = 16
+  num_fu_inports = 2
+  num_fu_outports = 2
+  num_tile_inports = 4
+  num_tile_outports = 4
+
+  data_mem_size_global = 16
+  addr_nbits = clog2(data_mem_size_global)
+  DataAddrType = mk_bits(addr_nbits)
+  num_registers_per_reg_bank = 16
+
+  CtrlAddrType = mk_bits(clog2(ctrl_mem_size))
+  CtrlType = mk_ctrl(num_fu_inports,
+                     num_fu_outports,
+                     num_tile_inports,
+                     num_tile_outports,
+                     num_registers_per_reg_bank)
+
+  CgraPayloadType = mk_cgra_payload(DataType,
+                                    DataAddrType,
+                                    CtrlType,
+                                    CtrlAddrType)
+
+  src_cmds = [# Simulates the PAUSE command to record the progress.
+              CgraPayloadType(CMD_PAUSE),
+              # Simulates some random commands.
+              CgraPayloadType(CMD_CONFIG_TOTAL_CTRL_COUNT),
+              CgraPayloadType(CMD_CONFIG_COUNT_PER_ITER),
+              CgraPayloadType(CMD_CONFIG_CTRL_LOWER_BOUND),
+              # Simulates the RESUME command to recover the progress.
+              CgraPayloadType(CMD_RESUME),
+              # Simulates some random commands.
+              CgraPayloadType(CMD_CONFIG_TOTAL_CTRL_COUNT),
+              CgraPayloadType(CMD_CONFIG_COUNT_PER_ITER),
+              CgraPayloadType(CMD_CONFIG_CTRL_LOWER_BOUND)
+              ]
+  src_opts = [
+              # Simulates some random operations.
+              CtrlType(OPT_NAH),
+              CtrlType(OPT_NAH),
+              # Simulates the clock cycle when FU executes PHI_CONST
+              # for the first time after receiving PAUSE command.
+              CtrlType(OPT_PHI_CONST),
+              # Simulates some random operations.
+              CtrlType(OPT_NAH),
+              CtrlType(OPT_NAH),
+              CtrlType(OPT_NAH),
+              # Simulates the clock cycle when FU executes PHI_CONST
+              # for the first time after receiving RESUME command.
+              CtrlType(OPT_PHI_CONST),
+              # Simulates some random operations.
+              CtrlType(OPT_NAH)
+              ]
+  src_progress_in = [
+                     # Simulates some random FU's outputs.
+                     DataType(0,1),
+                     DataType(0,1),
+                     # Simulates the output iteration (progress) of FU
+                     # when executing OPT_PHI_CONST for the first time
+                     # after receiving PAUSE command.
+                     DataType(1234,1),
+                     # Simulates some random FU's outputs.
+                     DataType(0,1),
+                     DataType(0,1),
+                     DataType(0,1),
+                     DataType(0,1),
+                     DataType(0,1)
+                     ]
+  sink_progress_out = [
+                       DataType(0,0),
+                       DataType(0,0),
+                       DataType(0,0),
+                       DataType(0,0),
+                       DataType(0,0),
+                       DataType(0,0),
+                       # ContextSiwtch module should output the progress
+                       # when executing OPT_PHI_CONST for the first time
+                       # after receiving RESUME command.
+                       DataType(1234,1),
+                       DataType(0,0)
+                      ]
+
+  th = TestHarness(Module, 
+                   DataType, 
+                   CtrlType, 
+                   CgraPayloadType, 
+                   src_cmds, 
+                   src_opts, 
+                   src_progress_in, 
+                   sink_progress_out, 
+                   num_status = 3)
+
+  run_sim(th)


### PR DESCRIPTION
Here is the RTL design for `ContextSwitchUnitRTL` (blue) and how it is connected with other components within the tile:
<img width="725" height="512" alt="1754989291471" src="https://github.com/user-attachments/assets/0f1314f6-21d9-476b-8a4c-b441688c74e8" />

The inports include:
- `recv_pkt_from_controller`: Receives `PAUSE` and `RESUME` commands from the controller.
- `recv_opt`: Receives ctrl signals from ctrl mem.
- `progess_in`: `iteration` (progress) from the `PHI_const` operation executed in `functional unit (FU)`.

The outports include:
- `progess_out`: `iteration` that replaces the `PHI_const` operation of `FU`, so as to resume the progress.
- `progess_out_vld`: Indicates when the replacment occurs.

The functionalities include:
- Updates the status register `statusReg`: It will be set to `PAUSING=2'b11` after receiving `PAUSE` command, reset to `RESUMING=2'b10` after receiving `RESUME` command, otherwise in `RUNNING=2'b00`.
- Updates the progess register `progressReg`: This register has a default value `0`, indicating no progress stored. 
    - It will register the `progess_in` at the rising edge of the incoming clock cycle, only if: (1) current cycle is PHI_const operation `(recv_opt=PHI_const)`; (2) currently under PAUSING status `(statusReg=2'b11)`; (3) progressReg has nothing `progess_out=0`.
    - It will be reset to `0` at the rising edge of the incoming clock cycle, only if: (1) current cycle is PHI_const operation `(recv_opt=PHI_const)`; (2) currently under RESUMING status `(statusReg=2'b10)`; (3) progressReg has something`progess_out != 0`.
        - This condition is also used for setting the signal `progess_out.predicate=1`, indicating the output progress is true. Tile can detect the predicate bit and replace the output `iteration` of `FU` with the valid `progess_out`. At next cycle,  `progess_out` is set back to 0, which means the module is ready for the next `PAUSE` command.
    - It will keep the progress unchanged in other cases.