### PR TITLE
Add shared const opcode definitions

### DIFF
--- a/lib/opt_type.py
+++ b/lib/opt_type.py
@@ -115,6 +115,46 @@ OPT_GEP                          = OpCodeType( 88 )
 OPT_GEP_CONST                    = OpCodeType( 89 )
 OPT_GEP_2D                       = OpCodeType( 90 )
 OPT_GEP_2D_CONST                 = OpCodeType( 91 )
+OPT_GRT_ONCE_CONST               = OpCodeType( 92 )
+OPT_GTE_CONST                    = OpCodeType( 93 )
+OPT_LT_CONST                     = OpCodeType( 94 )
+OPT_GT_CONST                     = OpCodeType( 95 )
+OPT_REM_CONST                    = OpCodeType( 96 )
+OPT_AND_CONST                    = OpCodeType( 97 )
+OPT_OR_CONST                     = OpCodeType( 98 )
+OPT_LLS_CONST                    = OpCodeType( 99 )
+
+OPT_USES_CONST_LIST = (
+  OPT_CONST,
+  OPT_ADD_CONST,
+  OPT_SUB_CONST,
+  OPT_DIV_CONST,
+  OPT_EQ_CONST,
+  OPT_NE_CONST,
+  OPT_PHI_CONST,
+  OPT_LD_CONST,
+  OPT_STR_CONST,
+  OPT_MUL_CONST,
+  OPT_MUL_CONST_ADD,
+  OPT_ADD_CONST_LD,
+  OPT_INC_NE_CONST_NOT_GRT,
+  OPT_FADD_CONST,
+  OPT_FMUL_CONST,
+  OPT_VEC_ADD_CONST,
+  OPT_VEC_SUB_CONST,
+  OPT_VEC_ADD_CONST_COMBINED,
+  OPT_VEC_SUB_CONST_COMBINED,
+  OPT_GRT_ONCE_CONST,
+  OPT_GTE_CONST,
+  OPT_LT_CONST,
+  OPT_GT_CONST,
+  OPT_AND_CONST,
+  OPT_OR_CONST,
+  OPT_LLS_CONST,
+  OPT_REM_CONST,
+  OPT_GEP_CONST,
+  OPT_GEP_2D_CONST,
+)
 
 OPT_SYMBOL_DICT = {
   OPT_START                      : "(start)",
@@ -201,6 +241,14 @@ OPT_SYMBOL_DICT = {
   OPT_REM_INCLUSIVE_START        : "(%st)",
   OPT_DIV_INCLUSIVE_END          : "(/ed)",
   OPT_REM_INCLUSIVE_END          : "(%ed)",
+  OPT_GRT_ONCE_CONST             : "(grant_once')",
+  OPT_GTE_CONST                  : "(?>=')",
+  OPT_LT_CONST                   : "(?<')",
+  OPT_GT_CONST                   : "(?>')",
+  OPT_AND_CONST                  : "(&')",
+  OPT_OR_CONST                   : "(|')",
+  OPT_LLS_CONST                  : "(<<')",
+  OPT_REM_CONST                  : "(%')",
 
   OPT_LOOP_CONTROL               : "(loop_ctrl)",
   OPT_STREAM_LD                  : "(streaming_ld)",


### PR DESCRIPTION

This PR only adds the shared opcode definitions needed by the const-op RTL fixes. It intentionally does not change any RTL module behavior.

The following module-specific PRs depend on these opcode names:
- DivRTL REM_CONST
- CompRTL const comparisons
- GrantRTL grant_once const
- ShifterRTL const shifts
- ConstQueueDynamicRTL const-op consume tracking
- conv small validation config generation

Validation:
This branch is metadata-only. I also verified that merging this shared branch before the other split branches avoids duplicated lib/opt_type.py diffs.