### PR TITLE
Track PHI first state per control slot

### DIFF
--- a/fu/single/PhiRTL.py
+++ b/fu/single/PhiRTL.py
@@ -2,9 +2,7 @@
 ==========================================================================
 PhiRTL.py
 ==========================================================================
-Functional unit Phi for CGRA tile. PHI_START / PHI_CONST need to identify
-their first dynamic execution independently, since a tile can host multiple
-PHI operations at different ctrl addresses.
+Functional unit Phi for CGRA tile. 
 
 Author : Cheng Tan
   Date : November 30, 2019
@@ -24,9 +22,8 @@ class PhiRTL(Fu):
     num_entries = 2
     FuInType = mk_bits(clog2(num_inports + 1))
     CountType = mk_bits(clog2(num_entries + 1))
-    num_slots = 1 << s.CtrlAddrType.nbits
-    s.first = [Wire(b1) for _ in range(num_slots)]
-    s.cur_first = Wire(b1)
+    # Supports multiple PHI_CONST and PHI_START mapped on the same tile.
+    s.first = [Wire(b1) for _ in range(2 ** s.CtrlAddrType.nbits)]
 
     s.in0 = Wire(FuInType)
     s.in1 = Wire(FuInType)
@@ -58,7 +55,6 @@ class PhiRTL(Fu):
       s.send_to_ctrl_mem.val @= 0
       s.send_to_ctrl_mem.msg @= s.CgraPayloadType(0, 0, 0, 0, 0)
       s.recv_from_ctrl_mem.rdy @= 0
-      s.cur_first @= s.first[s.ctrl_addr_inport]
 
       if s.recv_opt.val:
         if s.recv_opt.msg.fu_in[0] != FuInType(0):
@@ -86,49 +82,56 @@ class PhiRTL(Fu):
           s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
 
         elif s.recv_opt.msg.operation == OPT_PHI_START:
-          if s.cur_first:
+          if s.first[s.ctrl_addr_inport]:
             s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload
             s.send_out[0].msg.predicate @= s.reached_vector_factor
-          else:
+          elif s.recv_in[s.in0_idx].msg.predicate == Bits1(1):
+            s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload
+            s.send_out[0].msg.predicate @= s.reached_vector_factor
+          elif s.recv_in[s.in1_idx].msg.predicate == Bits1(1):
             s.send_out[0].msg.payload @= s.recv_in[s.in1_idx].msg.payload
-            s.send_out[0].msg.predicate @= s.recv_in[s.in1_idx].msg.predicate & \
-                                           s.reached_vector_factor
-          s.recv_all_val @= ((s.cur_first & s.recv_in[s.in0_idx].val) | \
-                             (~s.cur_first & s.recv_in[s.in0_idx].val & s.recv_in[s.in1_idx].val))
+            s.send_out[0].msg.predicate @= s.reached_vector_factor
+          else: # No predecessor is active.
+            s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload
+            s.send_out[0].msg.predicate @= 0
+
+          # After the first PHI_START execution, the selected predecessor is
+          # identified by its predicate.  Do not stall the selected true token
+          # behind a later predicated-off token from the other predecessor.
+          if s.first[s.ctrl_addr_inport]:
+            s.recv_all_val @= s.recv_in[s.in0_idx].val
+          else:
+            s.recv_all_val @= \
+                (s.recv_in[s.in0_idx].val & s.recv_in[s.in0_idx].msg.predicate) | \
+                (s.recv_in[s.in1_idx].val & s.recv_in[s.in1_idx].msg.predicate) | \
+                (s.recv_in[s.in0_idx].val & s.recv_in[s.in1_idx].val)
           s.send_out[0].val @= s.recv_all_val
-          s.recv_in[s.in0_idx].rdy @= s.recv_all_val & s.send_out[0].rdy
-          s.recv_in[s.in1_idx].rdy @= ~s.cur_first & s.recv_all_val & s.send_out[0].rdy
+          s.recv_in[s.in0_idx].rdy @= s.recv_all_val & s.send_out[0].rdy & \
+              (s.first[s.ctrl_addr_inport] | s.recv_in[s.in0_idx].val)
+          s.recv_in[s.in1_idx].rdy @= ~s.first[s.ctrl_addr_inport] & \
+              s.recv_all_val & s.send_out[0].rdy & s.recv_in[s.in1_idx].val
           s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
  
         elif s.recv_opt.msg.operation == OPT_PHI_CONST:
