### PR TITLE
Support const left shifts

### DIFF
--- a/fu/single/ShifterRTL.py
+++ b/fu/single/ShifterRTL.py
@@ -72,6 +72,17 @@ class ShifterRTL(Fu):
           s.recv_in[s.in1_idx].rdy @= s.recv_all_val & s.send_out[0].rdy
           s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
 
+        elif s.recv_opt.msg.operation == OPT_LLS_CONST:
+          s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload << s.recv_const.msg.payload
+          s.send_out[0].msg.predicate @= s.recv_in[s.in0_idx].msg.predicate & \
+                                         s.recv_const.msg.predicate & \
+                                         s.reached_vector_factor
+          s.recv_all_val @= s.recv_in[s.in0_idx].val & s.recv_const.val
+          s.send_out[0].val @= s.recv_all_val
+          s.recv_in[s.in0_idx].rdy @= s.recv_all_val & s.send_out[0].rdy
+          s.recv_const.rdy @= s.recv_all_val & s.send_out[0].rdy
+          s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
+
         elif s.recv_opt.msg.operation == OPT_LRS:
           s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload >> s.recv_in[s.in1_idx].msg.payload
           s.send_out[0].msg.predicate @= s.recv_in[s.in0_idx].msg.predicate & \

--- a/fu/single/ShifterRTL.py
+++ b/fu/single/ShifterRTL.py
@@ -73,6 +73,12 @@ class ShifterRTL(Fu):
           s.recv_opt.rdy @= s.recv_all_val & s.send_out[0].rdy
 
         elif s.recv_opt.msg.operation == OPT_LLS_CONST:
+          # Const shift uses the const queue for a fixed shift amount, avoiding
+          # a second dynamic operand. Example: payload=3, const=2 => 12; the
+          # output predicate still requires both the input and const predicates.
+          # Shift amount comes from the per-tile const queue. This is used by
+          # generated address arithmetic where the value is dataflow input but
+          # the left-shift amount is a static kernel constant.
           s.send_out[0].msg.payload @= s.recv_in[s.in0_idx].msg.payload << s.recv_const.msg.payload
           s.send_out[0].msg.predicate @= s.recv_in[s.in0_idx].msg.predicate & \
                                          s.recv_const.msg.predicate & \

--- a/lib/opt_type.py
+++ b/lib/opt_type.py
@@ -115,6 +115,46 @@ OPT_GEP                          = OpCodeType( 88 )
 OPT_GEP_CONST                    = OpCodeType( 89 )
 OPT_GEP_2D                       = OpCodeType( 90 )
 OPT_GEP_2D_CONST                 = OpCodeType( 91 )
+OPT_GRT_ONCE_CONST               = OpCodeType( 92 )
+OPT_GTE_CONST                    = OpCodeType( 93 )
+OPT_LT_CONST                     = OpCodeType( 94 )
+OPT_GT_CONST                     = OpCodeType( 95 )
+OPT_REM_CONST                    = OpCodeType( 96 )
+OPT_AND_CONST                    = OpCodeType( 97 )
+OPT_OR_CONST                     = OpCodeType( 98 )
+OPT_LLS_CONST                    = OpCodeType( 99 )
+
+OPT_USES_CONST_LIST = (
+  OPT_CONST,
+  OPT_ADD_CONST,
+  OPT_SUB_CONST,
+  OPT_DIV_CONST,
+  OPT_EQ_CONST,
+  OPT_NE_CONST,
+  OPT_PHI_CONST,
+  OPT_LD_CONST,
+  OPT_STR_CONST,
+  OPT_MUL_CONST,
+  OPT_MUL_CONST_ADD,
+  OPT_ADD_CONST_LD,
+  OPT_INC_NE_CONST_NOT_GRT,
+  OPT_FADD_CONST,
+  OPT_FMUL_CONST,
+  OPT_VEC_ADD_CONST,
+  OPT_VEC_SUB_CONST,
+  OPT_VEC_ADD_CONST_COMBINED,
+  OPT_VEC_SUB_CONST_COMBINED,
+  OPT_GRT_ONCE_CONST,
+  OPT_GTE_CONST,
+  OPT_LT_CONST,
+  OPT_GT_CONST,
+  OPT_AND_CONST,
+  OPT_OR_CONST,
+  OPT_LLS_CONST,
+  OPT_REM_CONST,
+  OPT_GEP_CONST,
+  OPT_GEP_2D_CONST,
+)
 
 OPT_SYMBOL_DICT = {
   OPT_START                      : "(start)",
@@ -201,6 +241,14 @@ OPT_SYMBOL_DICT = {
   OPT_REM_INCLUSIVE_START        : "(%st)",
   OPT_DIV_INCLUSIVE_END          : "(/ed)",
   OPT_REM_INCLUSIVE_END          : "(%ed)",
+  OPT_GRT_ONCE_CONST             : "(grant_once')",
+  OPT_GTE_CONST                  : "(?>=')",
+  OPT_LT_CONST                   : "(?<')",
+  OPT_GT_CONST                   : "(?>')",
+  OPT_AND_CONST                  : "(&')",
+  OPT_OR_CONST                   : "(|')",
+  OPT_LLS_CONST                  : "(<<')",
+  OPT_REM_CONST                  : "(%')",
 
   OPT_LOOP_CONTROL               : "(loop_ctrl)",
   OPT_STREAM_LD                  : "(streaming_ld)",


### PR DESCRIPTION
## Summary

Addresses #292 with minimized const-shift support. This PR updates `ShifterRTL.py` plus shared opcode definitions in `lib/opt_type.py`.

## Changes

- Add `OPT_LLS_CONST` handling using the const queue shift amount.
- Add the required shared const opcode entry.

## Validation

Part of the master-based small conv passing set.