### PR TITLE
Issue #55: Supplement the output predicate for contextswitch module.

### DIFF
--- a/mem/ctrl/ContextSwitchRTL.py
+++ b/mem/ctrl/ContextSwitchRTL.py
@@ -34,10 +34,10 @@ class ContextSwitchRTL(Component):
     s.recv_opt = InPort(OptType)
     s.progress_in = InPort(DataType)
     s.progress_out = OutPort(DataType)
-    # s.reset_fu_output_predicate is used for resetting FU's output predicate to 0.
+    # s.overwrite_fu_output_predicate is used for resetting FU's output predicate to 0.
     # During the PAUSING status, FU's output when executing PHI_CONST operation
     # should always have predicate=0, so as to avoid initiating new iteration.
-    s.reset_fu_output_predicate = OutPort(b1)
+    s.overwrite_fu_output_predicate = OutPort(b1)
    
     # Component
     s.progress_reg = Wire(DataType)
@@ -65,9 +65,9 @@ class ContextSwitchRTL(Component):
       # status should always have predicate=0, as it will be broadcasted 
       # to all other operations in this iteration via the dataflow. 
       if (s.is_pausing & s.is_executing_phi):
-        s.reset_fu_output_predicate @= 1
+        s.overwrite_fu_output_predicate @= 1
       else:
-        s.reset_fu_output_predicate @= 0
+        s.overwrite_fu_output_predicate @= 0
 
     @update_ff
     def update_regs():
@@ -97,7 +97,7 @@ class ContextSwitchRTL(Component):
     recv_opt_str = f'|| recv_opt: {s.recv_opt} '
     progress_in_str = f'|| progress_in: {s.progress_in} '
     progress_out_str = f'|| progress_out: {s.progress_out} '
-    reset_fu_output_predicate_str = f'|| reset_fu_output_predicate: {s.reset_fu_output_predicate} '
+    overwrite_fu_output_predicate_str = f'|| overwrite_fu_output_predicate: {s.overwrite_fu_output_predicate} '
     register_content_str = f'|| progress_reg: {s.progress_reg} | status_reg: {s.status_reg} '
     condition_str = f'|| condition: {s.progress_is_null}{s.is_pausing}{s.is_executing_phi} '
-    return recv_cmd_str + recv_opt_str + progress_in_str + progress_out_str + reset_fu_output_predicate_str + register_content_str + condition_str
+    return recv_cmd_str + recv_opt_str + progress_in_str + progress_out_str + overwrite_fu_output_predicate_str + register_content_str + condition_str

--- a/mem/ctrl/test/ContextSwitchRTL_test.py
+++ b/mem/ctrl/test/ContextSwitchRTL_test.py
@@ -21,43 +21,38 @@ from ....lib.status_type import *
 
 class TestHarness(Component):
 
-  def construct(s, Module, data_nbits, src_cmds, src_opts, src_progress_in, sink_progress_out, sink_progress_out_vld, sink_predicate):
+  def construct(s, Module, data_nbits, src_cmds, src_opts, src_progress_in, sink_progress_out, sink_reset_fu_output_predicate):
     
     CmdType = mk_bits(clog2(NUM_CMDS))
     StatusType = mk_bits(clog2(NUM_STATUS))
-    DataType = mk_bits(data_nbits)
+    DataType = mk_data(data_nbits)
     ValidType = mk_bits(1)
     OptType = mk_bits(clog2(NUM_OPTS))
-    PredicateType = mk_bits(1)
 
     s.src_cmds = TestSrcRTL(CmdType, src_cmds)
     s.src_opts = TestSrcRTL(OptType, src_opts)
     s.src_progress_in = TestSrcRTL(DataType, src_progress_in)
     s.sink_progress_out = TestSinkRTL(DataType, sink_progress_out)
-    s.sink_progress_out_vld = TestSinkRTL(ValidType, sink_progress_out_vld)
-    s.sink_predicate = TestSinkRTL(PredicateType, sink_predicate)
+    s.sink_reset_fu_output_predicate = TestSinkRTL(ValidType, sink_reset_fu_output_predicate)
 
     s.context_switch = Module(data_nbits)
 
     @update
     def issue_inputs():