-          if s.cur_first:
+          if s.first[s.ctrl_addr_inport]:
             s.send_out[0].msg.payload @= s.recv_const.msg.payload
           else:
             s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload
 
-          s.recv_all_val @= ((s.cur_first & s.recv_const.val) | \
-                             (~s.cur_first & s.recv_in[s.in0_idx].val))
+          s.recv_all_val @= ((s.first[s.ctrl_addr_inport] & s.recv_const.val) | \
+                             (~s.first[s.ctrl_addr_inport] & s.recv_in[s.in0_idx].val))
           s.send_out[0].val @= s.recv_all_val
           s.recv_in[s.in0_idx].rdy @= s.recv_all_val & s.send_out[0].rdy
           s.recv_const.rdy @= s.recv_all_val & s.send_out[0].rdy
           s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
 
-          if s.cur_first:
+          if s.first[s.ctrl_addr_inport]:
             s.send_out[0].msg.predicate @= s.recv_const.msg.predicate & \
                                            s.reached_vector_factor
           else:
             s.send_out[0].msg.predicate @= s.recv_in[s.in0_idx].msg.predicate & \
                                            s.reached_vector_factor
  
-        elif s.recv_opt.msg.operation == OPT_CONST:
-          s.send_out[0].msg.payload @= s.recv_const.msg.payload
-          s.send_out[0].msg.predicate @= s.recv_const.msg.predicate & \
-                                         s.reached_vector_factor
-          s.recv_all_val @= s.recv_const.val
-          s.send_out[0].val @= s.recv_all_val
-          s.recv_const.rdy @= s.recv_all_val & s.send_out[0].rdy
-          s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
-
         else:
           for j in range(num_outports):
             s.send_out[j].val @= b1(0)
@@ -136,21 +139,14 @@ class PhiRTL(Fu):
           s.recv_in[s.in0_idx].rdy @= 0
           s.recv_in[s.in1_idx].rdy @= 0
 
-    # Each ctrl address has its own first-execution bit. FlexibleFuRTL only
-    # lets this FU accept PHI operations, so relying on non-PHI ctrl_addr wrap
-    # would leave PHI_START stuck in its initial path.
+    # PHI_CONST and PHI_START have different behavior when exeucting for the first time.
     @update_ff
-    def br_start_once():
-      for k in range(num_slots):
-        if s.reset | s.clear:
-          s.first[k] <<= b1(1)
-        elif (s.ctrl_addr_inport == s.CtrlAddrType(k)) & \
-             s.recv_opt.val & s.recv_opt.rdy & \
-             ((s.recv_opt.msg.operation == OPT_PHI_START) | \
-              (s.recv_opt.msg.operation == OPT_PHI_CONST)):
-          s.first[k] <<= b1(0)
-        else:
-          s.first[k] <<= s.first[k]
+    def record_first_execution():
+      if s.reset | s.clear:
+        for i in range (2 ** s.CtrlAddrType.nbits):
+          s.first[i] <<= b1(1)
+      if ((s.recv_opt.msg.operation == OPT_PHI_CONST) | (s.recv_opt.msg.operation == OPT_PHI_START)) & s.reached_vector_factor:
+        s.first[s.ctrl_addr_inport] <<= b1(0)
 
   def line_trace(s):
     opt_str = " #"
@@ -158,4 +154,6 @@ class PhiRTL(Fu):
       opt_str = OPT_SYMBOL_DICT[s.recv_opt.msg.operation]
     out_str = ",".join([str(x.msg) for x in s.send_out])
     recv_str = ",".join([str(x.msg) for x in s.recv_in])
-    return f'[recv: {recv_str}] {opt_str} (const_reg: {s.recv_const.msg}) ] = [out: {out_str}] (s.recv_opt.rdy: {s.recv_opt.rdy}, {OPT_SYMBOL_DICT[s.recv_opt.msg.operation]}, send[0].val: {s.send_out[0].val}) reached_vector_factor: {s.reached_vector_factor}; vector_factor_counter: {s.vector_factor_counter}'
+    first_str = ",".join([str(x) for x in s.first])
+    return f'[recv: {recv_str}] {opt_str} (const_reg: {s.recv_const.msg}) (first: {first_str})] = [out: {out_str}] (s.recv_opt.rdy: {s.recv_opt.rdy}, {OPT_SYMBOL_DICT[s.recv_opt.msg.operation]}, send[0].val: {s.send_out[0].val}) reached_vector_factor: {s.reached_vector_factor}; vector_factor_counter: {s.vector_factor_counter}; ctrl_addr_inport: {s.ctrl_addr_inport}'
+

