### PR TITLE
feat: Enable MemUnit Fusion in Combo FUs

### DIFF
--- a/.github/prompts/openspec-apply.prompt.md
+++ b/.github/prompts/openspec-apply.prompt.md
@@ -1,0 +1,22 @@
+---
+description: Implement an approved OpenSpec change and keep tasks in sync.
+---
+
+$ARGUMENTS
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+
+**Steps**
+Track these steps as TODOs and complete them one by one.
+1. Read `changes/<id>/proposal.md`, `design.md` (if present), and `tasks.md` to confirm scope and acceptance criteria.
+2. Work through tasks sequentially, keeping edits minimal and focused on the requested change.
+3. Confirm completion before updating statuses—make sure every item in `tasks.md` is finished.
+4. Update the checklist after all work is done so each task is marked `- [x]` and reflects reality.
+5. Reference `openspec list` or `openspec show <item>` when additional context is required.
+
+**Reference**
+- Use `openspec show <id> --json --deltas-only` if you need additional context from the proposal while implementing.
+<!-- OPENSPEC:END -->

--- a/.github/prompts/openspec-archive.prompt.md
+++ b/.github/prompts/openspec-archive.prompt.md
@@ -1,0 +1,26 @@
+---
+description: Archive a deployed OpenSpec change and update specs.
+---
+
+$ARGUMENTS
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+
+**Steps**
+1. Determine the change ID to archive:
+   - If this prompt already includes a specific change ID (for example inside a `<ChangeId>` block populated by slash-command arguments), use that value after trimming whitespace.
+   - If the conversation references a change loosely (for example by title or summary), run `openspec list` to surface likely IDs, share the relevant candidates, and confirm which one the user intends.
+   - Otherwise, review the conversation, run `openspec list`, and ask the user which change to archive; wait for a confirmed change ID before proceeding.
+   - If you still cannot identify a single change ID, stop and tell the user you cannot archive anything yet.
+2. Validate the change ID by running `openspec list` (or `openspec show <id>`) and stop if the change is missing, already archived, or otherwise not ready to archive.
+3. Run `openspec archive <id> --yes` so the CLI moves the change and applies spec updates without prompts (use `--skip-specs` only for tooling-only work).
+4. Review the command output to confirm the target specs were updated and the change landed in `changes/archive/`.
+5. Validate with `openspec validate --strict` and inspect with `openspec show <id>` if anything looks off.
+
+**Reference**
+- Use `openspec list` to confirm change IDs before archiving.
+- Inspect refreshed specs with `openspec list --specs` and address any validation issues before handing off.
+<!-- OPENSPEC:END -->

--- a/.github/prompts/openspec-proposal.prompt.md
+++ b/.github/prompts/openspec-proposal.prompt.md
@@ -1,0 +1,26 @@
+---
+description: Scaffold a new OpenSpec change and validate strictly.
+---
+
+$ARGUMENTS
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+- Identify any vague or ambiguous details and ask the necessary follow-up questions before editing files.
+
+**Steps**
+1. Review `openspec/project.md`, run `openspec list` and `openspec list --specs`, and inspect related code or docs (e.g., via `rg`/`ls`) to ground the proposal in current behaviour; note any gaps that require clarification.
+2. Choose a unique verb-led `change-id` and scaffold `proposal.md`, `tasks.md`, and `design.md` (when needed) under `openspec/changes/<id>/`.
+3. Map the change into concrete capabilities or requirements, breaking multi-scope efforts into distinct spec deltas with clear relationships and sequencing.
+4. Capture architectural reasoning in `design.md` when the solution spans multiple systems, introduces new patterns, or demands trade-off discussion before committing to specs.
+5. Draft spec deltas in `changes/<id>/specs/<capability>/spec.md` (one folder per capability) using `## ADDED|MODIFIED|REMOVED Requirements` with at least one `#### Scenario:` per requirement and cross-reference related capabilities when relevant.
+6. Draft `tasks.md` as an ordered list of small, verifiable work items that deliver user-visible progress, include validation (tests, tooling), and highlight dependencies or parallelizable work.
+7. Validate with `openspec validate <id> --strict` and resolve every issue before sharing the proposal.
+
+**Reference**
+- Use `openspec show <id> --json --deltas-only` or `openspec show <spec> --type spec` to inspect details when validation fails.
+- Search existing requirements with `rg -n "Requirement:|Scenario:" openspec/specs` before writing new ones.
+- Explore the codebase with `rg <keyword>`, `ls`, or direct file reads so proposals align with current implementation realities.
+<!-- OPENSPEC:END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+<!-- OPENSPEC:START -->
+# OpenSpec Instructions
+
+These instructions are for AI assistants working in this project.
+
+Always open `@/openspec/AGENTS.md` when the request:
+- Mentions planning or proposals (words like proposal, spec, change, plan)
+- Introduces new capabilities, breaking changes, architecture shifts, or big performance/security work
+- Sounds ambiguous and you need the authoritative spec before coding
+
+Use `@/openspec/AGENTS.md` to learn:
+- How to create and apply change proposals
+- Spec format and conventions
+- Project structure and guidelines
+
+Keep this managed block so 'openspec update' can refresh the instructions.
+
+<!-- OPENSPEC:END -->

--- a/fu/basic/FourCombo.py
+++ b/fu/basic/FourCombo.py
@@ -118,13 +118,46 @@ class FourCombo(Component):
 
     @update
     def update_mem():
-      s.to_mem_waddr.val   @= b1(0)
-      s.to_mem_wdata.val   @= b1(0)
-      s.to_mem_wdata.msg   @= s.const_zero
-      s.to_mem_waddr.msg   @= AddrType(0)
-      s.to_mem_raddr.msg   @= AddrType(0)
-      s.to_mem_raddr.val   @= b1(0)
-      s.from_mem_rdata.rdy @= b1(0)
+      # Propagate memory interfaces from internal FUs using OR logic.
+      # This enables MemUnitRTL to be fused with other operations.
+      # Non-memory FUs tie their ports to 0, so OR-ing is effectively a passthrough.
+      s.to_mem_raddr.val @= s.Fu0.to_mem_raddr.val | s.Fu1.to_mem_raddr.val | s.Fu2.to_mem_raddr.val | s.Fu3.to_mem_raddr.val
+      s.to_mem_raddr.msg @= AddrType(zext(s.Fu0.to_mem_raddr.msg, AddrType) |
+                                     zext(s.Fu1.to_mem_raddr.msg, AddrType) |
+                                     zext(s.Fu2.to_mem_raddr.msg, AddrType) |
+                                     zext(s.Fu3.to_mem_raddr.msg, AddrType))
+      s.Fu0.to_mem_raddr.rdy @= s.to_mem_raddr.rdy
+      s.Fu1.to_mem_raddr.rdy @= s.to_mem_raddr.rdy
+      s.Fu2.to_mem_raddr.rdy @= s.to_mem_raddr.rdy
+      s.Fu3.to_mem_raddr.rdy @= s.to_mem_raddr.rdy
+
+      s.from_mem_rdata.rdy @= s.Fu0.from_mem_rdata.rdy | s.Fu1.from_mem_rdata.rdy | s.Fu2.from_mem_rdata.rdy | s.Fu3.from_mem_rdata.rdy
+      s.Fu0.from_mem_rdata.val @= s.from_mem_rdata.val
+      s.Fu1.from_mem_rdata.val @= s.from_mem_rdata.val
+      s.Fu2.from_mem_rdata.val @= s.from_mem_rdata.val
+      s.Fu3.from_mem_rdata.val @= s.from_mem_rdata.val
+      s.Fu0.from_mem_rdata.msg @= s.from_mem_rdata.msg
+      s.Fu1.from_mem_rdata.msg @= s.from_mem_rdata.msg
+      s.Fu2.from_mem_rdata.msg @= s.from_mem_rdata.msg
+      s.Fu3.from_mem_rdata.msg @= s.from_mem_rdata.msg
+
+      s.to_mem_waddr.val @= s.Fu0.to_mem_waddr.val | s.Fu1.to_mem_waddr.val | s.Fu2.to_mem_waddr.val | s.Fu3.to_mem_waddr.val
+      s.to_mem_waddr.msg @= AddrType(zext(s.Fu0.to_mem_waddr.msg, AddrType) |
+                                     zext(s.Fu1.to_mem_waddr.msg, AddrType) |
+                                     zext(s.Fu2.to_mem_waddr.msg, AddrType) |
+                                     zext(s.Fu3.to_mem_waddr.msg, AddrType))
+      s.Fu0.to_mem_waddr.rdy @= s.to_mem_waddr.rdy
+      s.Fu1.to_mem_waddr.rdy @= s.to_mem_waddr.rdy
+      s.Fu2.to_mem_waddr.rdy @= s.to_mem_waddr.rdy
+      s.Fu3.to_mem_waddr.rdy @= s.to_mem_waddr.rdy
+
+      s.to_mem_wdata.val @= s.Fu0.to_mem_wdata.val | s.Fu1.to_mem_wdata.val | s.Fu2.to_mem_wdata.val | s.Fu3.to_mem_wdata.val
+      s.to_mem_wdata.msg.payload @= s.Fu0.to_mem_wdata.msg.payload | s.Fu1.to_mem_wdata.msg.payload | s.Fu2.to_mem_wdata.msg.payload | s.Fu3.to_mem_wdata.msg.payload
+      s.to_mem_wdata.msg.predicate @= s.Fu0.to_mem_wdata.msg.predicate | s.Fu1.to_mem_wdata.msg.predicate | s.Fu2.to_mem_wdata.msg.predicate | s.Fu3.to_mem_wdata.msg.predicate
+      s.Fu0.to_mem_wdata.rdy @= s.to_mem_wdata.rdy
+      s.Fu1.to_mem_wdata.rdy @= s.to_mem_wdata.rdy
+      s.Fu2.to_mem_wdata.rdy @= s.to_mem_wdata.rdy
+      s.Fu3.to_mem_wdata.rdy @= s.to_mem_wdata.rdy
 
     @update
     def update_send_to_controller():