+      s.context_switch.recv_cmd_vld @= s.src_cmds.send.val
       s.context_switch.recv_cmd @= s.src_cmds.send.msg
       s.src_cmds.send.rdy @= 1
-      s.context_switch.recv_cmd_vld @= 1
       s.context_switch.recv_opt @= s.src_opts.send.msg
       s.src_opts.send.rdy @= 1
       s.context_switch.progress_in @= s.src_progress_in.send.msg
       s.src_progress_in.send.rdy @= 1
-      s.context_switch.progress_in_vld @= 1
       s.sink_progress_out.recv.val @= 1
       s.sink_progress_out.recv.msg @= s.context_switch.progress_out
-      s.sink_progress_out_vld.recv.val @= 1
-      s.sink_progress_out_vld.recv.msg @= s.context_switch.progress_out_vld
-      s.sink_predicate.recv.val @= 1
-      s.sink_predicate.recv.msg @= s.context_switch.predicate
+      s.sink_reset_fu_output_predicate.recv.val @= 1
+      s.sink_reset_fu_output_predicate.recv.msg @= s.context_switch.reset_fu_output_predicate
 
   def done(s):
-    return s.src_cmds.done() and s.src_opts.done() and s.src_progress_in.done() and s.sink_progress_out.done() and s.sink_progress_out_vld.done() and s.sink_predicate.done()
+    return s.src_cmds.done() and s.src_opts.done() and s.src_progress_in.done() and s.sink_progress_out.done() and s.sink_reset_fu_output_predicate.done()
 
   def line_trace(s):
     return s.context_switch.line_trace()
@@ -89,7 +84,7 @@ def test():
   Module = ContextSwitchRTL
   data_nbits = 16
   CmdType = mk_bits(clog2(NUM_CMDS))
-  DataType = mk_bits(data_nbits)
+  DataType = mk_data(data_nbits)
   OptType = mk_bits(clog2(NUM_OPTS))
 
   src_cmds = [# Assumes that tile receives the PAUSE command at clock cycle 1.
@@ -124,57 +119,46 @@ def test():
               ]
   src_progress_in = [
                      # A fake progress "4321", should not be recorded.
-                     DataType(4321),
+                     DataType(4321, 1),
                      # Some random FU's outputs.
-                     DataType(0),
+                     DataType(0, 0),
                      # The target progress (loop iteration) 
                      # output by FU when executing PHI_CONST for 
                      # the first time after receiving PAUSE command.
                      # Should be recorded to progress register at the rising
                      # edge of clock cycle 4
-                     DataType(1234),
+                     DataType(1234, 1),
                      # Some random FU's outputs.
-                     DataType(0),
-                     DataType(0),
-                     DataType(0),
-                     DataType(0),
-                     DataType(0)
+                     DataType(0, 0),
+                     DataType(0, 0),
+                     DataType(0, 0),
+                     DataType(0, 0),
+                     DataType(0, 0)
                      ]
   sink_progress_out = [
-                       DataType(0),
-                       DataType(0),
-                       DataType(0),
-                       DataType(0),
-                       DataType(0),
-                       DataType(0),
+                       DataType(0, 0),
+                       DataType(0, 0),
+                       DataType(0, 0),
+                       DataType(0, 0),
+                       DataType(0, 0),
+                       DataType(0, 0),
                        # ContextSiwtch module should output the target progress
                        # when executing PHI_CONST for the first time after
                        # receiving RESUME command.
-                       DataType(1234),
-                       DataType(0)
+                       DataType(1234, 1),
+                       DataType(0, 0)
                       ]