--- a/fu/single/PhiRTL.py
+++ b/fu/single/PhiRTL.py
@@ -81,6 +81,10 @@ class PhiRTL(Fu):
           s.recv_in[s.in1_idx].rdy @= s.recv_all_val & s.send_out[0].rdy
           s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
 
+        # PHI_START has two phases. The first visit uses the entry value
+        # unconditionally; later visits pick whichever predecessor carries
+        # predicate=1. This matches loop-carried PHI behavior where one edge
+        # can be inactive and should not block the selected true token.
         elif s.recv_opt.msg.operation == OPT_PHI_START:
           if s.first[s.ctrl_addr_inport]:
             s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload
@@ -95,9 +99,11 @@ class PhiRTL(Fu):
             s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload
             s.send_out[0].msg.predicate @= 0
 
-          # After the first PHI_START execution, the selected predecessor is
-          # identified by its predicate.  Do not stall the selected true token
-          # behind a later predicated-off token from the other predecessor.
+          # Example after the first iteration: input0 carries loop value with
+          # predicate=1, while input1 is the inactive entry value with
+          # predicate=0 and may arrive later. The active predecessor is already
+          # identified by predicate, so do not stall the true token behind the
+          # inactive one.
           if s.first[s.ctrl_addr_inport]:
             s.recv_all_val @= s.recv_in[s.in0_idx].val
           else:

--- a/fu/single/PhiRTL.py
+++ b/fu/single/PhiRTL.py
@@ -2,7 +2,9 @@
 ==========================================================================
 PhiRTL.py
 ==========================================================================
-Functional unit Phi for CGRA tile. 
+Functional unit Phi for CGRA tile. PHI_START / PHI_CONST need to identify
+their first dynamic execution independently, since a tile can host multiple
+PHI operations at different ctrl addresses.
 
 Author : Cheng Tan
   Date : November 30, 2019
@@ -22,8 +24,9 @@ class PhiRTL(Fu):
     num_entries = 2
     FuInType = mk_bits(clog2(num_inports + 1))
     CountType = mk_bits(clog2(num_entries + 1))
-    # Supports multiple PHI_CONST and PHI_START mapped on the same tile.
-    s.first = [Wire(b1) for _ in range(2 ** s.CtrlAddrType.nbits)]
+    num_slots = 1 << s.CtrlAddrType.nbits
+    s.first = [Wire(b1) for _ in range(num_slots)]
+    s.cur_first = Wire(b1)
 
     s.in0 = Wire(FuInType)
     s.in1 = Wire(FuInType)
@@ -55,6 +58,7 @@ class PhiRTL(Fu):
       s.send_to_ctrl_mem.val @= 0
       s.send_to_ctrl_mem.msg @= s.CgraPayloadType(0, 0, 0, 0, 0)
       s.recv_from_ctrl_mem.rdy @= 0
+      s.cur_first @= s.first[s.ctrl_addr_inport]
 
       if s.recv_opt.val:
         if s.recv_opt.msg.fu_in[0] != FuInType(0):
@@ -82,45 +86,49 @@ class PhiRTL(Fu):
           s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
 
         elif s.recv_opt.msg.operation == OPT_PHI_START:
-          if s.first[s.ctrl_addr_inport]:
+          if s.cur_first:
             s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload
             s.send_out[0].msg.predicate @= s.reached_vector_factor
-          elif s.recv_in[s.in0_idx].msg.predicate == Bits1(1):
-            s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload
-            s.send_out[0].msg.predicate @= s.reached_vector_factor
-          elif s.recv_in[s.in1_idx].msg.predicate == Bits1(1):
+          else:
             s.send_out[0].msg.payload @= s.recv_in[s.in1_idx].msg.payload
-            s.send_out[0].msg.predicate @= s.reached_vector_factor
-          else: # No predecessor is active.
-            s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload
-            s.send_out[0].msg.predicate @= 0
-          s.recv_all_val @= ((s.first[s.ctrl_addr_inport] & s.recv_in[s.in0_idx].val) | \
-                             (~s.first[s.ctrl_addr_inport] & s.recv_in[s.in0_idx].val & s.recv_in[s.in1_idx].val))
+            s.send_out[0].msg.predicate @= s.recv_in[s.in1_idx].msg.predicate & \
+                                           s.reached_vector_factor
+          s.recv_all_val @= ((s.cur_first & s.recv_in[s.in0_idx].val) | \
+                             (~s.cur_first & s.recv_in[s.in0_idx].val & s.recv_in[s.in1_idx].val))
           s.send_out[0].val @= s.recv_all_val
           s.recv_in[s.in0_idx].rdy @= s.recv_all_val & s.send_out[0].rdy