--- a/fu/basic/ThreeCombo.py
+++ b/fu/basic/ThreeCombo.py
@@ -99,13 +99,39 @@ class ThreeCombo(Component):
 
     @update
     def update_mem():
-      s.to_mem_waddr.val   @= b1(0)
-      s.to_mem_wdata.val   @= b1(0)
-      s.to_mem_wdata.msg   @= s.const_zero
-      s.to_mem_waddr.msg   @= AddrType(0)
-      s.to_mem_raddr.msg   @= AddrType(0)
-      s.to_mem_raddr.val   @= b1(0)
-      s.from_mem_rdata.rdy @= b1(0)
+      # Propagate memory interfaces from internal FUs using OR logic.
+      # This enables MemUnitRTL to be fused with other operations.
+      # Non-memory FUs tie their ports to 0, so OR-ing is effectively a passthrough.
+      s.to_mem_raddr.val @= s.Fu0.to_mem_raddr.val | s.Fu1.to_mem_raddr.val | s.Fu2.to_mem_raddr.val
+      s.to_mem_raddr.msg @= AddrType(zext(s.Fu0.to_mem_raddr.msg, AddrType) |
+                                     zext(s.Fu1.to_mem_raddr.msg, AddrType) |
+                                     zext(s.Fu2.to_mem_raddr.msg, AddrType))
+      s.Fu0.to_mem_raddr.rdy @= s.to_mem_raddr.rdy
+      s.Fu1.to_mem_raddr.rdy @= s.to_mem_raddr.rdy
+      s.Fu2.to_mem_raddr.rdy @= s.to_mem_raddr.rdy
+
+      s.from_mem_rdata.rdy @= s.Fu0.from_mem_rdata.rdy | s.Fu1.from_mem_rdata.rdy | s.Fu2.from_mem_rdata.rdy
+      s.Fu0.from_mem_rdata.val @= s.from_mem_rdata.val
+      s.Fu1.from_mem_rdata.val @= s.from_mem_rdata.val
+      s.Fu2.from_mem_rdata.val @= s.from_mem_rdata.val
+      s.Fu0.from_mem_rdata.msg @= s.from_mem_rdata.msg
+      s.Fu1.from_mem_rdata.msg @= s.from_mem_rdata.msg
+      s.Fu2.from_mem_rdata.msg @= s.from_mem_rdata.msg
+
+      s.to_mem_waddr.val @= s.Fu0.to_mem_waddr.val | s.Fu1.to_mem_waddr.val | s.Fu2.to_mem_waddr.val
+      s.to_mem_waddr.msg @= AddrType(zext(s.Fu0.to_mem_waddr.msg, AddrType) |
+                                     zext(s.Fu1.to_mem_waddr.msg, AddrType) |
+                                     zext(s.Fu2.to_mem_waddr.msg, AddrType))
+      s.Fu0.to_mem_waddr.rdy @= s.to_mem_waddr.rdy
+      s.Fu1.to_mem_waddr.rdy @= s.to_mem_waddr.rdy
+      s.Fu2.to_mem_waddr.rdy @= s.to_mem_waddr.rdy
+
+      s.to_mem_wdata.val @= s.Fu0.to_mem_wdata.val | s.Fu1.to_mem_wdata.val | s.Fu2.to_mem_wdata.val
+      s.to_mem_wdata.msg.payload @= s.Fu0.to_mem_wdata.msg.payload | s.Fu1.to_mem_wdata.msg.payload | s.Fu2.to_mem_wdata.msg.payload
+      s.to_mem_wdata.msg.predicate @= s.Fu0.to_mem_wdata.msg.predicate | s.Fu1.to_mem_wdata.msg.predicate | s.Fu2.to_mem_wdata.msg.predicate
+      s.Fu0.to_mem_wdata.rdy @= s.to_mem_wdata.rdy
+      s.Fu1.to_mem_wdata.rdy @= s.to_mem_wdata.rdy
+      s.Fu2.to_mem_wdata.rdy @= s.to_mem_wdata.rdy
 
     @update
     def update_send_to_controller():

--- a/fu/basic/TwoPrlCombo.py
+++ b/fu/basic/TwoPrlCombo.py
@@ -92,13 +92,32 @@ class TwoPrlCombo(Component):
 
     @update
     def update_mem():
