### PR TITLE
Vector FIR RTL

### DIFF
--- a/fu/vector/VectorAllReduceRTL.py
+++ b/fu/vector/VectorAllReduceRTL.py
@@ -89,17 +89,12 @@ class VectorAllReduceRTL(Component):
       low  = i * sub_bw
       high = (i + 1) * sub_bw
       # s.connect() works with slice objects directly during elaboration.
-      connect( s.temp_result[i][0:sub_bw], s.recv_in[0].msg.payload[low:high] )
+      s.temp_result[i][0:sub_bw] //= s.recv_in[0].msg.payload[low:high]
 
     @update
     def update_result():
       # Connection: splits data into vectorized wires.
       s.send_out[0].msg.payload @= 0
-      #for i in range(num_lanes):
-      #  low  = i * sub_bw
-      #  high = (i + 1) * sub_bw
-      #  s.temp_result[i] @= TempDataType(0)
-      #  s.temp_result[i][0:sub_bw] @= s.recv_in[0].msg.payload[low:high]
 
       if s.recv_opt.msg.operation == OPT_VEC_REDUCE_ADD:
         s.send_out[0].msg.payload[0:data_bitwidth] @= s.reduce_add.out

--- a/multi_cgra/test/MeshMultiCgraRTL_test.py
+++ b/multi_cgra/test/MeshMultiCgraRTL_test.py
@@ -3273,6 +3273,6 @@ def test_multi_CGRA_fir_vector_global_reduce_translation(cmdline_opts):
                                test_name = 'test_fir_vector_global_reduce')
 
   th.elaborate()
-  th.dut.set_metadata(VerilogTranslationPass.explicit_module_name, "MeshMultiCgraRTL__explicit_vecgr")
-  th.dut.set_metadata(VerilogTranslationPass.explicit_file_name, "MeshMultiCgraRTL__explicit_vecgr__pickled.v")
+  th.dut.set_metadata(VerilogTranslationPass.explicit_module_name, "MeshMultiCgraRTL__explicit_vector_global_reduce")
+  th.dut.set_metadata(VerilogTranslationPass.explicit_file_name, "MeshMultiCgraRTL__explicit_vector_global_reduce__pickled.v")
   translate_model(th, ['dut'])


### PR DESCRIPTION
Looking at MeshMultiCgraRTL_test.py, the CGRA RTL is different between test_fir_vector_global_reduce and test_fir_scalar, since the former redefines some variables in its elif test_name == 'test_fir_vector_global_reduce': clause.

I tried adding a new function to translate the Vector FIR test into SV, but I was getting failures. The first one seemed to be a simple PyMTL "or" vs "|" for RTL purposes.

The second one is an issue with vector indexing. I found a fix that lets the code translate to SV, but I am not sure if the new version's functionality matches that of the old one. (Missing s.temp_result[i] @= TempDataType(0).)

This low:high indexing is not overlapping in Python due to the upper bound being exclusive, right?

Also, we might want to use //= instead of connect, but, IIUC, they are interchangeable.