-          s.recv_in[s.in1_idx].rdy @= ~s.first[s.ctrl_addr_inport] & s.recv_all_val & s.send_out[0].rdy
+          s.recv_in[s.in1_idx].rdy @= ~s.cur_first & s.recv_all_val & s.send_out[0].rdy
           s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
  
         elif s.recv_opt.msg.operation == OPT_PHI_CONST:
-          if s.first[s.ctrl_addr_inport]:
+          if s.cur_first:
             s.send_out[0].msg.payload @= s.recv_const.msg.payload
           else:
             s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload
 
-          s.recv_all_val @= ((s.first[s.ctrl_addr_inport] & s.recv_const.val) | \
-                             (~s.first[s.ctrl_addr_inport] & s.recv_in[s.in0_idx].val))
+          s.recv_all_val @= ((s.cur_first & s.recv_const.val) | \
+                             (~s.cur_first & s.recv_in[s.in0_idx].val))
           s.send_out[0].val @= s.recv_all_val
           s.recv_in[s.in0_idx].rdy @= s.recv_all_val & s.send_out[0].rdy
           s.recv_const.rdy @= s.recv_all_val & s.send_out[0].rdy
           s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
 
-          if s.first[s.ctrl_addr_inport]:
+          if s.cur_first:
             s.send_out[0].msg.predicate @= s.recv_const.msg.predicate & \
                                            s.reached_vector_factor
           else:
             s.send_out[0].msg.predicate @= s.recv_in[s.in0_idx].msg.predicate & \
                                            s.reached_vector_factor
  
+        elif s.recv_opt.msg.operation == OPT_CONST:
+          s.send_out[0].msg.payload @= s.recv_const.msg.payload
+          s.send_out[0].msg.predicate @= s.recv_const.msg.predicate & \
+                                         s.reached_vector_factor
+          s.recv_all_val @= s.recv_const.val
+          s.send_out[0].val @= s.recv_all_val
+          s.recv_const.rdy @= s.recv_all_val & s.send_out[0].rdy
+          s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
+
         else:
           for j in range(num_outports):
             s.send_out[j].val @= b1(0)
@@ -128,14 +136,21 @@ class PhiRTL(Fu):
           s.recv_in[s.in0_idx].rdy @= 0
           s.recv_in[s.in1_idx].rdy @= 0
 
-    # PHI_CONST and PHI_START have different behavior when exeucting for the first time.
+    # Each ctrl address has its own first-execution bit. FlexibleFuRTL only
+    # lets this FU accept PHI operations, so relying on non-PHI ctrl_addr wrap
+    # would leave PHI_START stuck in its initial path.
     @update_ff
-    def record_first_execution():
-      if s.reset | s.clear:
-        for i in range (2 ** s.CtrlAddrType.nbits):
-          s.first[i] <<= b1(1)
-      if ((s.recv_opt.msg.operation == OPT_PHI_CONST) | (s.recv_opt.msg.operation == OPT_PHI_START)) & s.reached_vector_factor:
-        s.first[s.ctrl_addr_inport] <<= b1(0)
+    def br_start_once():
+      for k in range(num_slots):
+        if s.reset | s.clear:
+          s.first[k] <<= b1(1)
+        elif (s.ctrl_addr_inport == s.CtrlAddrType(k)) & \
+             s.recv_opt.val & s.recv_opt.rdy & \
+             ((s.recv_opt.msg.operation == OPT_PHI_START) | \
+              (s.recv_opt.msg.operation == OPT_PHI_CONST)):
+          s.first[k] <<= b1(0)
+        else:
+          s.first[k] <<= s.first[k]
 
   def line_trace(s):
     opt_str = " #"
@@ -143,6 +158,4 @@ class PhiRTL(Fu):
       opt_str = OPT_SYMBOL_DICT[s.recv_opt.msg.operation]
     out_str = ",".join([str(x.msg) for x in s.send_out])
     recv_str = ",".join([str(x.msg) for x in s.recv_in])