-      s.to_mem_waddr.val   @= b1(0)
-      s.to_mem_wdata.val   @= b1(0)
-      s.to_mem_wdata.msg   @= s.const_zero
-      s.to_mem_waddr.msg   @= AddrType(0)
-      s.to_mem_raddr.msg   @= AddrType(0)
-      s.to_mem_raddr.val   @= b1(0)
-      s.from_mem_rdata.rdy @= b1(0)
+      # Propagate memory interfaces from internal FUs using OR logic.
+      # This enables MemUnitRTL to be fused with other operations.
+      # Non-memory FUs tie their ports to 0, so OR-ing is effectively a passthrough.
+      s.to_mem_raddr.val @= s.Fu0.to_mem_raddr.val | s.Fu1.to_mem_raddr.val
+      s.to_mem_raddr.msg @= AddrType(zext(s.Fu0.to_mem_raddr.msg, AddrType) |
+                                     zext(s.Fu1.to_mem_raddr.msg, AddrType))
+      s.Fu0.to_mem_raddr.rdy @= s.to_mem_raddr.rdy
+      s.Fu1.to_mem_raddr.rdy @= s.to_mem_raddr.rdy
+
+      s.from_mem_rdata.rdy @= s.Fu0.from_mem_rdata.rdy | s.Fu1.from_mem_rdata.rdy
+      s.Fu0.from_mem_rdata.val @= s.from_mem_rdata.val
+      s.Fu1.from_mem_rdata.val @= s.from_mem_rdata.val
+      s.Fu0.from_mem_rdata.msg @= s.from_mem_rdata.msg
+      s.Fu1.from_mem_rdata.msg @= s.from_mem_rdata.msg
+
+      s.to_mem_waddr.val @= s.Fu0.to_mem_waddr.val | s.Fu1.to_mem_waddr.val
+      s.to_mem_waddr.msg @= AddrType(zext(s.Fu0.to_mem_waddr.msg, AddrType) |
+                                     zext(s.Fu1.to_mem_waddr.msg, AddrType))
+      s.Fu0.to_mem_waddr.rdy @= s.to_mem_waddr.rdy
+      s.Fu1.to_mem_waddr.rdy @= s.to_mem_waddr.rdy
+
+      s.to_mem_wdata.val @= s.Fu0.to_mem_wdata.val | s.Fu1.to_mem_wdata.val
+      s.to_mem_wdata.msg.payload @= s.Fu0.to_mem_wdata.msg.payload | s.Fu1.to_mem_wdata.msg.payload
+      s.to_mem_wdata.msg.predicate @= s.Fu0.to_mem_wdata.msg.predicate | s.Fu1.to_mem_wdata.msg.predicate
+      s.Fu0.to_mem_wdata.rdy @= s.to_mem_wdata.rdy
+      s.Fu1.to_mem_wdata.rdy @= s.to_mem_wdata.rdy
 
     @update
     def update_send_to_controller():

--- a/fu/basic/TwoSeqCombo.py
+++ b/fu/basic/TwoSeqCombo.py
@@ -89,13 +89,32 @@ class TwoSeqCombo(Component):
 
     @update
     def update_mem():
-      s.to_mem_waddr.val   @= b1(0)
-      s.to_mem_wdata.val   @= b1(0)
-      s.to_mem_wdata.msg   @= s.const_zero
-      s.to_mem_waddr.msg   @= AddrType(0)
-      s.to_mem_raddr.msg   @= AddrType(0)
-      s.to_mem_raddr.val   @= b1(0)
-      s.from_mem_rdata.rdy @= b1(0)
+      # Propagate memory interfaces from internal FUs using OR logic.
+      # This enables MemUnitRTL to be fused with other operations.
+      # Non-memory FUs tie their ports to 0, so OR-ing is effectively a passthrough.
+      s.to_mem_raddr.val @= s.Fu0.to_mem_raddr.val | s.Fu1.to_mem_raddr.val
+      s.to_mem_raddr.msg @= AddrType(zext(s.Fu0.to_mem_raddr.msg, AddrType) |
+                                     zext(s.Fu1.to_mem_raddr.msg, AddrType))
+      s.Fu0.to_mem_raddr.rdy @= s.to_mem_raddr.rdy
+      s.Fu1.to_mem_raddr.rdy @= s.to_mem_raddr.rdy
+
+      s.from_mem_rdata.rdy @= s.Fu0.from_mem_rdata.rdy | s.Fu1.from_mem_rdata.rdy
+      s.Fu0.from_mem_rdata.val @= s.from_mem_rdata.val
+      s.Fu1.from_mem_rdata.val @= s.from_mem_rdata.val
+      s.Fu0.from_mem_rdata.msg @= s.from_mem_rdata.msg
+      s.Fu1.from_mem_rdata.msg @= s.from_mem_rdata.msg
+
+      s.to_mem_waddr.val @= s.Fu0.to_mem_waddr.val | s.Fu1.to_mem_waddr.val
+      s.to_mem_waddr.msg @= AddrType(zext(s.Fu0.to_mem_waddr.msg, AddrType) |
+                                     zext(s.Fu1.to_mem_waddr.msg, AddrType))
+      s.Fu0.to_mem_waddr.rdy @= s.to_mem_waddr.rdy
+      s.Fu1.to_mem_waddr.rdy @= s.to_mem_waddr.rdy
+
+      s.to_mem_wdata.val @= s.Fu0.to_mem_wdata.val | s.Fu1.to_mem_wdata.val
+      s.to_mem_wdata.msg.payload @= s.Fu0.to_mem_wdata.msg.payload | s.Fu1.to_mem_wdata.msg.payload
+      s.to_mem_wdata.msg.predicate @= s.Fu0.to_mem_wdata.msg.predicate | s.Fu1.to_mem_wdata.msg.predicate
+      s.Fu0.to_mem_wdata.rdy @= s.to_mem_wdata.rdy
+      s.Fu1.to_mem_wdata.rdy @= s.to_mem_wdata.rdy
 
     @update
     def update_send_to_controller():

--- a/fu/double/SeqAdderMemRTL.py
+++ b/fu/double/SeqAdderMemRTL.py
@@ -1,0 +1,54 @@
+"""
+==========================================================================
+SeqAdderMemRTL.py
+==========================================================================
+Adder followed by MemUnit in sequential for CGRA tile.
+This enables fused address-computation + load operations.
+
+Author : Cheng Tan
+  Date : December 2, 2024
+"""
+
+from pymtl3 import *
+from ..basic.TwoSeqCombo import TwoSeqCombo
+from ..single.AdderRTL import AdderRTL
+from ..single.MemUnitRTL import MemUnitRTL
+from ...lib.opt_type import *
+
+class SeqAdderMemRTL(TwoSeqCombo):
+
+  # Class attribute to indicate this combo FU contains MemUnitRTL
+  contains_mem_unit = True
+
+  def construct(s, DataType, CtrlType,
+                num_inports, num_outports,
+                data_mem_size, ctrl_mem_size = 4,
+                data_bitwidth = 32):
+
+    super(SeqAdderMemRTL, s).construct(DataType, CtrlType,
+                                       AdderRTL, MemUnitRTL,
+                                       num_inports, num_outports,
+                                       data_mem_size, ctrl_mem_size,
+                                       data_bitwidth = data_bitwidth)
+
+    FuInType = mk_bits(clog2(num_inports + 1))
+
+    @update
+    def update_opt():
+
+      s.Fu0.recv_opt.msg @= s.recv_opt.msg
+      s.Fu1.recv_opt.msg @= s.recv_opt.msg
+  
+      s.Fu0.recv_opt.msg.fu_in[0] @= 1
+      s.Fu0.recv_opt.msg.fu_in[1] @= 2
+      s.Fu1.recv_opt.msg.fu_in[0] @= 1
+      s.Fu1.recv_opt.msg.fu_in[1] @= 2
+
+      if s.recv_opt.msg.operation == OPT_ADD_CONST_LD:
+        # First add the constant offset to the address, then load
+        s.Fu0.recv_opt.msg.operation @= OPT_ADD_CONST
+        s.Fu1.recv_opt.msg.operation @= OPT_LD
+      else:
+        # Indicates no computation should happen on this fused FU.
+        s.Fu0.recv_opt.msg.operation @= OPT_START
+        s.Fu1.recv_opt.msg.operation @= OPT_START

