### PR TITLE
Cleanup type-delivery condition in ControllerRTL (partial fix for #188)

### DIFF
--- a/controller/ControllerRTL.py
+++ b/controller/ControllerRTL.py
@@ -461,28 +461,19 @@ class ControllerRTL(Component):
           s.global_reduce_unit.recv_count.val @= 1
           s.global_reduce_unit.recv_count.msg @= s.recv_from_inter_cgra_noc.msg
 
-        elif (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_CONFIG) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_CONFIG_PROLOGUE_FU) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_CONFIG_PROLOGUE_FU_CROSSBAR) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_CONFIG_PROLOGUE_ROUTING_CROSSBAR) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_CONFIG_TOTAL_CTRL_COUNT) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_CONFIG_COUNT_PER_ITER) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_CONFIG_CTRL_LOWER_BOUND) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_CONST) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_GLOBAL_REDUCE_ADD_RESPONSE) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_GLOBAL_REDUCE_MUL_RESPONSE) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_CONFIG_STREAMING_LD_START_ADDR) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_CONFIG_STREAMING_LD_STRIDE) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_CONFIG_STREAMING_LD_END_ADDR) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_PAUSE) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_PRESERVE) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_RESUME) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_RECORD_PHI_ADDR) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_TERMINATE) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_LAUNCH) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_CONFIG_LOOP_LOWER) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_CONFIG_LOOP_UPPER) | \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd == CMD_CONFIG_LOOP_STEP) :
+        # Catch-all: any type not specially handled above (i.e., not one of
+        # CMD_LOAD_REQUEST/CMD_STORE_REQUEST/CMD_LOAD_RESPONSE/CMD_COMPLETE/
+        # CMD_LEAF_COUNTER_COMPLETE/CMD_GLOBAL_REDUCE_ADD/CMD_GLOBAL_REDUCE_COUNT)
+        # is forwarded to the ctrl ring as-is. This avoids silently dropping
+        # newly-added command types that forget to be added to an explicit
+        # allow-list here (see #188).
+        elif (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_LOAD_REQUEST) & \
+             (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_STORE_REQUEST) & \
+             (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_LOAD_RESPONSE) & \
+             (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_COMPLETE) & \
+             (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_LEAF_COUNTER_COMPLETE) & \
+             (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_GLOBAL_REDUCE_ADD) & \
+             (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_GLOBAL_REDUCE_COUNT):
           s.recv_from_inter_cgra_noc.rdy @= s.send_to_ctrl_ring_pkt.rdy
           s.send_to_ctrl_ring_pkt.val @= s.recv_from_inter_cgra_noc.val
           s.send_to_ctrl_ring_pkt.msg @= \
@@ -497,10 +488,6 @@ class ControllerRTL(Component):
                                0, # opaque
                                0, # vc_id
                                s.recv_from_inter_cgra_noc.msg.payload)
-
-        # else:
-        #   # TODO: Handle other cmd types.
-        #   assert(False)
 
       # WARNING
       # A possible conflict occurs when dma_done.valis True and the received message is CMD_COMPLETEat the same time,

--- a/controller/ControllerRTL.py
+++ b/controller/ControllerRTL.py
@@ -178,6 +178,22 @@ class ControllerRTL(Component):
     s.dma_bytes        = Wire(DmaBytesType)
     s.dma_tag          = Wire(DmaTagType)
 
+    # Bit i indicates whether the cmd received from the inter-CGRA NoC
+    # matches CTRL_NON_GENERIC_FORWARD_CMDS[i] (declared in
+    # lib/util/common.py), i.e., is consumed by a dedicated branch in
+    # update_received_msg rather than generically forwarded to the ctrl
+    # ring. Derived from the tuple so newly added command types are
+    # forwarded by default without touching this file (see #188). The
+    # tuple members are loaded into constant wires because PyMTL3's RTLIR
+    # translator supports neither `in`/`not in` nor tuple-valued free
+    # variables inside update blocks.
+    CmdType = CgraPayloadType.get_field_type(kAttrCmd)
+    num_non_generic_forward_cmds = len(CTRL_NON_GENERIC_FORWARD_CMDS)
+    s.recv_cmd_non_generic_match = Wire(num_non_generic_forward_cmds)
+    s.non_generic_forward_cmds = [Wire(CmdType) for _ in range(num_non_generic_forward_cmds)]
+    for i, cmd in enumerate(CTRL_NON_GENERIC_FORWARD_CMDS):
+      s.non_generic_forward_cmds[i] //= CmdType(cmd)
+
     # Connections.
     # Requests towards others, 1 cycle delay to improve timing.
     s.recv_from_tile_load_request_pkt_queue.recv //= s.recv_from_tile_load_request_pkt