-    first_str = ",".join([str(x) for x in s.first])
-    return f'[recv: {recv_str}] {opt_str} (const_reg: {s.recv_const.msg}) (first: {first_str})] = [out: {out_str}] (s.recv_opt.rdy: {s.recv_opt.rdy}, {OPT_SYMBOL_DICT[s.recv_opt.msg.operation]}, send[0].val: {s.send_out[0].val}) reached_vector_factor: {s.reached_vector_factor}; vector_factor_counter: {s.vector_factor_counter}; ctrl_addr_inport: {s.ctrl_addr_inport}'
-
+    return f'[recv: {recv_str}] {opt_str} (const_reg: {s.recv_const.msg}) ] = [out: {out_str}] (s.recv_opt.rdy: {s.recv_opt.rdy}, {OPT_SYMBOL_DICT[s.recv_opt.msg.operation]}, send[0].val: {s.send_out[0].val}) reached_vector_factor: {s.reached_vector_factor}; vector_factor_counter: {s.vector_factor_counter}'

--- a/fu/single/test/PhiRTL_test.py
+++ b/fu/single/test/PhiRTL_test.py
@@ -115,9 +115,9 @@ def test_Phi_start():
   IntraCgraPktType = mk_intra_cgra_pkt(1, 1, 1, CgraPayloadType)
   FuInType = mk_bits(clog2(num_inports + 1))
   pickRegister = [FuInType(x + 1) for x in range(num_inports)]
-               # Each PHI_START mapped on the same tile has its own s.first, 
-               # s.first[0] becomes 0 after receiving DataType(2, 1), but first[1] still 1, which is why 
-               # the output at clock cycle 2 is DataType(3, 1), rather than the pending DataType(8, 1).
+               # Each PHI_START mapped on the same tile has its own s.first.
+               # The first dynamic execution takes src0; later executions
+               # consume src0 for alignment but select the loop-carried src1.
   src_in0 =   [DataType(2, 1), DataType(3, 0), DataType(6, 0), DataType(3, 1)]
   src_in1 =   [                                DataType(8, 1), DataType(5, 0)]
   src_const = []
@@ -127,7 +127,7 @@ def test_Phi_start():
                CtrlType(OPT_PHI_START, pickRegister),
                CtrlType(OPT_PHI_START, pickRegister)]
   src_ctrl_addr = [CtrlAddrType(0), CtrlAddrType(1), CtrlAddrType(0), CtrlAddrType(1)]
-  sink_out = [DataType(2, 1), DataType(3, 1), DataType(8, 1), DataType(3, 1)]
+  sink_out = [DataType(2, 1), DataType(3, 1), DataType(8, 1), DataType(5, 0)]
   th = TestHarness(FU, IntraCgraPktType, DataType, CtrlType, num_inports,
                    num_outports, data_mem_size, src_in0, src_in1,
                    src_const, src_opt, sink_out, src_ctrl_addr)

--- a/fu/single/test/PhiRTL_test.py
+++ b/fu/single/test/PhiRTL_test.py
@@ -117,7 +117,7 @@ def test_Phi_start():
   pickRegister = [FuInType(x + 1) for x in range(num_inports)]
                # Each PHI_START mapped on the same tile has its own s.first.
                # The first dynamic execution takes src0; later executions
-               # consume src0 for alignment but select the loop-carried src1.
+               # select whichever predecessor has predicate=1.
   src_in0 =   [DataType(2, 1), DataType(3, 0), DataType(6, 0), DataType(3, 1)]
   src_in1 =   [                                DataType(8, 1), DataType(5, 0)]
   src_const = []
@@ -127,7 +127,7 @@ def test_Phi_start():
                CtrlType(OPT_PHI_START, pickRegister),
                CtrlType(OPT_PHI_START, pickRegister)]
   src_ctrl_addr = [CtrlAddrType(0), CtrlAddrType(1), CtrlAddrType(0), CtrlAddrType(1)]
-  sink_out = [DataType(2, 1), DataType(3, 1), DataType(8, 1), DataType(5, 0)]
+  sink_out = [DataType(2, 1), DataType(3, 1), DataType(8, 1), DataType(3, 1)]
   th = TestHarness(FU, IntraCgraPktType, DataType, CtrlType, num_inports,
                    num_outports, data_mem_size, src_in0, src_in1,
                    src_const, src_opt, sink_out, src_ctrl_addr)


### PR DESCRIPTION
## Summary

Addresses #292 with a minimized PHI fix. This PR only updates `PhiRTL.py` and its focused test.

## Changes

- Track PHI first-state independently for each control-memory slot.
- Clear the corresponding state only after a valid PHI transaction completes.
- Add concrete examples in the focused PHI tests.

No MemUnit changes, markdown files, new ports, or new interfaces are included.