--- a/fu/double/test/SeqAdderMemRTL_test.py
+++ b/fu/double/test/SeqAdderMemRTL_test.py
@@ -1,0 +1,147 @@
+"""
+==========================================================================
+SeqAdderMemRTL_test.py
+==========================================================================
+Test cases for Adder + MemUnit sequential combo functional unit.
+This tests the fix for issue #214: MemUnit is not fusible.
+
+Author : Cheng Tan
+  Date : December 2, 2024
+"""
+
+from pymtl3 import *
+from ..SeqAdderMemRTL import SeqAdderMemRTL
+from ....lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL
+from ....lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
+from ....lib.messages import *
+from ....lib.opt_type import *
+
+#-------------------------------------------------------------------------
+# Test harness
+#-------------------------------------------------------------------------
+
+class TestHarness(Component):
+
+  def construct(s, FunctionUnit, DataType, CtrlType,
+                num_inports, num_outports, data_mem_size,
+                src0_msgs, src1_msgs, src2_msgs,
+                ctrl_msgs, sink_msgs, mem_data):
+
+    AddrType = mk_bits(clog2(data_mem_size))
+
+    s.src_in0   = TestSrcRTL(DataType, src0_msgs)
+    s.src_in1   = TestSrcRTL(DataType, src1_msgs)
+    s.src_in2   = TestSrcRTL(DataType, src2_msgs)
+    s.src_const = TestSrcRTL(DataType, src1_msgs)  # const for add offset
+    s.src_opt   = TestSrcRTL(CtrlType, ctrl_msgs)
+    s.sink_out  = TestSinkRTL(DataType, sink_msgs)
+
+    s.dut = FunctionUnit(DataType, CtrlType,
+                         num_inports, num_outports, data_mem_size)
+
+    # Simple memory model for testing
+    s.mem_data = mem_data
+    s.mem_raddr_pending = Wire(1)
+    s.mem_raddr_val = Wire(AddrType)
+
+    connect(s.src_in0.send,    s.dut.recv_in[0])
+    connect(s.src_in1.send,    s.dut.recv_in[1])
+    connect(s.src_in2.send,    s.dut.recv_in[2])
+    connect(s.src_const.send,  s.dut.recv_const)
+    connect(s.src_opt.send,    s.dut.recv_opt)
+    connect(s.dut.send_out[0], s.sink_out.recv)
+
+    @update
+    def mem_read_logic():
+      # Memory read address handling
+      s.dut.to_mem_raddr.rdy @= 1
+      s.dut.from_mem_rdata.val @= s.mem_raddr_pending
+      s.dut.from_mem_rdata.msg @= DataType(0, 1)
+      if s.mem_raddr_pending:
+        addr = int(s.mem_raddr_val)
+        if addr < len(s.mem_data):
+          s.dut.from_mem_rdata.msg @= s.mem_data[addr]
+
+    @update_ff
+    def mem_read_pending():
+      if s.reset:
+        s.mem_raddr_pending <<= 0
+        s.mem_raddr_val <<= AddrType(0)
+      else:
+        if s.dut.to_mem_raddr.val & s.dut.to_mem_raddr.rdy:
+          s.mem_raddr_pending <<= 1
+          s.mem_raddr_val <<= s.dut.to_mem_raddr.msg
+        elif s.dut.from_mem_rdata.val & s.dut.from_mem_rdata.rdy:
+          s.mem_raddr_pending <<= 0
+
+    @update
+    def mem_write_logic():
+      # Memory write (not used in this test but need to connect)
+      s.dut.to_mem_waddr.rdy @= 1
+      s.dut.to_mem_wdata.rdy @= 1
+
+  def done(s):
+    return s.src_in0.done() and s.src_opt.done() and s.sink_out.done()
+
+  def line_trace(s):
+    return s.dut.line_trace()
+
+def run_sim(test_harness, max_cycles=50):
+  test_harness.elaborate()
+  test_harness.apply(DefaultPassGroup())
+  test_harness.sim_reset()
+
+  # Run simulation
+  ncycles = 0
+  print()
+  print("{}:{}".format(ncycles, test_harness.line_trace()))
+  while not test_harness.done() and ncycles < max_cycles:
+    test_harness.sim_tick()
+    ncycles += 1
+    print("{}:{}".format(ncycles, test_harness.line_trace()))
+
+  # Check timeout
+  assert ncycles < max_cycles
+
+  test_harness.sim_tick()
+  test_harness.sim_tick()
+  test_harness.sim_tick()
+
+def test_adder_mem_basic():
+  """
+  Test that memory interfaces are correctly propagated through combo FU.
+  This verifies the fix for issue #214.
+  """
+  FU            = SeqAdderMemRTL
+  DataType      = mk_data(16, 1)
+  PredicateType = mk_predicate(1, 1)
+  num_inports   = 4
+  num_outports  = 2
+  CtrlType      = mk_ctrl(num_inports, num_outports)
+  data_mem_size = 16
+
+  # Memory contents: mem[0]=100, mem[1]=200, mem[2]=300, mem[3]=400
+  mem_data = [DataType(100, 1), DataType(200, 1), DataType(300, 1), DataType(400, 1)]
+
+  # Test: Add base address + const offset, then load
+  # Input: base_addr=0, const_offset=2 -> should load mem[2]=300
+  src_in0  = [DataType(0, 1)]  # Base address
+  src_in1  = [DataType(2, 1)]  # Const offset (will be added)
+  src_in2  = [DataType(0, 1)]  # Unused
+
+  # Expected: addr = 0 + 2 = 2, mem[2] = 300
+  sink_out = [DataType(300, 1)]
+  src_opt  = [CtrlType(OPT_ADD_CONST_LD)]
+
+  th = TestHarness(FU, DataType, CtrlType,
+                   num_inports, num_outports, data_mem_size,
+                   src_in0, src_in1, src_in2, src_opt,
+                   sink_out, mem_data)
+  run_sim(th)
+
+def test_contains_mem_unit_attribute():
+  """
+  Test that the SeqAdderMemRTL has the contains_mem_unit attribute set.
+  """
+  assert hasattr(SeqAdderMemRTL, 'contains_mem_unit')
+  assert SeqAdderMemRTL.contains_mem_unit == True