-  sink_progress_out_vld = [
-                          0,
-                          0,
-                          0,
-                          0,
-                          0,
-                          0,
-                          # The output progress is valid duing clock cycle 7
-                          1,
-                          0
-                          ]
-  sink_predicate = [
-                    1,
-                    1,
-                    # clock cycle 3 has predicate=0, as in the PAUSING status and executing the PHI_CONST.
-                    0,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1
-                    ]
+  sink_reset_fu_output_predicate = [
+                                    0,
+                                    0,
+                                    # clock cycle 3 has reset_fu_output_predicate = 1, as in the PAUSING status and executing the PHI_CONST.
+                                    1,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                   ]
 
   th = TestHarness(Module, 
                    data_nbits,
@@ -182,7 +166,6 @@ def test():
                    src_opts, 
                    src_progress_in, 
                    sink_progress_out, 
-                   sink_progress_out_vld,
-                   sink_predicate)
+                   sink_reset_fu_output_predicate)
 
   run_sim(th)

--- a/mem/ctrl/test/ContextSwitchRTL_test.py
+++ b/mem/ctrl/test/ContextSwitchRTL_test.py
@@ -21,7 +21,7 @@ from ....lib.status_type import *
 
 class TestHarness(Component):
 
-  def construct(s, Module, data_nbits, src_cmds, src_opts, src_progress_in, sink_progress_out, sink_reset_fu_output_predicate):
+  def construct(s, Module, data_nbits, src_cmds, src_opts, src_progress_in, sink_progress_out, sink_overwrite_fu_output_predicate):
     
     CmdType = mk_bits(clog2(NUM_CMDS))
     StatusType = mk_bits(clog2(NUM_STATUS))
@@ -33,7 +33,7 @@ class TestHarness(Component):
     s.src_opts = TestSrcRTL(OptType, src_opts)
     s.src_progress_in = TestSrcRTL(DataType, src_progress_in)
     s.sink_progress_out = TestSinkRTL(DataType, sink_progress_out)
-    s.sink_reset_fu_output_predicate = TestSinkRTL(ValidType, sink_reset_fu_output_predicate)
+    s.sink_overwrite_fu_output_predicate = TestSinkRTL(ValidType, sink_overwrite_fu_output_predicate)
 
     s.context_switch = Module(data_nbits)
 
@@ -48,11 +48,11 @@ class TestHarness(Component):
       s.src_progress_in.send.rdy @= 1
       s.sink_progress_out.recv.val @= 1
       s.sink_progress_out.recv.msg @= s.context_switch.progress_out
-      s.sink_reset_fu_output_predicate.recv.val @= 1
-      s.sink_reset_fu_output_predicate.recv.msg @= s.context_switch.reset_fu_output_predicate
+      s.sink_overwrite_fu_output_predicate.recv.val @= 1
+      s.sink_overwrite_fu_output_predicate.recv.msg @= s.context_switch.overwrite_fu_output_predicate
 
   def done(s):
-    return s.src_cmds.done() and s.src_opts.done() and s.src_progress_in.done() and s.sink_progress_out.done() and s.sink_reset_fu_output_predicate.done()
+    return s.src_cmds.done() and s.src_opts.done() and s.src_progress_in.done() and s.sink_progress_out.done() and s.sink_overwrite_fu_output_predicate.done()
 
   def line_trace(s):
     return s.context_switch.line_trace()
@@ -148,10 +148,10 @@ def test():
                        DataType(1234, 1),
                        DataType(0, 0)
                       ]
-  sink_reset_fu_output_predicate = [
+  sink_overwrite_fu_output_predicate = [
                                     0,
                                     0,
-                                    # clock cycle 3 has reset_fu_output_predicate = 1, as in the PAUSING status and executing the PHI_CONST.
+                                    # clock cycle 3 has overwrite_fu_output_predicate = 1, as in the PAUSING status and executing the PHI_CONST.
                                     1,
                                     0,
                                     0,
@@ -166,6 +166,6 @@ def test():
                    src_opts, 
                    src_progress_in, 
                    sink_progress_out, 
-                   sink_reset_fu_output_predicate)
+                   sink_overwrite_fu_output_predicate)
 
   run_sim(th)


### PR DESCRIPTION
The output predicate should be performed AND operation with the predicate of FU's output, so as to get the real predicate.
Sets predicate=0 only when in the PAUSING status and everytime executing the PHI_CONST (first node in DFG). Then predicate=0 will be broadcasted to all other operations in this iteration via the dataflow. Consequently, all iterations after progress is recorded all have predicate=0.