### PR TITLE
Update CrossbarRTL_test.py

### DIFF
--- a/noc/test/CrossbarRTL_test.py
+++ b/noc/test/CrossbarRTL_test.py
@@ -42,12 +42,12 @@ class TestHarness(Component):
 
     for i in range(num_inports):
       s.src_data[i].send //= s.dut.recv_data[i]
-      s.dut.send_data[i] //= s.sink_out[i].recv
       for addr in range(ctrl_mem_size):
         s.dut.prologue_count_inport[addr][i] //= 0
     s.src_opt.send //= s.dut.recv_opt
 
     for i in range(num_outports):
+      s.dut.send_data[i] //= s.sink_out[i].recv
       s.dut.crossbar_outport[i] //= s.src_opt.send.msg.routing_xbar_outport[i]
 
   def done(s):


### PR DESCRIPTION
When testing with num_inports = 3 and num_outports = 4, I found that dut.send_data[4].rdy was always 0. After debugging, I discovered that CrossbarRTL_test.py needs to be modified.