--- a/openspec/AGENTS.md
+++ b/openspec/AGENTS.md
@@ -1,0 +1,456 @@
+# OpenSpec Instructions
+
+Instructions for AI coding assistants using OpenSpec for spec-driven development.
+
+## TL;DR Quick Checklist
+
+- Search existing work: `openspec spec list --long`, `openspec list` (use `rg` only for full-text search)
+- Decide scope: new capability vs modify existing capability
+- Pick a unique `change-id`: kebab-case, verb-led (`add-`, `update-`, `remove-`, `refactor-`)
+- Scaffold: `proposal.md`, `tasks.md`, `design.md` (only if needed), and delta specs per affected capability
+- Write deltas: use `## ADDED|MODIFIED|REMOVED|RENAMED Requirements`; include at least one `#### Scenario:` per requirement
+- Validate: `openspec validate [change-id] --strict` and fix issues
+- Request approval: Do not start implementation until proposal is approved
+
+## Three-Stage Workflow
+
+### Stage 1: Creating Changes
+Create proposal when you need to:
+- Add features or functionality
+- Make breaking changes (API, schema)
+- Change architecture or patterns  
+- Optimize performance (changes behavior)
+- Update security patterns
+
+Triggers (examples):
+- "Help me create a change proposal"
+- "Help me plan a change"
+- "Help me create a proposal"
+- "I want to create a spec proposal"
+- "I want to create a spec"
+
+Loose matching guidance:
+- Contains one of: `proposal`, `change`, `spec`
+- With one of: `create`, `plan`, `make`, `start`, `help`
+
+Skip proposal for:
+- Bug fixes (restore intended behavior)
+- Typos, formatting, comments
+- Dependency updates (non-breaking)
+- Configuration changes
+- Tests for existing behavior
+
+**Workflow**
+1. Review `openspec/project.md`, `openspec list`, and `openspec list --specs` to understand current context.
+2. Choose a unique verb-led `change-id` and scaffold `proposal.md`, `tasks.md`, optional `design.md`, and spec deltas under `openspec/changes/<id>/`.
+3. Draft spec deltas using `## ADDED|MODIFIED|REMOVED Requirements` with at least one `#### Scenario:` per requirement.
+4. Run `openspec validate <id> --strict` and resolve any issues before sharing the proposal.
+
+### Stage 2: Implementing Changes
+Track these steps as TODOs and complete them one by one.
+1. **Read proposal.md** - Understand what's being built
+2. **Read design.md** (if exists) - Review technical decisions
+3. **Read tasks.md** - Get implementation checklist
+4. **Implement tasks sequentially** - Complete in order
+5. **Confirm completion** - Ensure every item in `tasks.md` is finished before updating statuses
+6. **Update checklist** - After all work is done, set every task to `- [x]` so the list reflects reality
+7. **Approval gate** - Do not start implementation until the proposal is reviewed and approved
+
+### Stage 3: Archiving Changes
+After deployment, create separate PR to:
+- Move `changes/[name]/` → `changes/archive/YYYY-MM-DD-[name]/`
+- Update `specs/` if capabilities changed
+- Use `openspec archive <change-id> --skip-specs --yes` for tooling-only changes (always pass the change ID explicitly)
+- Run `openspec validate --strict` to confirm the archived change passes checks
+
+## Before Any Task
+
+**Context Checklist:**
+- [ ] Read relevant specs in `specs/[capability]/spec.md`
+- [ ] Check pending changes in `changes/` for conflicts
+- [ ] Read `openspec/project.md` for conventions
+- [ ] Run `openspec list` to see active changes
+- [ ] Run `openspec list --specs` to see existing capabilities
+
+**Before Creating Specs:**
+- Always check if capability already exists
+- Prefer modifying existing specs over creating duplicates
+- Use `openspec show [spec]` to review current state
+- If request is ambiguous, ask 1–2 clarifying questions before scaffolding
+
+### Search Guidance
+- Enumerate specs: `openspec spec list --long` (or `--json` for scripts)
+- Enumerate changes: `openspec list` (or `openspec change list --json` - deprecated but available)
+- Show details:
+  - Spec: `openspec show <spec-id> --type spec` (use `--json` for filters)
+  - Change: `openspec show <change-id> --json --deltas-only`
+- Full-text search (use ripgrep): `rg -n "Requirement:|Scenario:" openspec/specs`
+
+## Quick Start
+
+### CLI Commands
+
+```bash
+# Essential commands
+openspec list                  # List active changes
+openspec list --specs          # List specifications
+openspec show [item]           # Display change or spec
+openspec validate [item]       # Validate changes or specs
+openspec archive <change-id> [--yes|-y]   # Archive after deployment (add --yes for non-interactive runs)
+
+# Project management
+openspec init [path]           # Initialize OpenSpec
+openspec update [path]         # Update instruction files
+
+# Interactive mode
+openspec show                  # Prompts for selection
+openspec validate              # Bulk validation mode
+
+# Debugging
+openspec show [change] --json --deltas-only
+openspec validate [change] --strict
+```
+
+### Command Flags
+
+- `--json` - Machine-readable output
+- `--type change|spec` - Disambiguate items
+- `--strict` - Comprehensive validation
+- `--no-interactive` - Disable prompts
+- `--skip-specs` - Archive without spec updates
+- `--yes`/`-y` - Skip confirmation prompts (non-interactive archive)
+
+## Directory Structure
+
+```
+openspec/
+├── project.md              # Project conventions
+├── specs/                  # Current truth - what IS built
+│   └── [capability]/       # Single focused capability
+│       ├── spec.md         # Requirements and scenarios
+│       └── design.md       # Technical patterns
+├── changes/                # Proposals - what SHOULD change
+│   ├── [change-name]/
+│   │   ├── proposal.md     # Why, what, impact
+│   │   ├── tasks.md        # Implementation checklist
+│   │   ├── design.md       # Technical decisions (optional; see criteria)
+│   │   └── specs/          # Delta changes
+│   │       └── [capability]/
+│   │           └── spec.md # ADDED/MODIFIED/REMOVED
+│   └── archive/            # Completed changes
+```
+
+## Creating Change Proposals
+
+### Decision Tree
+
+```
+New request?
+├─ Bug fix restoring spec behavior? → Fix directly
+├─ Typo/format/comment? → Fix directly  
+├─ New feature/capability? → Create proposal
+├─ Breaking change? → Create proposal
+├─ Architecture change? → Create proposal
+└─ Unclear? → Create proposal (safer)
+```
+
+### Proposal Structure
+
+1. **Create directory:** `changes/[change-id]/` (kebab-case, verb-led, unique)
+
+2. **Write proposal.md:**
+```markdown
+# Change: [Brief description of change]
+
+## Why
+[1-2 sentences on problem/opportunity]
+
+## What Changes
+- [Bullet list of changes]
+- [Mark breaking changes with **BREAKING**]
+
+## Impact
+- Affected specs: [list capabilities]
+- Affected code: [key files/systems]
+```
+
+3. **Create spec deltas:** `specs/[capability]/spec.md`
+```markdown
+## ADDED Requirements
+### Requirement: New Feature
+The system SHALL provide...
+
+#### Scenario: Success case
+- **WHEN** user performs action
+- **THEN** expected result
+
+## MODIFIED Requirements
+### Requirement: Existing Feature
+[Complete modified requirement]
+
+## REMOVED Requirements
+### Requirement: Old Feature
+**Reason**: [Why removing]
+**Migration**: [How to handle]
+```
+If multiple capabilities are affected, create multiple delta files under `changes/[change-id]/specs/<capability>/spec.md`—one per capability.
+
+4. **Create tasks.md:**
+```markdown
+## 1. Implementation
+- [ ] 1.1 Create database schema
+- [ ] 1.2 Implement API endpoint
+- [ ] 1.3 Add frontend component
+- [ ] 1.4 Write tests
+```
+
+5. **Create design.md when needed:**
+Create `design.md` if any of the following apply; otherwise omit it:
+- Cross-cutting change (multiple services/modules) or a new architectural pattern
+- New external dependency or significant data model changes
+- Security, performance, or migration complexity
+- Ambiguity that benefits from technical decisions before coding
+
+Minimal `design.md` skeleton:
+```markdown
+## Context
+[Background, constraints, stakeholders]
+
+## Goals / Non-Goals
+- Goals: [...]
+- Non-Goals: [...]
+
+## Decisions
+- Decision: [What and why]
+- Alternatives considered: [Options + rationale]
+
+## Risks / Trade-offs
+- [Risk] → Mitigation
+
+## Migration Plan
+[Steps, rollback]
+
+## Open Questions
+- [...]
+```
+
+## Spec File Format
+
+### Critical: Scenario Formatting
+
+**CORRECT** (use #### headers):
+```markdown
+#### Scenario: User login success
+- **WHEN** valid credentials provided
+- **THEN** return JWT token
+```
+
+**WRONG** (don't use bullets or bold):
+```markdown
+- **Scenario: User login**  ❌
+**Scenario**: User login     ❌
+### Scenario: User login      ❌
+```
+
+Every requirement MUST have at least one scenario.
+
+### Requirement Wording
+- Use SHALL/MUST for normative requirements (avoid should/may unless intentionally non-normative)
+
+### Delta Operations
+
+- `## ADDED Requirements` - New capabilities
+- `## MODIFIED Requirements` - Changed behavior
+- `## REMOVED Requirements` - Deprecated features
+- `## RENAMED Requirements` - Name changes
+
+Headers matched with `trim(header)` - whitespace ignored.
+
+#### When to use ADDED vs MODIFIED
+- ADDED: Introduces a new capability or sub-capability that can stand alone as a requirement. Prefer ADDED when the change is orthogonal (e.g., adding "Slash Command Configuration") rather than altering the semantics of an existing requirement.
+- MODIFIED: Changes the behavior, scope, or acceptance criteria of an existing requirement. Always paste the full, updated requirement content (header + all scenarios). The archiver will replace the entire requirement with what you provide here; partial deltas will drop previous details.
+- RENAMED: Use when only the name changes. If you also change behavior, use RENAMED (name) plus MODIFIED (content) referencing the new name.
+
+Common pitfall: Using MODIFIED to add a new concern without including the previous text. This causes loss of detail at archive time. If you aren’t explicitly changing the existing requirement, add a new requirement under ADDED instead.
+
+Authoring a MODIFIED requirement correctly:
+1) Locate the existing requirement in `openspec/specs/<capability>/spec.md`.
+2) Copy the entire requirement block (from `### Requirement: ...` through its scenarios).
+3) Paste it under `## MODIFIED Requirements` and edit to reflect the new behavior.
+4) Ensure the header text matches exactly (whitespace-insensitive) and keep at least one `#### Scenario:`.
+
+Example for RENAMED:
+```markdown
+## RENAMED Requirements
+- FROM: `### Requirement: Login`
+- TO: `### Requirement: User Authentication`
+```
+
+## Troubleshooting
+
+### Common Errors
+
+**"Change must have at least one delta"**
+- Check `changes/[name]/specs/` exists with .md files
+- Verify files have operation prefixes (## ADDED Requirements)
+
+**"Requirement must have at least one scenario"**
+- Check scenarios use `#### Scenario:` format (4 hashtags)
+- Don't use bullet points or bold for scenario headers
+
+**Silent scenario parsing failures**
+- Exact format required: `#### Scenario: Name`
+- Debug with: `openspec show [change] --json --deltas-only`
+
+### Validation Tips
+
+```bash
+# Always use strict mode for comprehensive checks
+openspec validate [change] --strict
+
+# Debug delta parsing
+openspec show [change] --json | jq '.deltas'
+
+# Check specific requirement
+openspec show [spec] --json -r 1
+```
+
+## Happy Path Script
+
+```bash
+# 1) Explore current state
+openspec spec list --long
+openspec list
+# Optional full-text search:
+# rg -n "Requirement:|Scenario:" openspec/specs
+# rg -n "^#|Requirement:" openspec/changes
+
+# 2) Choose change id and scaffold
+CHANGE=add-two-factor-auth
+mkdir -p openspec/changes/$CHANGE/{specs/auth}
+printf "## Why\n...\n\n## What Changes\n- ...\n\n## Impact\n- ...\n" > openspec/changes/$CHANGE/proposal.md
+printf "## 1. Implementation\n- [ ] 1.1 ...\n" > openspec/changes/$CHANGE/tasks.md
+
+# 3) Add deltas (example)
+cat > openspec/changes/$CHANGE/specs/auth/spec.md << 'EOF'
+## ADDED Requirements
+### Requirement: Two-Factor Authentication
+Users MUST provide a second factor during login.
+
+#### Scenario: OTP required
+- **WHEN** valid credentials are provided
+- **THEN** an OTP challenge is required
+EOF
+
+# 4) Validate
+openspec validate $CHANGE --strict
+```
+
+## Multi-Capability Example
+
+```
+openspec/changes/add-2fa-notify/
+├── proposal.md
+├── tasks.md
+└── specs/
+    ├── auth/
+    │   └── spec.md   # ADDED: Two-Factor Authentication
+    └── notifications/
+        └── spec.md   # ADDED: OTP email notification
+```
+
+auth/spec.md
+```markdown
+## ADDED Requirements
+### Requirement: Two-Factor Authentication
+...
+```
+
+notifications/spec.md
+```markdown
+## ADDED Requirements
+### Requirement: OTP Email Notification
+...
+```
+
+## Best Practices
+
+### Simplicity First
+- Default to <100 lines of new code
+- Single-file implementations until proven insufficient
+- Avoid frameworks without clear justification
+- Choose boring, proven patterns
+
+### Complexity Triggers
+Only add complexity with:
+- Performance data showing current solution too slow
+- Concrete scale requirements (>1000 users, >100MB data)
+- Multiple proven use cases requiring abstraction
+
+### Clear References
+- Use `file.ts:42` format for code locations
+- Reference specs as `specs/auth/spec.md`
+- Link related changes and PRs
+
+### Capability Naming
+- Use verb-noun: `user-auth`, `payment-capture`
+- Single purpose per capability
+- 10-minute understandability rule
+- Split if description needs "AND"
+
+### Change ID Naming
+- Use kebab-case, short and descriptive: `add-two-factor-auth`
+- Prefer verb-led prefixes: `add-`, `update-`, `remove-`, `refactor-`
+- Ensure uniqueness; if taken, append `-2`, `-3`, etc.
+
+## Tool Selection Guide
+
+| Task | Tool | Why |
+|------|------|-----|
+| Find files by pattern | Glob | Fast pattern matching |
+| Search code content | Grep | Optimized regex search |
+| Read specific files | Read | Direct file access |
+| Explore unknown scope | Task | Multi-step investigation |
+
+## Error Recovery
+
+### Change Conflicts
+1. Run `openspec list` to see active changes
+2. Check for overlapping specs
+3. Coordinate with change owners
+4. Consider combining proposals
+
+### Validation Failures
+1. Run with `--strict` flag
+2. Check JSON output for details
+3. Verify spec file format
+4. Ensure scenarios properly formatted
+
+### Missing Context
+1. Read project.md first
+2. Check related specs
+3. Review recent archives
+4. Ask for clarification
+
+## Quick Reference
+
+### Stage Indicators
+- `changes/` - Proposed, not yet built
+- `specs/` - Built and deployed
+- `archive/` - Completed changes
+
+### File Purposes
+- `proposal.md` - Why and what
+- `tasks.md` - Implementation steps
+- `design.md` - Technical decisions
+- `spec.md` - Requirements and behavior
+
+### CLI Essentials
+```bash
+openspec list              # What's in progress?
+openspec show [item]       # View details
+openspec validate --strict # Is it correct?
+openspec archive <change-id> [--yes|-y]  # Mark complete (add --yes for automation)
+```
+
+Remember: Specs are truth. Changes are proposals. Keep them in sync.