@@ -240,6 +256,12 @@ class ControllerRTL(Component):
         s.recv_from_dma_spm_rd_req.rdy @= 0
         s.send_to_dma_spm_rd_resp.val @= 0
         s.send_to_dma_spm_rd_resp.msg @= DmaSpmReadRespType()
+
+    @update
+    def update_recv_cmd_non_generic_match():
+      for i in range(num_non_generic_forward_cmds):
+        s.recv_cmd_non_generic_match[i] @= \
+            (s.recv_from_inter_cgra_noc.msg.payload.cmd == s.non_generic_forward_cmds[i])
 
     @update
     def update_received_msg():
@@ -461,20 +483,13 @@ class ControllerRTL(Component):
           s.global_reduce_unit.recv_count.val @= 1
           s.global_reduce_unit.recv_count.msg @= s.recv_from_inter_cgra_noc.msg
 
-        # Catch-all: any type not consumed by a dedicated branch above is
-        # forwarded to the ctrl ring as-is. This avoids silently dropping
-        # newly-added command types that forget to be added to an explicit
-        # allow-list here (see #188). The set handled above is
-        # CTRL_NON_GENERIC_FORWARD_CMDS (defined in lib/util/common.py);
-        # PyMTL3's RTLIR translator has no `in`/`not in` on hardware values,
-        # so it is spelled out here as a `!=` chain over each member.
-        elif (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_LOAD_REQUEST) & \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_STORE_REQUEST) & \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_LOAD_RESPONSE) & \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_COMPLETE) & \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_LEAF_COUNTER_COMPLETE) & \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_GLOBAL_REDUCE_ADD) & \
-             (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_GLOBAL_REDUCE_COUNT):
+        # Catch-all: any type not consumed by a dedicated branch above
+        # (i.e., not in CTRL_NON_GENERIC_FORWARD_CMDS, from which
+        # s.recv_cmd_non_generic_match is derived) is forwarded to the
+        # ctrl ring as-is. This avoids silently dropping newly-added
+        # command types that forget to be added to an explicit allow-list
+        # here (see #188).
+        elif s.recv_cmd_non_generic_match == 0:
           s.recv_from_inter_cgra_noc.rdy @= s.send_to_ctrl_ring_pkt.rdy
           s.send_to_ctrl_ring_pkt.val @= s.recv_from_inter_cgra_noc.val
           s.send_to_ctrl_ring_pkt.msg @= \

--- a/controller/ControllerRTL.py
+++ b/controller/ControllerRTL.py
@@ -21,6 +21,17 @@ from ..noc.PyOCN.pymtl3_net.xbar.XbarRTL import XbarRTL
 from .GlobalReduceUnitRTL import GlobalReduceUnitRTL
 from ..lib.util.data_struct_attr import *
 