--- a/openspec/changes/fix-memunit-fusion/design.md
+++ b/openspec/changes/fix-memunit-fusion/design.md
@@ -1,0 +1,50 @@
+## Context
+The CGRA tile architecture allows flexible functional units through `FlexibleFuRTL`, which wraps a list of FUs. Each FU exposes memory interfaces (`to_mem_raddr`, `from_mem_rdata`, `to_mem_waddr`, `to_mem_wdata`) that are aggregated in `FlexibleFuRTL` as arrays indexed by FU position.
+
+Currently, `TileRTL` connects these memory ports to the tile's external memory interface only when the FU at position `i` is exactly `MemUnitRTL`. However, combo FUs (like `TwoSeqCombo`, `ThreeCombo`, etc.) internally instantiate multiple FUs but expose only a single set of memory ports that are tied to 0.
+
+## Goals / Non-Goals
+### Goals
+- Enable `MemUnitRTL` to be used as a component within combo FUs
+- Propagate memory interface signals from internal `MemUnitRTL` through combo FU wrappers
+- Maintain backward compatibility with existing non-memory combo FUs
+
+### Non-Goals
+- Supporting multiple `MemUnitRTL` instances within a single combo FU (only one memory access per cycle is supported at tile level)
+- Adding new memory access patterns or operations
+- Changing the memory interface protocol
+
+## Decisions
+
+### Decision 1: Propagate memory signals from internal FUs in combo classes
+**What**: In combo FU base classes, connect the internal FU's memory ports to the combo's external memory ports using OR logic (similar to `LinkOrRTL`).
+
+**Why**: This allows memory signals to pass through when any internal FU is a `MemUnitRTL`. The OR approach works because:
+1. Only one internal FU will be actively using memory at a time (enforced by operation type)
+2. Non-memory FUs tie their memory ports to 0, so OR-ing with them is a no-op
+
+**Alternatives considered**:
+- MUX-based selection: More complex, requires additional control signals
+- Explicit MemUnit detection at combo construction: Would require factory functions and break simple inheritance pattern
+
+### Decision 2: Detect combo FUs containing MemUnit in TileRTL
+**What**: In `TileRTL`, check if a FU class has `MemUnitRTL` in its composition (via class attributes or inspection) rather than checking exact class equality.
+
+**Why**: The current `FuList[i] == MemUnitRTL` check only matches standalone MemUnits. We need to also match combo FUs that contain MemUnit.
+
+**Implementation approach**: 
+- Add a class attribute `contains_mem_unit = True` to combo FUs that include `MemUnitRTL`
+- Or use `hasattr(FuList[i], 'Fu0')` style introspection to detect combo FUs, then check their internal FU types
+- Simplest: check if FU has a method/attribute indicating memory capability, defaulting to checking `== MemUnitRTL` for backward compatibility
+
+## Risks / Trade-offs
+
+### Risk: Multiple memory operations in same combo
+**Mitigation**: Document that only one internal FU in a combo can be `MemUnitRTL`. The hardware will still work (OR of two memory requests), but behavior would be undefined.
+
+### Risk: Timing impact
+**Mitigation**: The OR logic for memory signals is purely combinational and adds minimal delay. Memory access timing is already the critical path.
+
+## Open Questions
+1. Should we add explicit validation to prevent multiple `MemUnitRTL` in a single combo FU?
+2. Should we create a new combo FU class specifically for memory-compute fusion (e.g., `MemComputeCombo`) or modify existing classes?

--- a/openspec/changes/fix-memunit-fusion/proposal.md
+++ b/openspec/changes/fix-memunit-fusion/proposal.md
@@ -1,0 +1,21 @@
+# Change: Enable MemUnit Fusion in Combo FUs
+
+## Why
+Currently, when performing pattern fusion into single FUs (e.g., MAC = mul+add), `MemUnitRTL` cannot be fused with other operations. The combo FUs (`TwoSeqCombo`, `TwoPrlCombo`, `ThreeCombo`, `FourCombo`) force memory ports to be dangling (tied to 0), and `TileRTL` only connects memory ports for standalone `MemUnitRTL` FUs, not combo FUs that may contain `MemUnitRTL`.
+
+This prevents useful fusion patterns like `ADD_CONST + LD` (address computation fused with load) from being implemented as single-cycle operations.
+
+## What Changes
+- **Combo FUs**: Modify `TwoSeqCombo`, `TwoPrlCombo`, `ThreeCombo`, and `FourCombo` to propagate memory interfaces from internal FUs instead of tying them to 0
+- **TileRTL**: Update memory port connection logic to detect combo FUs that contain `MemUnitRTL` and connect their memory ports appropriately
+- **FlexibleFuRTL**: Already correctly exposes per-FU memory ports; no changes needed
+
+## Impact
+- Affected specs: `functional-units` (new capability spec)
+- Affected code:
+  - `fu/basic/TwoSeqCombo.py`
+  - `fu/basic/TwoPrlCombo.py`
+  - `fu/basic/ThreeCombo.py`
+  - `fu/basic/FourCombo.py`
+  - `tile/TileRTL.py`
+- Tests: Need to add tests for combo FUs containing `MemUnitRTL`

--- a/openspec/changes/fix-memunit-fusion/specs/functional-units/spec.md
+++ b/openspec/changes/fix-memunit-fusion/specs/functional-units/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Combo FU Memory Interface Propagation
+Combo FUs (TwoSeqCombo, TwoPrlCombo, ThreeCombo, FourCombo) SHALL propagate memory interface signals from their internal FUs to their external memory ports when any internal FU is a memory-capable unit.
+
+The memory signals to propagate are:
+- `to_mem_raddr` (read address output)
+- `from_mem_rdata` (read data input)
+- `to_mem_waddr` (write address output)
+- `to_mem_wdata` (write data output)
+
+The propagation SHALL use OR logic to combine signals from all internal FUs, since non-memory FUs tie their memory ports to 0.
+
+#### Scenario: TwoSeqCombo with MemUnitRTL as second FU
+- **WHEN** a TwoSeqCombo is constructed with MemUnitRTL as Fu1
+- **AND** the combo FU receives a load operation
+- **THEN** the memory read address from the internal MemUnitRTL SHALL be propagated to the combo's `to_mem_raddr` port
+- **AND** the memory read data received on `from_mem_rdata` SHALL be propagated to the internal MemUnitRTL
+
+#### Scenario: Combo FU without MemUnitRTL
+- **WHEN** a combo FU is constructed with no internal MemUnitRTL
+- **THEN** all memory ports SHALL remain at their default values (0)
+- **AND** backward compatibility SHALL be maintained
+
+### Requirement: TileRTL Combo FU Memory Detection
+TileRTL SHALL detect when a functional unit in its FuList is a combo FU containing MemUnitRTL and connect the tile's memory ports to that combo FU's memory interfaces.
+
+#### Scenario: Tile with combo FU containing MemUnitRTL
+- **WHEN** TileRTL is constructed with a FuList containing a combo FU that includes MemUnitRTL
+- **THEN** the tile's memory interfaces SHALL be connected to that combo FU's memory ports
+- **AND** memory operations within the combo FU SHALL function correctly
+
+#### Scenario: Tile with standalone MemUnitRTL (backward compatibility)
+- **WHEN** TileRTL is constructed with a FuList containing a standalone MemUnitRTL
+- **THEN** the existing behavior SHALL be preserved
+- **AND** the tile's memory interfaces SHALL be connected to MemUnitRTL's memory ports