+# Command types received via the inter-CGRA NoC that are handled by their
+# own dedicated branch below rather than being generically forwarded to
+# the ctrl ring.
+kNonGenericForwardCmds = (CMD_LOAD_REQUEST,
+                          CMD_STORE_REQUEST,
+                          CMD_LOAD_RESPONSE,
+                          CMD_COMPLETE,
+                          CMD_LEAF_COUNTER_COMPLETE,
+                          CMD_GLOBAL_REDUCE_ADD,
+                          CMD_GLOBAL_REDUCE_COUNT)
+
 class ControllerRTL(Component):
 
   def construct(s,
@@ -462,11 +473,13 @@ class ControllerRTL(Component):
           s.global_reduce_unit.recv_count.msg @= s.recv_from_inter_cgra_noc.msg
 
         # Catch-all: any type not specially handled above (i.e., not one of
-        # CMD_LOAD_REQUEST/CMD_STORE_REQUEST/CMD_LOAD_RESPONSE/CMD_COMPLETE/
-        # CMD_LEAF_COUNTER_COMPLETE/CMD_GLOBAL_REDUCE_ADD/CMD_GLOBAL_REDUCE_COUNT)
-        # is forwarded to the ctrl ring as-is. This avoids silently dropping
-        # newly-added command types that forget to be added to an explicit
-        # allow-list here (see #188).
+        # the kNonGenericForwardCmds declared above) is forwarded to the
+        # ctrl ring as-is. This avoids silently dropping newly-added command
+        # types that forget to be added to an explicit allow-list here (see
+        # #188). Note: PyMTL3's RTLIR translator does not support the
+        # `in`/`not in` operators on hardware values, so membership against
+        # kNonGenericForwardCmds has to be spelled out as a `!=` chain
+        # instead of a single "not in" check.
         elif (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_LOAD_REQUEST) & \
              (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_STORE_REQUEST) & \
              (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_LOAD_RESPONSE) & \

--- a/controller/ControllerRTL.py
+++ b/controller/ControllerRTL.py
@@ -21,17 +21,6 @@ from ..noc.PyOCN.pymtl3_net.xbar.XbarRTL import XbarRTL
 from .GlobalReduceUnitRTL import GlobalReduceUnitRTL
 from ..lib.util.data_struct_attr import *
 
-# Command types received via the inter-CGRA NoC that are handled by their
-# own dedicated branch below rather than being generically forwarded to
-# the ctrl ring.
-kNonGenericForwardCmds = (CMD_LOAD_REQUEST,
-                          CMD_STORE_REQUEST,
-                          CMD_LOAD_RESPONSE,
-                          CMD_COMPLETE,
-                          CMD_LEAF_COUNTER_COMPLETE,
-                          CMD_GLOBAL_REDUCE_ADD,
-                          CMD_GLOBAL_REDUCE_COUNT)
-
 class ControllerRTL(Component):
 
   def construct(s,
@@ -472,14 +461,13 @@ class ControllerRTL(Component):
           s.global_reduce_unit.recv_count.val @= 1
           s.global_reduce_unit.recv_count.msg @= s.recv_from_inter_cgra_noc.msg
 
-        # Catch-all: any type not specially handled above (i.e., not one of
-        # the kNonGenericForwardCmds declared above) is forwarded to the
-        # ctrl ring as-is. This avoids silently dropping newly-added command
-        # types that forget to be added to an explicit allow-list here (see
-        # #188). Note: PyMTL3's RTLIR translator does not support the
-        # `in`/`not in` operators on hardware values, so membership against
-        # kNonGenericForwardCmds has to be spelled out as a `!=` chain
-        # instead of a single "not in" check.
+        # Catch-all: any type not consumed by a dedicated branch above is
+        # forwarded to the ctrl ring as-is. This avoids silently dropping
+        # newly-added command types that forget to be added to an explicit
+        # allow-list here (see #188). The set handled above is
+        # CTRL_NON_GENERIC_FORWARD_CMDS (defined in lib/util/common.py);
+        # PyMTL3's RTLIR translator has no `in`/`not in` on hardware values,
+        # so it is spelled out here as a `!=` chain over each member.
         elif (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_LOAD_REQUEST) & \
              (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_STORE_REQUEST) & \
              (s.recv_from_inter_cgra_noc.msg.payload.cmd != CMD_LOAD_RESPONSE) & \

--- a/lib/util/common.py
+++ b/lib/util/common.py
@@ -6,6 +6,8 @@ Author : Cheng Tan
   Date : Dec 24, 2022
 """
 
+from ..cmd_type import *
+
 # Constants for port index.
 PORT_INDEX_NORTH     = 0
 PORT_INDEX_SOUTH     = 1
@@ -90,3 +92,61 @@ STATE_DMA_MVOUT_RESP    = StateType( 5 ) # MVOUT: Receiving SPM read response an
 STATE_DMA_MVOUT_WRITE   = StateType( 6 ) # MVOUT: Issuing DRAM write request
 STATE_DMA_MVOUT_WAIT    = StateType( 7 ) # MVOUT: Waiting for DRAM write response
 STATE_DMA_DONE          = StateType( 8 ) # Signaling command completion
+
+############################################
+# Command-type groupings for packet dispatch.
+############################################
+# Centralizes the command-type sets used by the controller / ctrl-mem
+# dispatch logic so each grouping is defined in exactly one place.
+#
+# Note: PyMTL3's RTLIR translator does not support the `in`/`not in`
+# operators on hardware values, so the `@update` conditions in those
+# components cannot test membership directly; they compare against each
+# member by name (a `!=`/`==` chain). These tuples are the canonical,
+# documented definition of each set that those chains mirror.
+
+# Command types the CGRA controller consumes via a dedicated branch in its
+# inter-CGRA NoC handler, i.e. that are NOT generically forwarded to the
+# ctrl ring (see issue #188). Mirrored by ControllerRTL's NoC handler.
+CTRL_NON_GENERIC_FORWARD_CMDS = (CMD_LOAD_REQUEST,
+                                 CMD_STORE_REQUEST,
+                                 CMD_LOAD_RESPONSE,
+                                 CMD_COMPLETE,
+                                 CMD_LEAF_COUNTER_COMPLETE,
+                                 CMD_GLOBAL_REDUCE_ADD,
+                                 CMD_GLOBAL_REDUCE_COUNT)
+
+# Command types CtrlMemDynamicRTL forwards to another element (e.g. the loop
+# counter), in addition to accepting them. Mirrored by its `update_msg`.
+CTRL_MEM_SEND_TO_ELEMENT_CMDS = (CMD_GLOBAL_REDUCE_ADD_RESPONSE,
+                                 CMD_GLOBAL_REDUCE_MUL_RESPONSE,
+                                 CMD_CONFIG_LOOP_LOWER,
+                                 CMD_CONFIG_LOOP_UPPER,
+                                 CMD_CONFIG_LOOP_STEP,
+                                 CMD_UPDATE_COUNTER_SHADOW_VALUE,
+                                 CMD_RESET_LEAF_COUNTER)
+
+# All command types CtrlMemDynamicRTL recognizes / accepts. Unlike the
+# controller's generic catch-all, this is a curated allow-list -- the
+# component only knows what to do with these. Mirrored by its `update_msg`.
+CTRL_MEM_ACCEPTED_CMDS = CTRL_MEM_SEND_TO_ELEMENT_CMDS + (
+    CMD_CONFIG,
+    CMD_CONFIG_PROLOGUE_FU,
+    CMD_CONFIG_PROLOGUE_FU_CROSSBAR,
+    CMD_CONFIG_PROLOGUE_ROUTING_CROSSBAR,
+    CMD_LAUNCH,
+    CMD_TERMINATE,
+    CMD_PAUSE,
+    CMD_PRESERVE,
+    CMD_RESUME,
+    CMD_CONFIG_TOTAL_CTRL_COUNT,
+    CMD_CONFIG_COUNT_PER_ITER,
+    CMD_CONFIG_CTRL_LOWER_BOUND,
+    CMD_RECORD_PHI_ADDR,
+    CMD_CONFIG_STREAMING_LD_START_ADDR,
+    CMD_CONFIG_STREAMING_LD_STRIDE,
+    CMD_CONFIG_STREAMING_LD_END_ADDR)
+
+# Every command forwarded to another element must also be accepted, or it
+# would never reach the branch that forwards it.
+assert set(CTRL_MEM_SEND_TO_ELEMENT_CMDS) <= set(CTRL_MEM_ACCEPTED_CMDS)

--- a/lib/util/common.py
+++ b/lib/util/common.py
@@ -97,17 +97,17 @@ STATE_DMA_DONE          = StateType( 8 ) # Signaling command completion
 # Command-type groupings for packet dispatch.
 ############################################
 # Centralizes the command-type sets used by the controller / ctrl-mem
-# dispatch logic so each grouping is defined in exactly one place.
-#
-# Note: PyMTL3's RTLIR translator does not support the `in`/`not in`
-# operators on hardware values, so the `@update` conditions in those
-# components cannot test membership directly; they compare against each
-# member by name (a `!=`/`==` chain). These tuples are the canonical,
-# documented definition of each set that those chains mirror.
+# dispatch logic so each grouping is defined in exactly one place. The
+# components load these tuples into constant wires and compare the
+# received cmd against them, so editing a tuple here directly updates
+# the generated hardware -- no per-member condition needs to be touched.
+# (The indirection through constant wires exists because PyMTL3's RTLIR
+# translator supports neither `in`/`not in` on hardware values nor
+# tuple-valued free variables inside update blocks.)
 
 # Command types the CGRA controller consumes via a dedicated branch in its
 # inter-CGRA NoC handler, i.e. that are NOT generically forwarded to the
-# ctrl ring (see issue #188). Mirrored by ControllerRTL's NoC handler.
+# ctrl ring (see issue #188). Used by ControllerRTL.
 CTRL_NON_GENERIC_FORWARD_CMDS = (CMD_LOAD_REQUEST,
                                  CMD_STORE_REQUEST,
                                  CMD_LOAD_RESPONSE,
@@ -117,7 +117,7 @@ CTRL_NON_GENERIC_FORWARD_CMDS = (CMD_LOAD_REQUEST,
                                  CMD_GLOBAL_REDUCE_COUNT)
 
 # Command types CtrlMemDynamicRTL forwards to another element (e.g. the loop
-# counter), in addition to accepting them. Mirrored by its `update_msg`.
+# counter), in addition to accepting them. Used by its `update_msg`.
 CTRL_MEM_SEND_TO_ELEMENT_CMDS = (CMD_GLOBAL_REDUCE_ADD_RESPONSE,
                                  CMD_GLOBAL_REDUCE_MUL_RESPONSE,
                                  CMD_CONFIG_LOOP_LOWER,
@@ -128,7 +128,7 @@ CTRL_MEM_SEND_TO_ELEMENT_CMDS = (CMD_GLOBAL_REDUCE_ADD_RESPONSE,
 
 # All command types CtrlMemDynamicRTL recognizes / accepts. Unlike the
 # controller's generic catch-all, this is a curated allow-list -- the
-# component only knows what to do with these. Mirrored by its `update_msg`.
+# component only knows what to do with these. Used by its `update_msg`.
 CTRL_MEM_ACCEPTED_CMDS = CTRL_MEM_SEND_TO_ELEMENT_CMDS + (
     CMD_CONFIG,
     CMD_CONFIG_PROLOGUE_FU,

--- a/mem/ctrl/CtrlMemDynamicRTL.py
+++ b/mem/ctrl/CtrlMemDynamicRTL.py
@@ -20,6 +20,45 @@ from ...lib.opt_type import *
 from ...lib.util.common import *
 from ...lib.util.data_struct_attr import *
 
+# Command types that are forwarded to another element (e.g., the loop
+# counter) in `update_msg` below, in addition to being accepted here.
+kSendToElementCmds = (CMD_GLOBAL_REDUCE_ADD_RESPONSE,
+                      CMD_GLOBAL_REDUCE_MUL_RESPONSE,
+                      CMD_CONFIG_LOOP_LOWER,
+                      CMD_CONFIG_LOOP_UPPER,
+                      CMD_CONFIG_LOOP_STEP,
+                      CMD_UPDATE_COUNTER_SHADOW_VALUE,
+                      CMD_RESET_LEAF_COUNTER)
+
+# All command types recognized anywhere in this file, i.e., that this
+# component accepts (sets `recv_pkt_from_controller_queue.send.rdy`) in
+# `update_msg` below. This must stay in sync with every CMD_* referenced
+# elsewhere in this file (e.g. in issue_complete, update_raddr_and_fu_prologue,
+# update_upper_bound, update_total_ctrl_steps) -- unlike ControllerRTL's
+# generic catch-all (#188), this component only knows what to do with a
+# fixed, curated set of commands, so it can't safely default-accept
+# anything it doesn't recognize.
+kAcceptedCmds = kSendToElementCmds + (CMD_CONFIG,
+                                      CMD_CONFIG_PROLOGUE_FU,
+                                      CMD_CONFIG_PROLOGUE_FU_CROSSBAR,
+                                      CMD_CONFIG_PROLOGUE_ROUTING_CROSSBAR,
+                                      CMD_LAUNCH,
+                                      CMD_TERMINATE,
+                                      CMD_PAUSE,
+                                      CMD_PRESERVE,
+                                      CMD_RESUME,
+                                      CMD_CONFIG_TOTAL_CTRL_COUNT,
+                                      CMD_CONFIG_COUNT_PER_ITER,
+                                      CMD_CONFIG_CTRL_LOWER_BOUND,
+                                      CMD_RECORD_PHI_ADDR,
+                                      CMD_CONFIG_STREAMING_LD_START_ADDR,
+                                      CMD_CONFIG_STREAMING_LD_STRIDE,
+                                      CMD_CONFIG_STREAMING_LD_END_ADDR)
+
+# Static self-check: every command that's forwarded to another element must
+# also be accepted, or it would never reach the elif branch that forwards it.
+assert set(kSendToElementCmds) <= set(kAcceptedCmds)
+
 class CtrlMemDynamicRTL(Component):
 
   def construct(s, IntraCgraPktType,
@@ -129,6 +168,7 @@ class CtrlMemDynamicRTL(Component):
           s.reg_file.wdata[0].fu_xbar_outport[i] @= s.recv_pkt_from_controller_queue.send.msg.payload.ctrl.fu_xbar_outport[i]
         s.reg_file.wdata[0].vector_factor_power @= s.recv_pkt_from_controller_queue.send.msg.payload.ctrl.vector_factor_power
         s.reg_file.wdata[0].is_last_ctrl @= s.recv_pkt_from_controller_queue.send.msg.payload.ctrl.is_last_ctrl
+      # Mirrors kSendToElementCmds (see module-level comment above).
       elif s.recv_pkt_from_controller_queue.send.val & \
            ((s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_GLOBAL_REDUCE_ADD_RESPONSE) | \
             (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_GLOBAL_REDUCE_MUL_RESPONSE) | \
@@ -140,6 +180,7 @@ class CtrlMemDynamicRTL(Component):
         s.send_to_element.msg @= s.recv_pkt_from_controller_queue.send.msg.payload
         s.send_to_element.val @= 1
 
+      # Mirrors kAcceptedCmds (see module-level comment above).
       if (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG) | \
          (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_PROLOGUE_FU) | \
          (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_PROLOGUE_FU_CROSSBAR) | \

--- a/mem/ctrl/CtrlMemDynamicRTL.py
+++ b/mem/ctrl/CtrlMemDynamicRTL.py
@@ -88,9 +88,36 @@ class CtrlMemDynamicRTL(Component):
     s.prologue_count_reg_routing_crossbar = \
         [[Wire(PrologueCountType) for _ in range(num_routing_xbar_inports)] for _ in range(ctrl_mem_size)]
 
+    # Match vectors derived from the command-type groupings declared in
+    # lib/util/common.py: bit i of each vector indicates whether the
+    # received cmd equals member i of the corresponding tuple. Loading the
+    # tuple members into constant wires keeps the tuples the single source
+    # of truth, since PyMTL3's RTLIR translator supports neither
+    # `in`/`not in` nor tuple-valued free variables inside update blocks.
+    CmdType = CgraPayloadType.get_field_type(kAttrCmd)
+    num_send_to_element_cmds = len(CTRL_MEM_SEND_TO_ELEMENT_CMDS)
+    num_accepted_cmds = len(CTRL_MEM_ACCEPTED_CMDS)
+    s.send_to_element_cmds = [Wire(CmdType) for _ in range(num_send_to_element_cmds)]
+    s.accepted_cmds = [Wire(CmdType) for _ in range(num_accepted_cmds)]
+    s.recv_cmd_send_to_element_match = Wire(num_send_to_element_cmds)
+    s.recv_cmd_accepted_match = Wire(num_accepted_cmds)
+    for i, cmd in enumerate(CTRL_MEM_SEND_TO_ELEMENT_CMDS):
+      s.send_to_element_cmds[i] //= CmdType(cmd)
+    for i, cmd in enumerate(CTRL_MEM_ACCEPTED_CMDS):
+      s.accepted_cmds[i] //= CmdType(cmd)
+
     # Connections.
     s.recv_pkt_from_controller //= s.recv_pkt_from_controller_queue.recv
     s.recv_from_element //= s.recv_from_element_queue.recv
+
+    @update
+    def update_recv_cmd_match():
+      for i in range(num_send_to_element_cmds):
+        s.recv_cmd_send_to_element_match[i] @= \
+            (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == s.send_to_element_cmds[i])
+      for i in range(num_accepted_cmds):
+        s.recv_cmd_accepted_match[i] @= \
+            (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == s.accepted_cmds[i])
 
     @update
     def update_msg():
@@ -129,42 +156,16 @@ class CtrlMemDynamicRTL(Component):
           s.reg_file.wdata[0].fu_xbar_outport[i] @= s.recv_pkt_from_controller_queue.send.msg.payload.ctrl.fu_xbar_outport[i]
         s.reg_file.wdata[0].vector_factor_power @= s.recv_pkt_from_controller_queue.send.msg.payload.ctrl.vector_factor_power
         s.reg_file.wdata[0].is_last_ctrl @= s.recv_pkt_from_controller_queue.send.msg.payload.ctrl.is_last_ctrl
-      # Mirrors CTRL_MEM_SEND_TO_ELEMENT_CMDS (defined in lib/util/common.py).
+      # The cmd is one of CTRL_MEM_SEND_TO_ELEMENT_CMDS (defined in
+      # lib/util/common.py, from which the match vector is derived).
       elif s.recv_pkt_from_controller_queue.send.val & \
-           ((s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_GLOBAL_REDUCE_ADD_RESPONSE) | \
-            (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_GLOBAL_REDUCE_MUL_RESPONSE) | \
-            (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_LOOP_LOWER) | \
-            (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_LOOP_UPPER) | \
-            (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_LOOP_STEP) | \
-            (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_UPDATE_COUNTER_SHADOW_VALUE) | \
-            (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_RESET_LEAF_COUNTER)):
+           (s.recv_cmd_send_to_element_match != 0):
         s.send_to_element.msg @= s.recv_pkt_from_controller_queue.send.msg.payload
         s.send_to_element.val @= 1
 
-      # Mirrors CTRL_MEM_ACCEPTED_CMDS (defined in lib/util/common.py).
-      if (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_PROLOGUE_FU) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_PROLOGUE_FU_CROSSBAR) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_PROLOGUE_ROUTING_CROSSBAR) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_LAUNCH) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_TERMINATE) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_PAUSE) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_PRESERVE) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_RESUME) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_TOTAL_CTRL_COUNT) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_COUNT_PER_ITER) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_CTRL_LOWER_BOUND) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_RECORD_PHI_ADDR) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_GLOBAL_REDUCE_ADD_RESPONSE) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_STREAMING_LD_START_ADDR) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_STREAMING_LD_STRIDE) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_STREAMING_LD_END_ADDR) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_GLOBAL_REDUCE_MUL_RESPONSE) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_LOOP_LOWER) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_LOOP_UPPER) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_LOOP_STEP) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_UPDATE_COUNTER_SHADOW_VALUE) | \
-         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_RESET_LEAF_COUNTER):
+      # The cmd is one of CTRL_MEM_ACCEPTED_CMDS (defined in
+      # lib/util/common.py, from which the match vector is derived).
+      if s.recv_cmd_accepted_match != 0:
         s.recv_pkt_from_controller_queue.send.rdy @= 1
       # TODO: Extend for the other commands. Maybe another queue to
       # handle complicated actions.

--- a/mem/ctrl/CtrlMemDynamicRTL.py
+++ b/mem/ctrl/CtrlMemDynamicRTL.py
@@ -20,45 +20,6 @@ from ...lib.opt_type import *
 from ...lib.util.common import *
 from ...lib.util.data_struct_attr import *
 
-# Command types that are forwarded to another element (e.g., the loop
-# counter) in `update_msg` below, in addition to being accepted here.
-kSendToElementCmds = (CMD_GLOBAL_REDUCE_ADD_RESPONSE,
-                      CMD_GLOBAL_REDUCE_MUL_RESPONSE,
-                      CMD_CONFIG_LOOP_LOWER,
-                      CMD_CONFIG_LOOP_UPPER,
-                      CMD_CONFIG_LOOP_STEP,
-                      CMD_UPDATE_COUNTER_SHADOW_VALUE,
-                      CMD_RESET_LEAF_COUNTER)
-
-# All command types recognized anywhere in this file, i.e., that this
-# component accepts (sets `recv_pkt_from_controller_queue.send.rdy`) in
-# `update_msg` below. This must stay in sync with every CMD_* referenced
-# elsewhere in this file (e.g. in issue_complete, update_raddr_and_fu_prologue,
-# update_upper_bound, update_total_ctrl_steps) -- unlike ControllerRTL's
-# generic catch-all (#188), this component only knows what to do with a
-# fixed, curated set of commands, so it can't safely default-accept
-# anything it doesn't recognize.
-kAcceptedCmds = kSendToElementCmds + (CMD_CONFIG,
-                                      CMD_CONFIG_PROLOGUE_FU,
-                                      CMD_CONFIG_PROLOGUE_FU_CROSSBAR,
-                                      CMD_CONFIG_PROLOGUE_ROUTING_CROSSBAR,
-                                      CMD_LAUNCH,
-                                      CMD_TERMINATE,
-                                      CMD_PAUSE,
-                                      CMD_PRESERVE,
-                                      CMD_RESUME,
-                                      CMD_CONFIG_TOTAL_CTRL_COUNT,
-                                      CMD_CONFIG_COUNT_PER_ITER,
-                                      CMD_CONFIG_CTRL_LOWER_BOUND,
-                                      CMD_RECORD_PHI_ADDR,
-                                      CMD_CONFIG_STREAMING_LD_START_ADDR,
-                                      CMD_CONFIG_STREAMING_LD_STRIDE,
-                                      CMD_CONFIG_STREAMING_LD_END_ADDR)
-
-# Static self-check: every command that's forwarded to another element must
-# also be accepted, or it would never reach the elif branch that forwards it.
-assert set(kSendToElementCmds) <= set(kAcceptedCmds)
-
 class CtrlMemDynamicRTL(Component):
 
   def construct(s, IntraCgraPktType,
@@ -168,7 +129,7 @@ class CtrlMemDynamicRTL(Component):
           s.reg_file.wdata[0].fu_xbar_outport[i] @= s.recv_pkt_from_controller_queue.send.msg.payload.ctrl.fu_xbar_outport[i]
         s.reg_file.wdata[0].vector_factor_power @= s.recv_pkt_from_controller_queue.send.msg.payload.ctrl.vector_factor_power
         s.reg_file.wdata[0].is_last_ctrl @= s.recv_pkt_from_controller_queue.send.msg.payload.ctrl.is_last_ctrl
-      # Mirrors kSendToElementCmds (see module-level comment above).
+      # Mirrors CTRL_MEM_SEND_TO_ELEMENT_CMDS (defined in lib/util/common.py).
       elif s.recv_pkt_from_controller_queue.send.val & \
            ((s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_GLOBAL_REDUCE_ADD_RESPONSE) | \
             (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_GLOBAL_REDUCE_MUL_RESPONSE) | \
@@ -180,7 +141,7 @@ class CtrlMemDynamicRTL(Component):
         s.send_to_element.msg @= s.recv_pkt_from_controller_queue.send.msg.payload
         s.send_to_element.val @= 1
 
-      # Mirrors kAcceptedCmds (see module-level comment above).
+      # Mirrors CTRL_MEM_ACCEPTED_CMDS (defined in lib/util/common.py).
       if (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG) | \
          (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_PROLOGUE_FU) | \
          (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_PROLOGUE_FU_CROSSBAR) | \


### PR DESCRIPTION
## Summary
Addresses #188: several places gate command delivery by exhaustively enumerating command types, which is easy to forget when adding a new type.

### The mechanism
The command-type groupings are declared once as tuples in `lib/util/common.py`:
- `CTRL_NON_GENERIC_FORWARD_CMDS` — types the controller consumes via a dedicated branch in its inter-CGRA NoC handler (everything else is now generically forwarded to the ctrl ring).
- `CTRL_MEM_SEND_TO_ELEMENT_CMDS` / `CTRL_MEM_ACCEPTED_CMDS` — `CtrlMemDynamicRTL`'s "forward to element" and "accept" sets, with an `assert SEND_TO_ELEMENT <= ACCEPTED` self-check next to the definitions.

The components **derive their dispatch conditions from these tuples**: each tuple's members are loaded into constant wires at construct time (same pattern as `ControllerRTL`'s existing `idTo2d_x_lut`), a small unrolled update block computes a per-member match vector, and the dispatch conditions test that vector (`== 0` / `!= 0`). Editing a tuple in `common.py` directly changes the generated hardware — no per-member condition line to keep in sync.

Why the constant-wire indirection instead of `cmd not in TUPLE`: PyMTL3's RTLIR translator supports neither `in`/`not in` on hardware values (`Operator <ast.NotIn> is not supported!`) nor tuple-valued free variables inside update blocks (`RTLIRConversionError: unrecognized object (10, 12, ...)`), both confirmed with `pytest --test-verilog`.

### Behavior changes
- `ControllerRTL`: the generic-forward branch previously allow-listed ~20 types by name; a newly-added type missing from the list was silently dropped (the disabled `# else: assert(False)` shows this was a known risk). It is now a true catch-all: anything without a dedicated branch is forwarded. Behavior for all previously-listed types (including `CMD_CONST`) is unchanged.
- `CtrlMemDynamicRTL`: **no behavior change** — its accept gate is a curated "do I recognize this at all" allow-list (the complement spans types nothing in the component can process), so it cannot be inverted like the controller's. Its conditions are now derived from the centralized tuples instead of duplicating them inline.

## Scope: why `tile/TileRTL.py` is untouched
Tracing every connection to `s.ctrl_mem.recv_pkt_from_controller` in `TileRTL.py`: the `feed_pkt` block is the only feeder, and it forwards only 12 of the ~23 types `CtrlMemDynamicRTL` recognizes — the rest (`CMD_TERMINATE`, `CMD_PAUSE`, `CMD_RESUME`, …) must reach ctrl_mem via another path. It's a two-purpose dispatcher (config → ctrl_mem, const → const_mem), not a catch-all; inverting it risks double-delivering commands handled elsewhere. Flagging for the assignees (@yyan7223 @ShangkunLi) with this tracing so it needn't be re-derived.

## Test plan
- `pytest controller/test/ControllerRTL_test.py mem/ctrl/test/CtrlMemDynamicRTL_test.py mem/ctrl/test/RingCtrlMemDynamicRTL_test.py tile/test/TileRTL_test.py` — same pass/fail counts as `master` (the 2 failures are a pre-existing local Verilator-version issue in my environment, reproduced identically on unmodified `master`; CI is authoritative here).
- Verified the generated Verilog with `--test-verilog`: tuple values appear as constant array assignments (`assign accepted_cmds[0] = 6'd20;` etc.) and the dispatch conditions become match-vector compares (`recv_cmd_accepted_match != 23'd0`).