--- a/openspec/changes/fix-memunit-fusion/tasks.md
+++ b/openspec/changes/fix-memunit-fusion/tasks.md
@@ -1,0 +1,19 @@
+## 1. Implementation
+
+### Combo FU Memory Port Propagation
+- [x] 1.1 Modify `fu/basic/TwoSeqCombo.py` to propagate memory interfaces from internal FUs using OR logic
+- [x] 1.2 Modify `fu/basic/TwoPrlCombo.py` to propagate memory interfaces from internal FUs using OR logic
+- [x] 1.3 Modify `fu/basic/ThreeCombo.py` to propagate memory interfaces from internal FUs using OR logic
+- [x] 1.4 Modify `fu/basic/FourCombo.py` to propagate memory interfaces from internal FUs using OR logic
+
+### TileRTL Memory Connection Logic
+- [x] 1.5 Update `tile/TileRTL.py` to detect combo FUs containing `MemUnitRTL` and connect their memory ports
+
+## 2. Testing
+- [x] 2.1 Add unit test for combo FU with `MemUnitRTL` - created `fu/double/SeqAdderMemRTL.py` and `fu/double/test/SeqAdderMemRTL_test.py`
+- [x] 2.2 Add tile-level test verifying memory-compute fusion works - added `test_tile_combo_fu_with_memunit` in `tile/test/TileRTL_test.py`
+- [ ] 2.3 Run existing tests to ensure no regression
+
+## 3. Validation
+- [ ] 3.1 Verify Verilog translation works with `--test-verilog`
+- [ ] 3.2 Run full test suite to ensure backward compatibility

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -1,0 +1,93 @@
+# Project Context
+
+## Purpose
+VectorCGRA (Vectorizable Coarse-Grained Reconfigurable Accelerator) is a parameterizable CGRA generator that produces synthesizable Verilog for different CGRA architectures based on user-specified configurations. Key capabilities include:
+- Configurable CGRA size (width × height tiles)
+- Customizable functional units per tile
+- Vector lane support for SIMD operations
+- Multiple topologies (Mesh, King Mesh)
+- Multi-CGRA interconnection (Ring, Mesh topologies)
+- Context switching support
+
+## Tech Stack
+- **Primary Language**: Python 3.9/3.12
+- **Hardware Description**: PyMTL3 (Python-based RTL modeling framework)
+- **Verilog Generation**: PyMTL3 translation passes with Verilator backend
+- **Testing**: pytest with PyMTL3 test utilities
+- **Simulation**: Verilator 4.036
+- **Synthesis**: sv2v + Yosys (via mflowgen)
+- **Dependencies**:
+  - PyMTL3 (custom fork: `tancheng/pymtl3.1@yo-struct-list-fix`)
+  - hypothesis (property-based testing)
+  - PyYAML (configuration parsing)
+  - graphviz (visualization)
+  - py-markdown-table (documentation)
+
+## Project Conventions
+
+### Code Style
+- **File naming**: `<ModuleName>RTL.py` for RTL components, `<ModuleName>FL.py` for functional-level models
+- **Test files**: `<ModuleName>_test.py` in `test/` subdirectory
+- **Class naming**: PascalCase with RTL/FL suffix (e.g., `TileRTL`, `CgraRTL`)
+- **Constants**: UPPER_SNAKE_CASE (e.g., `OPT_ADD`, `CMD_CONFIG`)
+- **Signal naming**: snake_case (e.g., `recv_data`, `send_to_controller_pkt`)
+- **File headers**: Include author attribution and date in docstring
+- **Comments**: Use `#=========================================================================` for section separators
+
+### Architecture Patterns
+- **Hierarchical RTL composition**: Components use PyMTL3's `construct()` method with explicit port connections
+- **Interface conventions**:
+  - `RecvIfcRTL` / `SendIfcRTL`: Val/Rdy handshaking interfaces
+  - Port naming: `recv_*` for inputs, `send_*` for outputs
+  - `//=` operator for port connections
+- **Type factory functions**: Use `mk_*` functions to create parameterized bitstruct types (e.g., `mk_data()`, `mk_ctrl()`, `mk_intra_cgra_pkt()`)
+- **Attribute constants**: Define field names as string constants in `lib/util/data_struct_attr.py` (e.g., `kAttrPayload`, `kAttrData`)
+- **Flexible functional units**: Use `FlexibleFuRTL` wrapper with configurable `FuList` parameter
+- **Tile-based architecture**: Each tile contains FUs, crossbars, register cluster, ctrl memory, and const memory
+- **Control flow**: Ring network for control packet distribution, mesh/king-mesh for data routing
+
+### Testing Strategy
+- **Test framework**: pytest with PyMTL3's `run_sim()` helper
+- **Test harness pattern**: Create `TestHarness` class wrapping DUT with `TestSrcRTL`/`TestSinkRTL`
+- **Simulation levels**:
+  - Pure Python simulation (default)
+  - Verilog translation + Verilator simulation (`--test-verilog`)
+- **Test artifacts**:
+  - `--dump-vtb`: Generate Verilog test bench
+  - `--dump-vcd`: Generate waveform dump
+- **Verilator warnings**: Configure via `VerilogVerilatorImportPass.vl_Wno_list` metadata
+- **File pattern**: `python_files = *_test.py`, `python_functions = test test_*`
+
+### Git Workflow
+- **Default branch**: `master`
+- **Feature branches**: Named after issue number (e.g., `214-p3-memunit-is-not-fusible`)
+- **CI/CD**: GitHub Actions on push/PR to master
+  - Matrix testing: Python 3.9.20, 3.12.8
+  - Simulation + Verilog translation tests
+  - Synthesis validation (Yosys, max 15 min)
+
+## Domain Context
+- **CGRA**: Coarse-Grained Reconfigurable Array - spatial computing architecture with configurable tiles
+- **Tile**: Processing element containing functional units, routing crossbars, and local storage
+- **Functional Unit (FU)**: Computation primitive (Adder, Multiplier, MemUnit, etc.)
+- **Crossbar**: Routing network connecting tile ports to FU inputs/outputs
+- **Control Memory**: Stores per-cycle configuration for FU operation selection and routing
+- **Const Memory**: Queue for immediate/constant values
+- **Register Cluster**: Local register file banks per tile
+- **Val/Rdy Protocol**: Handshake where producer asserts `val`, consumer asserts `rdy`, transfer occurs when both high
+- **Operations**: Defined in `lib/opt_type.py` (e.g., `OPT_ADD`, `OPT_MUL`, `OPT_LD`, `OPT_VEC_ADD`)
+- **Commands**: Defined in `lib/cmd_type.py` (e.g., `CMD_CONFIG`, `CMD_LAUNCH`, `CMD_COMPLETE`)
+
+## Important Constraints
+- **Verilator version**: 4.036 (specific version required for compatibility)
+- **PyMTL3 fork**: Must use custom fork with struct list fix
+- **Synthesis time**: CGRA template synthesis must complete within 15 minutes
+- **Python compatibility**: Must work on Python 3.7/3.8/3.9/3.10/3.12
+- **Submodules**: PyOCN network library is a git submodule (requires `git submodule update --init`)
+- **Build directory**: Tests should run from `build/` directory
+
+## External Dependencies
+- **PyOCN**: Network-on-Chip library (`noc/PyOCN/`) - ring and mesh network implementations
+- **pymtl3_hardfloat**: Floating-point unit support (submodule in `fu/pymtl3_hardfloat/`)
+- **mflowgen**: Physical design flow automation for synthesis
+- **sv2v**: SystemVerilog to Verilog converter for synthesis compatibility

--- a/tile/TileRTL.py
+++ b/tile/TileRTL.py
@@ -35,6 +35,21 @@ from ..rf.RegisterRTL import RegisterRTL
 from ..lib.util.data_struct_attr import *
 
 
+def _fu_contains_mem_unit(FuClass):
+  """
+  Check if a functional unit class is or contains MemUnitRTL.
+  This handles both standalone MemUnitRTL and combo FUs that may have
+  MemUnitRTL as one of their internal FUs.
+  """
+  # Direct match for standalone MemUnitRTL
+  if FuClass == MemUnitRTL:
+    return True
+  # Check for explicit class attribute (preferred for combo FUs)
+  if hasattr(FuClass, 'contains_mem_unit') and FuClass.contains_mem_unit:
+    return True
+  return False
+
+
 class TileRTL(Component):
 
   def construct(s, IntraCgraPktType,
@@ -169,7 +184,8 @@ class TileRTL(Component):
             s.ctrl_mem.prologue_count_outport_fu_crossbar[addr][i]
 
     for i in range(len(FuList)):
-      if FuList[i] == MemUnitRTL:
+      # Check if the FU is or contains MemUnitRTL (including combo FUs)
+      if _fu_contains_mem_unit(FuList[i]):
         s.to_mem_raddr //= s.element.to_mem_raddr[i]
         s.from_mem_rdata //= s.element.from_mem_rdata[i]
         s.to_mem_waddr //= s.element.to_mem_waddr[i]


### PR DESCRIPTION
- Added SeqAdderMemRTL test to validate memory interface propagation in combo FUs.
- Introduced design document outlining the context, goals, and decisions for enabling MemUnit fusion.
- Updated TileRTL to detect and connect memory ports for combo FUs containing MemUnitRTL.
- Modified functional unit classes (TwoSeqCombo, TwoPrlCombo, ThreeCombo, FourCombo) to propagate memory signals using OR logic.
- Created specifications for functional units to ensure proper memory interface behavior.
- Implemented tests to verify that combo FUs with MemUnit are correctly detected and connected in TileRTL.