### PR TITLE
Extend YAML kernel configuration generation

### DIFF
--- a/mem/ctrl/CtrlMemDynamicRTL.py
+++ b/mem/ctrl/CtrlMemDynamicRTL.py
@@ -135,6 +135,7 @@ class CtrlMemDynamicRTL(Component):
             (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_LOOP_LOWER) | \
             (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_LOOP_UPPER) | \
             (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_LOOP_STEP) | \
+            (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_GEP_STRIDE) | \
             (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_UPDATE_COUNTER_SHADOW_VALUE) | \
             (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_RESET_LEAF_COUNTER)):
         s.send_to_element.msg @= s.recv_pkt_from_controller_queue.send.msg.payload
@@ -161,6 +162,7 @@ class CtrlMemDynamicRTL(Component):
          (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_LOOP_LOWER) | \
          (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_LOOP_UPPER) | \
          (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_LOOP_STEP) | \
+         (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_CONFIG_GEP_STRIDE) | \
          (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_UPDATE_COUNTER_SHADOW_VALUE) | \
          (s.recv_pkt_from_controller_queue.send.msg.payload.cmd == CMD_RESET_LEAF_COUNTER):
         s.recv_pkt_from_controller_queue.send.rdy @= 1

--- a/tile/TileRTL.py
+++ b/tile/TileRTL.py
@@ -39,7 +39,7 @@ class TileRTL(Component):
 
   def construct(s, IntraCgraPktType,
                 ctrl_mem_size, data_mem_size, num_ctrl,
-                total_steps, num_fu_inports, num_fu_outports, 
+                total_steps, num_fu_inports, num_fu_outports,
                 num_tile_inports, num_tile_outports, num_cgras, num_tiles,
                 num_registers_per_reg_bank = 16,
                 Fu = FlexibleFuRTL,
@@ -81,7 +81,7 @@ class TileRTL(Component):
     s.to_mem_wdata = SendIfcRTL(DataType)
 
     # Components.
-    s.element = FlexibleFuRTL(CtrlPktType, num_fu_inports, 
+    s.element = FlexibleFuRTL(CtrlPktType, num_fu_inports,
                               num_fu_outports, num_tiles, FuList)
     s.const_mem = ConstQueueDynamicRTL(DataType, ctrl_mem_size)
     s.routing_crossbar = CrossbarRTL(DataType,
@@ -258,7 +258,8 @@ class TileRTL(Component):
             (s.recv_from_controller_pkt.msg.payload.cmd == CMD_LAUNCH) | \
             (s.recv_from_controller_pkt.msg.payload.cmd == CMD_CONFIG_LOOP_LOWER) | \
             (s.recv_from_controller_pkt.msg.payload.cmd == CMD_CONFIG_LOOP_UPPER) | \
-            (s.recv_from_controller_pkt.msg.payload.cmd == CMD_CONFIG_LOOP_STEP)):
+            (s.recv_from_controller_pkt.msg.payload.cmd == CMD_CONFIG_LOOP_STEP) | \
+            (s.recv_from_controller_pkt.msg.payload.cmd == CMD_CONFIG_GEP_STRIDE)):
             s.ctrl_mem.recv_pkt_from_controller.val @= 1
             s.ctrl_mem.recv_pkt_from_controller.msg @= s.recv_from_controller_pkt.msg
             s.recv_from_controller_pkt.rdy @= s.ctrl_mem.recv_pkt_from_controller.rdy
@@ -332,4 +333,3 @@ class TileRTL(Component):
     ctrl_mem = s.ctrl_mem.line_trace()
     const_mem = s.const_mem.line_trace()
     return f"send_str: {send_str}, tile_inports: {recv_str} => [tile_in_channel: {tile_in_channel_str} || routing_crossbar: {s.routing_crossbar.recv_opt.msg} || fu_crossbar: {s.fu_crossbar.recv_opt.msg} || element: {s.element.line_trace()} || s.element_done: {s.element_done}, s.fu_crossbar_done: {s.fu_crossbar_done}, s.routing_crossbar_done: {s.routing_crossbar_done} ||  ctrl_mem: {ctrl_mem}, const_mem: {const_mem} ## "
-

--- a/validation/script_generator.py
+++ b/validation/script_generator.py
@@ -75,13 +75,17 @@ yaml_to_VectorCGRA_map = {
     "FMUL": OPT_FMUL,
     "FDIV": None, # ?
     "OR": OPT_OR,
+    "AND": OPT_AND,
     "NOT": OPT_NOT,
-    "ICMP": None, # ?
+    "ICMP_EQ": OPT_EQ, # ?
+    "ICMP_SGE": OPT_GTE,
+    "ICMP_SGT": OPT_GT,
+    "ICMP_SLT": OPT_LT,
     "FCMP": None, # ?
     "SEL": OPT_SEL,
     "CAST": None, # ?
     "SEXT": OPT_PAS, # no sext, just a fake one.
-    "ZEXT": None, # ?
+    "ZEXT": OPT_PAS, # zero extension treated as pass-through
     "SHL": OPT_LLS,
     "VFMUL": None, # ?
     "FADD_FADD": None, #?
@@ -95,9 +99,17 @@ yaml_to_VectorCGRA_map = {
     "PHI": OPT_PHI,
     "LOOP_CONTROL": None, #?
     "PHI_CONST": OPT_PHI_CONST, 
+    "PHI_START": OPT_PHI_START,
+    
+    "GEP": OPT_ADD, # By now, we just support 2 op GEP and it is equivalent to ADD (base + index)
+    "GEP_2D": OPT_GEP_2D, # special GEP for 2D array access, with 3 operands (base, idx1, idx2) and idx1/idx2 are multiplied with different stride.
     
     "RETURN": OPT_RET,
+    "RETURN_VALUE": OPT_RET,
+    "RETURN_VOID": OPT_RET_VOID,
     "LDD": OPT_LD,
+    "LOAD": OPT_LD,
+    "STORE": OPT_STR,
     
     "NE": OPT_NE,
     "MUL_ADD": OPT_MUL_ADD,
@@ -106,9 +118,22 @@ yaml_to_VectorCGRA_map = {
 }
 
 yaml_to_VectorCGRA_map_const = {
+    "CONSTANT": OPT_CONST,
     "NE": OPT_NE_CONST,
     "ADD": OPT_ADD_CONST,
     "MUL_ADD": OPT_MUL_CONST_ADD,
+    "MUL": OPT_MUL_CONST,
+    "SUB": OPT_SUB_CONST,
+    "DIV": OPT_DIV_CONST,
+    "GEP": OPT_ADD_CONST, # By now, we just support 2 op GEP and it is equivalent to ADD (base + index)
+    "GEP_2D": OPT_GEP_2D_CONST,
+    "ICMP_EQ": OPT_EQ_CONST,
+    "ICMP_SGE": OPT_GTE_CONST,
+    "ICMP_SGT": OPT_GT_CONST,
+    "ICMP_SLT": OPT_LT_CONST,
+
+    "GRANT_ONCE": OPT_GRT_ONCE_CONST,
+    "SHL": OPT_LLS_CONST,
 }
 
 
@@ -121,17 +146,44 @@ def _type(Operand):
         return 'PORT'
     else:
         return 'IMM'
+    
+def direction_to_idx(direction):
+    if direction == 'NORTH':
+        return 0
+    elif direction == 'SOUTH':
+        return 1
+    elif direction == 'WEST':
+        return 2
+    elif direction == 'EAST':
+        return 3
+    else:
+        raise ValueError("Invalid direction: ", direction)
 
 def _is_take_up_fu_operation(operation):
-    if operation['opcode'] == 'MOV' or operation['opcode'] == 'DATA_MOV':
+    if operation['opcode'] == 'MOV' or operation['opcode'] == 'DATA_MOV' or operation['opcode'] == 'CTRL_MOV':
         if len(operation['src_operands']) != 1:
             raise ValueError("MOV operation must have exactly one source operand")
-        elif _type(operation['src_operands'][0]) == 'REG':
-            return True
+        elif _type(operation['src_operands'][0]) == 'PORT':
+            return False # By now, only Port -> Port and Port -> Reg are not take up fu operations
         else:
-            return False
+            # REG -> PORT only: can be handled by FU output crossbar routing
+            # without occupying the FU, so treat as not-take-up-fu.
+            dst_operands = operation.get('dst_operands', [])
+            if dst_operands and all(_type(d) == 'PORT' for d in dst_operands):
+                return False
+            return True
     else:
         return True
+    
+def _take_up_fu_operation_idx_of(operations: list):
+    # check if there is only < 1 take up fu operation, if 1, return the idx, if > 1, raise error, if 0, return -1
+    take_up_fu_operation_idx = -1
+    for idx, operation in enumerate(operations):
+        if _is_take_up_fu_operation(operation):
+            if take_up_fu_operation_idx != -1:
+                raise ValueError("Only one take up fu operation is allowed, panic in instruction ", operations)
+            take_up_fu_operation_idx = idx
+    return take_up_fu_operation_idx
     
 def _reg_cluster_no_of(operand): # start from 1
     impl = operand['operand']
@@ -146,6 +198,9 @@ def _reg_cluster_intra_index_of(operand):
         return int(impl[1:]) % REG_CLUSTER_SIZE
     else:
         raise ValueError("Operand is not a register")
+
+def print_instruction(instruction):
+    print(f"Instruction: {[operation['opcode'] for operation in instruction['operations']]}")
 
 FROM_NOWHERE = 0
 FROM_PORT = 1
@@ -197,8 +252,10 @@ class InstructionSignals:
         # States
         self.TileInParams = [-1, -1, -1, -1, -1, -1, -1, -1]
         self.FuOutParams = [-1, -1, -1, -1, -1, -1, -1, -1]
-        self.read_from_reg = [-1, -1, -1, -1]
-        self.read_from_reg_idx = [-1, -1, -1, -1]
+        self.read_reg_towards_fu = [-1, -1, -1, -1]
+        self.read_reg_towards_xbar = [-1, -1, -1, -1]
+        self.operand_from = [-1, -1, -1, -1]
+        self.read_towards_reg_idx = [-1, -1, -1, -1]
         self.write_to_reg = [-1, -1, -1, -1]
         self.write_to_reg_idx = [-1, -1, -1, -1]
         self.shuffle_fu_operand_input_index = [-1, -1, -1, -1]
@@ -207,73 +264,175 @@ class InstructionSignals:
     def buildCtrlPkt(self) -> list: # return the const needed to put into the const queue
         # you must call buildCtrlPkt before makeCtrlPkt, and for a Tile's signal, you must call buildCtrlPkt in order.
         try:
-            take_up_fu_operation_idx = -1
-            for idx, operation in enumerate(self.operations):
-                if _is_take_up_fu_operation(operation):
-                    if take_up_fu_operation_idx != -1:
-                        raise ValueError("Only one take up fu operation is allowed")
-                    take_up_fu_operation_idx = idx
             
-            # TODO: fix logic here
-                  
-            take_up_fu_operation = self.operations[take_up_fu_operation_idx]
-            has_const = False
-            # if has src_operands, check if has const
-            try:
-                src_operands = take_up_fu_operation['src_operands']
-            except Exception as e:
-                src_operands = []
-            for src_operand in src_operands:
-                if _type(src_operand) == 'IMM':
-                    has_const = True
-                    break 
-                
-            if take_up_fu_operation['opcode'] == 'PHI_CONST' or take_up_fu_operation['opcode'] == 'CONSTANT' or take_up_fu_operation['opcode'] == 'GRANT_ONCE':
-                has_const = False # PHI_CONST and CONSTANT are special.
+            # 1. Find take up fu operation
+            take_up_fu_operation_idx = _take_up_fu_operation_idx_of(self.operations)
             
-            if has_const:
-                self.opCode = yaml_to_VectorCGRA_map_const[self.operations[take_up_fu_operation_idx]['opcode']]
+            if take_up_fu_operation_idx == -1:
+                print("No take up fu operation found, just take the first.")
+                take_up_fu_operation_idx = 0
+                take_up_fu_operation = "NAH"
+                self.OpCode = OPT_NAH
             else:
-                self.opCode = yaml_to_VectorCGRA_map[self.operations[take_up_fu_operation_idx]['opcode']]
+                print("Take_up_fu_operation: ", self.operations[take_up_fu_operation_idx])
+                take_up_fu_operation = self.operations[take_up_fu_operation_idx]
+                # only take up fu can be const
+                has_const = False
+                # if has src_operands, check if has const
+                try:
+                    src_operands = take_up_fu_operation['src_operands']
+                except Exception as e:
+                    src_operands = []
+                for src_operand in src_operands:
+                    if _type(src_operand) == 'IMM':
+                        has_const = True
+                        break 
+                
+                #if take_up_fu_operation['opcode'] == 'PHI_CONST' or take_up_fu_operation['opcode'] == 'CONSTANT':
+                    #has_const = False # PHI_CONST and CONSTANT are special.
+            
+                if has_const:
+                    self.OpCode = yaml_to_VectorCGRA_map_const[self.operations[take_up_fu_operation_idx]['opcode']]
+                else:
+                    self.OpCode = yaml_to_VectorCGRA_map[self.operations[take_up_fu_operation_idx]['opcode']]
 
             const_operands = []
 
-            for operation in self.operations: # for each operation in the instruction
-                
-                print("Working on operation: ", operation)
-                
+            # Process non-take-up-fu operations first to reserve their
+            # TileInParams slots before take-up-fu port lane allocation.
+            ordered_operations = sorted(
+                self.operations,
+                key=lambda op: 0 if not _is_take_up_fu_operation(op) else 1)
+
+            for operation in ordered_operations: # for each operation in the instruction
+
+                print("\n Operation: ", operation)
+
                 operation_opcode = operation['opcode']
                 try:
-                    src_operands = operation['src_operands']
+                    src_operands = operation['src_operands'].copy()
+                    if operation_opcode == 'STORE' and len(src_operands) >= 2:
+                        # HW expects address in0 and data in1, but YAML gives [data, addr]
+                        src_operands[0], src_operands[1] = src_operands[1], src_operands[0]
                 except Exception as e:
                     src_operands = []
                 try:
                     dst_operands = operation['dst_operands']
                 except Exception as e:
                     dst_operands = []
-                
+
                 # find all the const
                 for index, src_operand in enumerate(src_operands):
                     if _type(src_operand) == 'IMM':
-                        const_operands.append(src_operand)
+                        # include the real timestep for future sorting
+                        const_operands.append((src_operand, operation["time_step"]))
                         # delete it from the src_operands since it is implicit in vectorCGRA
                         del src_operands[index]
+
+                # for not_take_up_fu_operation
+                if not _is_take_up_fu_operation(operation):
+
+                    if len(src_operands) != 1:
+                        raise ValueError(f"Not take up fu operation {operation} must have exactly one source operand.")
+
+                    src_operand = src_operands[0]
+
+                    # REG -> PORT: route via FU output crossbar (merge with
+                    # the take-up-fu operation's output routing).
+                    if _type(src_operand) == 'REG': 
+                        intra_index = _reg_cluster_intra_index_of(src_operand)
+                        cluster_no = _reg_cluster_no_of(src_operand)
+                        
+                        # check collision
+                        if self.read_reg_towards_xbar[cluster_no - 1] != -1 and self.read_towards_reg_idx[cluster_no - 1] != intra_index:
+                            # another register calls for sending to the FU
+                            raise ValueError(f"Collision when reading from register in read_reg_towards_fu, when translate the operation {operation} to VectorCGRA")
+                        
+                        if self.operand_from[cluster_no - 1] != -1 and self.operand_from[cluster_no - 1] == OPR_FROM_PORT:
+                            raise ValueError(f"The register operand overwrite the port operand in lane {cluster_no -1}")
+                        
+                        for index, dst_operand in enumerate(dst_operands):
+                            if _type(dst_operand) == 'PORT':
+                                if dst_operand['operand'] == 'NORTH':
+                                    port_out_xbar_idx = 0
+                                elif dst_operand['operand'] == 'SOUTH':
+                                    port_out_xbar_idx = 1
+                                elif dst_operand['operand'] == 'WEST':
+                                    port_out_xbar_idx = 2
+                                elif dst_operand['operand'] == 'EAST':
+                                    port_out_xbar_idx = 3
+                                if self.TileInParams[port_out_xbar_idx] != -1:
+                                    # another source want to send to the direction
+                                    raise ValueError(f"Collision in writing to port {dst_operand} in FuOutParams (REG->PORT), when translate the operation {operation} to VectorCGRA")
+                                self.TileInParams[port_out_xbar_idx] = cluster_no + 4 # directly route from the register cluster to the port, no need to shuffle to FU first
+                                self.read_reg_towards_xbar[cluster_no - 1] = 1
+                                self.read_towards_reg_idx[cluster_no - 1] = intra_index
+                                self.operand_from[cluster_no - 1] = OPR_FROM_REGISTER
+                            else:
+                                raise ValueError(f"REG->non-PORT dst {dst_operand} classified as not take-up-fu, when translate the operation {operation} to VectorCGRA")
+                        continue
+
+                    elif _type(src_operand) == 'PORT':
+                        src_direction_idx = direction_to_idx(src_operand['operand'])
+
+                        for index, dst_operand in enumerate(dst_operands):
+                            if _type(dst_operand) == 'REG':
+                                cluster_no = _reg_cluster_no_of(dst_operand)
+                                intra_index = _reg_cluster_intra_index_of(dst_operand)
+                                # set the TileInParams
+                                if self.TileInParams[cluster_no + 4 - 1] != -1 and self.TileInParams[cluster_no + 4 - 1] != src_direction_idx + 1:
+                                    raise ValueError(f"Collision when reading from port in TileInParams, when translate the operation {operation} to VectorCGRA")
+                                self.TileInParams[cluster_no + 4 - 1] = src_direction_idx + 1
+
+                                if self.write_to_reg_idx[cluster_no - 1] != -1 and self.write_to_reg_idx[cluster_no - 1] != intra_index:
+                                    raise ValueError(f"Collision when writing to register in write_to_reg_idx, when translate the operation {operation} to VectorCGRA")
+                                self.write_to_reg[cluster_no - 1] = FROM_PORT
+                                self.write_to_reg_idx[cluster_no - 1] = intra_index
+                            elif _type(dst_operand) == 'PORT':
+                                if dst_operand['operand'] == 'NORTH':
+                                    port_out_xbar_idx = 0
+                                elif dst_operand['operand'] == 'SOUTH':
+                                    port_out_xbar_idx = 1
+                                elif dst_operand['operand'] == 'WEST':
+                                    port_out_xbar_idx = 2
+                                elif dst_operand['operand'] == 'EAST':
+                                    port_out_xbar_idx = 3
+                                if self.TileInParams[port_out_xbar_idx] != -1 and self.TileInParams[port_out_xbar_idx] != src_direction_idx + 1:
+                                    raise ValueError(f"Collision in writing to port {dst_operand} in FuOutParams, when translate the operation {operation} to VectorCGRA")
+                                self.TileInParams[port_out_xbar_idx] = src_direction_idx + 1 # 1,2,3,4 for N,S,W,E
+                            else:
+                                raise ValueError(f"Unsupported type of dst operand {dst_operand}, when translate the operation {operation} to VectorCGRA")
+                        continue
+                             
                 
+                # reorder the src operands since register has high priority (cause reg can't be shuffled but port can be shuffled)
+                # TODO: not complete, actually should also take dst into account
+                reordered_src_operands = {}
                 for index, src_operand in enumerate(src_operands):
+                    if _type(src_operand) == 'REG':
+                        reordered_src_operands[index] = src_operand
+                for index, src_operand in enumerate(src_operands):
+                    if not _type(src_operand) == 'REG':
+                        reordered_src_operands[index] = src_operand
+                
+                for index, src_operand in reordered_src_operands.items():
                     if _type(src_operand) == 'REG':
                         print(f">>> index {index} is REG")
                         cluster_no = _reg_cluster_no_of(src_operand)
                         intra_index = _reg_cluster_intra_index_of(src_operand)
                         # Check if cluster_no is within valid range (1 to num_fu_inports)
-                        if cluster_no < 1 or cluster_no > len(self.read_from_reg_idx):
-                            raise ValueError(f"Register cluster number {cluster_no} is out of range. Valid range is 1 to {len(self.read_from_reg_idx)} for register {src_operand['operand']} in operation {operation}")
+                        if cluster_no < 1 or cluster_no > len(self.read_towards_reg_idx):
+                            raise ValueError(f"Register cluster number {cluster_no} is out of range. Valid range is 1 to {len(self.read_towards_reg_idx)} for register {src_operand['operand']} in operation {operation}")
                         # Check if intra_index is within valid range (0 to REG_CLUSTER_SIZE-1)
                         if intra_index < 0 or intra_index >= REG_CLUSTER_SIZE:
                             raise ValueError(f"Register intra index {intra_index} is out of range. Valid range is 0 to {REG_CLUSTER_SIZE-1} for register {src_operand['operand']} in operation {operation}")
-                        if self.read_from_reg_idx[cluster_no - 1] != -1 and self.read_from_reg_idx[cluster_no - 1] != intra_index:
+                        if self.read_reg_towards_fu[cluster_no - 1] != -1 and self.read_towards_reg_idx[cluster_no - 1] != intra_index:
                             raise ValueError(f"Collision when reading from register in read_from_reg_idx, when translate the operation {operation} to VectorCGRA")
-                        self.read_from_reg[cluster_no - 1] = OPR_FROM_REGISTER
-                        self.read_from_reg_idx[cluster_no - 1] = intra_index
+                        if self.operand_from[cluster_no - 1] != -1 and self.operand_from[cluster_no - 1] != OPR_FROM_REGISTER:
+                            raise ValueError(f"Register operand overwrite the port operand in lane {cluster_no -1}, when translate the operation {operation} to VectorCGRA")
+                        self.operand_from[cluster_no - 1] = OPR_FROM_REGISTER
+                        self.read_towards_reg_idx[cluster_no - 1] = intra_index
+                        self.read_reg_towards_fu[cluster_no - 1] = 1
                         if self.shuffle_fu_operand_input_index[index] != -1:
                             raise ValueError(f"Collision when reading from register in shuffle_fu_operand_input_index, when translate the operation {operation} to VectorCGRA")
                         self.shuffle_fu_operand_input_index[index] = cluster_no # shuffle the data to the correct inport of the FU from the register
@@ -290,22 +449,25 @@ class InstructionSignals:
                         # find an available lane
                         lane = -1
                         for i in range(4):
-                            if self.read_from_reg[i] == -1: # if not set the selection, then it could be available
+                            ok = self.operand_from[i] == -1 and self.TileInParams[i + 4] == -1 # The lane is completely empty
+                            ok = ok or (self.operand_from[i] == OPR_FROM_PORT and self.TileInParams[i + 4] == port_in_xbar_idx) # The lane is already used by the same port, can be reused
+                            ok = ok or (self.operand_from[i] == -1 and self.TileInParams[i + 4] == port_in_xbar_idx) # The lane is used by the same port to register 
+                            if ok:
                                 lane = i
                                 break
                         if lane == -1:
                             raise ValueError(f"No available lane found when reading from port {src_operand} in TileInParams, when translate the operation {operation} to VectorCGRA")
-                        if self.TileInParams[lane + 4] != -1:
-                            raise ValueError(f"Collision in reading from port in TileInParams, when translate the operation {operation} to VectorCGRA")
+                        else:
+                            print(f"Lane {lane} available for port source {src_operand}")
                         self.TileInParams[lane + 4] = port_in_xbar_idx
-                        self.read_from_reg[lane] = OPR_FROM_PORT
+                        self.operand_from[lane] = OPR_FROM_PORT
                         # shuffle to the given fu input index
                         if self.shuffle_fu_operand_input_index[index] != -1:
-                            raise ValueError(f"Collision when reading from port in shuffle_fu_operand_input_index, when translate the operation {operation} to VectorCGRA")
+                            raise ValueError(f"Collision when reading from port in shuffle_fu_operand_input_index {self.shuffle_fu_operand_input_index} (want to set opr {index} to {lane}), when translate the operation {operation} to VectorCGRA")
                         self.shuffle_fu_operand_input_index[index] = lane + 1
                         
                     if _type(src_operand) == 'IMM':
-                        raise NotImplementedError("IMM src operand is not supported yet")
+                        raise NotImplementedError("IMM src should have been removed here")
                     
                 for index, dst_operand in enumerate(dst_operands):
                     if _type(dst_operand) == 'REG':
@@ -318,7 +480,7 @@ class InstructionSignals:
                         if intra_index < 0 or intra_index >= REG_CLUSTER_SIZE:
                             raise ValueError(f"Register intra index {intra_index} is out of range. Valid range is 0 to {REG_CLUSTER_SIZE-1} for register {dst_operand['operand']} in operation {operation}")
                         if self.write_to_reg_idx[cluster_no - 1] != -1 and self.write_to_reg_idx[cluster_no - 1] != intra_index:
-                            raise ValueError(f"Collision when writing to register in write_to_reg_idx, when translate the operation {operation} to VectorCGRA")
+                            raise ValueError(f"Collision when writing to register in write_to_reg_idx, when translate the operation {operation} to VectorCGRA, cluster {cluster_no - 1} originally has intra index {self.write_to_reg_idx[cluster_no - 1]}, but now want to set intra index {intra_index}")
                         self.write_to_reg[cluster_no - 1] = FROM_FU
                         self.write_to_reg_idx[cluster_no - 1] = intra_index
                         if self.FuOutParams[cluster_no + 3] != -1:
@@ -350,7 +512,7 @@ class InstructionSignals:
         # make fu_in_code
         for idx, fu_in_code in enumerate(self.shuffle_fu_operand_input_index):
             if fu_in_code == -1:
-                self.shuffle_fu_operand_input_index[idx] = idx + 1 # 0 or idle inport of ALU?
+                self.shuffle_fu_operand_input_index[idx] = 0
         fu_in_code_made = [self.FuInType(x) for x in self.shuffle_fu_operand_input_index] # is it correct?
         
         # make TileIn
@@ -375,17 +537,24 @@ class InstructionSignals:
         write_reg_idx_made = [self.RegIdxType(x) for x in self.write_to_reg_idx]
         
         # make read reg from code
-        for idx, read_from_reg in enumerate(self.read_from_reg):
-            if read_from_reg == -1:
-                self.read_from_reg[idx] = OPR_FROM_PORT
+        read_towards = [-1, -1, -1, -1]
+        for idx in range(4):
+             if self.read_reg_towards_fu[idx] == 1 and self.read_reg_towards_xbar[idx] == 1:
+                read_towards[idx] = 3 # both
+             elif self.read_reg_towards_fu[idx] == 1:
+                read_towards[idx] = 1 # to fu
+             elif self.read_reg_towards_xbar[idx] == 1:
+                read_towards[idx] = 2 # to xbar
+             else:
+                read_towards[idx] = 0 # to nowhere
 
         # read_reg_towards uses 2-bit type (RegFromType): 0=nothing, 1=FU, 2=routing_xbar, 3=both
-        read_reg_towards_made = [self.B2Type(x) for x in self.read_from_reg]
+        read_reg_towards_made = [self.B2Type(x) for x in read_towards]
         
-        for idx, read_from_reg_idx in enumerate(self.read_from_reg_idx):
-            if read_from_reg_idx == -1:
-                self.read_from_reg_idx[idx] = 0
-        read_reg_idx_made = [self.RegIdxType(x) for x in self.read_from_reg_idx]
+        for idx, read_towards_reg_idx in enumerate(self.read_towards_reg_idx):
+            if read_towards_reg_idx == -1:
+                self.read_towards_reg_idx[idx] = 0
+        read_reg_idx_made = [self.RegIdxType(x) for x in self.read_towards_reg_idx]
         
         # make FuOut
         # CtrlType requires: operation, fu_in, routing_xbar_outport, fu_xbar_outport,
@@ -395,7 +564,7 @@ class InstructionSignals:
         pkt = self.IntraCgraPktType(0, self.id_,
                                     payload = self.CgraPayloadType(self.CMD_CONFIG_,
                                                                     ctrl_addr = self.CtrlAddrType(self.ctrl_addr),
-                                                                    ctrl = self.CtrlType(self.opCode,
+                                                                    ctrl = self.CtrlType(self.OpCode,
                                                                                         fu_in_code_made,
                                                                                         TileIn_made,
                                                                                         FuOut_made,
@@ -460,95 +629,65 @@ class TileSignals:
         
         self.CMD_LAUNCH_ = CMD_LAUNCH_input
         
+    def sanitize(self, instruction):
+        # check 1: take_up_fu function <= 1
+        take_up_fu_operation_idx = _take_up_fu_operation_idx_of(instruction['operations'])
         
-    def makeProloguePackets(self, instruction):
-        print(f"Making prologue packets for instruction {instruction}")
-        pkts = []
-        pkts.append(self.makePrologueFUPackets(instruction)) # always prologue FU
-        take_up_fu_operation_idx = -1
-        for idx, operation in enumerate(instruction['operations']):
-            if _is_take_up_fu_operation(operation):
-                if take_up_fu_operation_idx != -1:
-                    raise ValueError("Only one take up fu operation is allowed")
-                take_up_fu_operation_idx = idx
-        take_up_fu_operation = None  
-        if take_up_fu_operation_idx != -1:
-            take_up_fu_operation = instruction['operations'][take_up_fu_operation_idx]
-            # TODO: fix the logic for only having non-take up fu operation
-        else:
-            raise ValueError("No take up fu operation found")
-        try:
-            src_operands = take_up_fu_operation['src_operands']
-        except Exception as e:
-            src_operands = []
-        for src_operand in src_operands:
-            if _type(src_operand) == 'PORT':
-                print(f"src_operand is PORT, add Prologue. {src_operand}")
-                if src_operand['operand'] == 'NORTH':
-                    routing_xbar_idx = 0 # here is from 0, strange.
-                elif src_operand['operand'] == 'SOUTH':
-                    routing_xbar_idx = 1
-                elif src_operand['operand'] == 'WEST':
-                    routing_xbar_idx = 2
-                elif src_operand['operand'] == 'EAST':
-                    routing_xbar_idx = 3
-                pkts.append(self.makePrologueRoutingCrossbarPackets(instruction, routing_xbar_idx))
-        
-        try:
-            dst_operands = take_up_fu_operation['dst_operands']
-        except Exception as e:
-            dst_operands = []
-
-        for dst_operand in dst_operands:
-            if _type(dst_operand) == 'REG':
-                pkts.append(self.makePrologueFUCrossbarPackets(instruction))
-        return pkts
-    
-    def makePhiConstProloguePackets(self, instruction):
-        print(f"Making phi const prologue packets for instruction {instruction}")
+        # check 2: prologue routing crossbar each port consistently either all ignore or not 
+        routing_xbar_ports_if_prologued = {}
         for operation in instruction['operations']:
-            if operation['opcode'] == 'PHI_CONST':
-                phi_const_operation = operation
-                break
-        if phi_const_operation is None:
-            raise ValueError("No PHI_CONST operation found")
-        try:
-            src_operands = phi_const_operation['src_operands']
-        except Exception as e:
-            src_operands = []
+            invalid_cycle = operation['invalid_iterations']
             
-        pkts = []
+            # for reg -> port
+            if not _is_take_up_fu_operation(operation):
+                if len(operation['src_operands']) != 1:
+                    raise ValueError("Not take up fu operation must have exactly one source operand, panic in instruction ", instruction, " at operation ", operation)
+                src_operand = operation['src_operands'][0]
+                if _type(src_operand) == 'REG':
+                    cluster_no = _reg_cluster_no_of(src_operand)
+                    idd = f"R{cluster_no}"
+                    # print (f"Check prologue for reg operand {src_operand['operand']} in operation {operation}, cluster_no {cluster_no}, idd {idd}")
+                    if idd in routing_xbar_ports_if_prologued:
+                        if routing_xbar_ports_if_prologued[idd] != invalid_cycle:
+                            raise ValueError("Routing crossbar ports must be consistently either all ignore or not, panic in instruction ", instruction)
+                    else:
+                        routing_xbar_ports_if_prologued[idd] = invalid_cycle
+                    
+            for src_operand in operation['src_operands']:
+                if _type(src_operand) == 'PORT':
+                    if src_operand['operand'] in routing_xbar_ports_if_prologued:
+                        if routing_xbar_ports_if_prologued[src_operand['operand']] != invalid_cycle:
+                            raise ValueError("Routing crossbar ports must be consistently either all ignore or not, panic in instruction ", instruction)
+                    else:
+                        routing_xbar_ports_if_prologued[src_operand['operand']] = invalid_cycle
+                        
+        # check 3: all the time_steps are aligned with the index_per_ii
+        for operation in instruction['operations']:
+            if operation['time_step'] % self.ii != instruction['index_per_ii']:
+                print("Time step ", operation['time_step'], "ii", self.ii, " is not aligned with index per ii ", instruction['index_per_ii'])
+                raise ValueError("Time step is not aligned with index per ii, panic in instruction ", instruction, " at operation ", operation)
+                        
+        return routing_xbar_ports_if_prologued
+
+    
+    
+    def makePrologueFUPackets(self, timestep, prologue_count=1):
+        # make prologue FU packet
+        return self.IntraCgraPktType(0, self.id_, 
+                                     payload = self.CgraPayloadType(self.CMD_CONFIG_PROLOGUE_FU_, ctrl_addr = self.CtrlAddrType(timestep % self.ii),
+                                                                     data = self.DataType(prologue_count, 1)))
         
-        for src_operand in src_operands:
-            if _type(src_operand) == 'PORT':
-                if src_operand['operand'] == 'NORTH':
-                    routing_xbar_idx = 0
-                elif src_operand['operand'] == 'SOUTH':
-                    routing_xbar_idx = 1
-                elif src_operand['operand'] == 'WEST':
-                    routing_xbar_idx = 2
-                elif src_operand['operand'] == 'EAST':
-                    routing_xbar_idx = 3
-                pkts.append(self.makePrologueRoutingCrossbarPackets(instruction, routing_xbar_idx))
-                
-        print(f"Phi const prologue packets: {pkts}")
-        return pkts
-    
-    
-    def makePrologueFUPackets(self, instruction):
+    def makePrologueRoutingCrossbarPackets(self, timestep, routing_xbar_idx, prologue_count=1):
         return self.IntraCgraPktType(0, self.id_, 
-                                     payload = self.CgraPayloadType(self.CMD_CONFIG_PROLOGUE_FU_, ctrl_addr = self.CtrlAddrType(instruction['timestep'] % self.ii),
-                                                                     data = self.DataType(1, 1)))
-    def makePrologueRoutingCrossbarPackets(self, instruction, routing_xbar_idx):
-        return self.IntraCgraPktType(0, self.id_, 
-                                     payload = self.CgraPayloadType(self.CMD_CONFIG_PROLOGUE_ROUTING_CROSSBAR_, ctrl_addr = self.CtrlAddrType(instruction['timestep'] % self.ii),
+                                     payload = self.CgraPayloadType(self.CMD_CONFIG_PROLOGUE_ROUTING_CROSSBAR_, ctrl_addr = self.CtrlAddrType(timestep % self.ii),
                                                                      ctrl = self.CtrlType(routing_xbar_outport = [self.TileInType(routing_xbar_idx)] + [self.TileInType(0)] * 7),
-                                                                     data = self.DataType(1, 1)))
-    def makePrologueFUCrossbarPackets(self, instruction):
+                                                                     data = self.DataType(prologue_count, 1)))
+    def makePrologueFUCrossbarPackets(self, timestep, prologue_count=1):
         return self.IntraCgraPktType(0, self.id_, 
-                                     payload = self.CgraPayloadType(self.CMD_CONFIG_PROLOGUE_FU_CROSSBAR_, ctrl_addr = self.CtrlAddrType(instruction['timestep'] % self.ii),
+                                     payload = self.CgraPayloadType(self.CMD_CONFIG_PROLOGUE_FU_CROSSBAR_, ctrl_addr = self.CtrlAddrType(timestep % self.ii),
                                                                      ctrl = self.CtrlType(fu_xbar_outport = [self.FuOutType(0)] * 8),
-                                                                     data = self.DataType(1, 1)))
+                                                                     # WARN:by now, only support one result for each operation
+                                                                     data = self.DataType(prologue_count, 1)))
     def makeTileSignals(self):
         consts = []
         all_signals = []
@@ -558,24 +697,81 @@ class TileSignals:
         
         # build all the instruction signals and get all the const
         for instruction in self.instructions:
-            if instruction['timestep'] >= self.ii:
-                prologue_signals.extend(self.makeProloguePackets(instruction))
+            print("================================================")
+            print("Instruction: ", instruction)
+             # do necessary sanitization
+            prologued_ports = self.sanitize(instruction)
+            #print(prologued_ports)
             
-            has_phi_const = False # cope with special PHI_CONST operation
+            # only when the take_up_fu_op exists and no prologue, then no prologue
+            prologue_fu = False
+            prologue_fu_cycles = 0
+            has_take_up_fu_op = False
+            non_take_up_fu_prologue_cycle_max = 0
+            
             for operation in instruction['operations']:
-                if operation['opcode'] == 'PHI_CONST':
-                    has_phi_const = True
-                    break
-            if has_phi_const:
-                prologue_signals.extend(self.makePhiConstProloguePackets(instruction))
+                if operation['invalid_iterations'] >= 1:
+                    prologue_fu = True     
+            
+            for operation in instruction['operations']:
+                if _is_take_up_fu_operation(operation):
+                    has_take_up_fu_op = True
+                    if operation['invalid_iterations'] == 0:
+                        prologue_fu = False
+                    else: # the prologue cycle depends on the comp instruction since only one take-up fu is allowed.
+                        prologue_fu_cycles = operation['invalid_iterations'] # this should only be executed once.
+                else:
+                    non_take_up_fu_prologue_cycle_max = max(non_take_up_fu_prologue_cycle_max, operation['invalid_iterations'])
+            
+            if not has_take_up_fu_op: # pure move operations, the prologue should be the max of them
+                prologue_fu_cycles = non_take_up_fu_prologue_cycle_max
+                        
+            
+            # only non-taken prologue -> still need prologue FU
+            # only taken prologue -> need prologue FU
+            #  +--------------------+----------+--------------+
+            #  | non-taken \ taken  | prologue | not prologue |
+            #  +--------------------+----------+--------------+
+            #  | prologue           |   yes    |    no        |
+            #  | not prologue       |   yes    |    no        |
+            #  +--------------------+----------+--------------+
+                    
+            if prologue_fu:
+                prologue_signals.append(self.makePrologueFUPackets(instruction['index_per_ii'], prologue_fu_cycles))
+                prologue_signals.append(self.makePrologueFUCrossbarPackets(instruction['index_per_ii'], prologue_fu_cycles))
                 
-            has_addrs.append(instruction['timestep'] % self.ii)
+            # add all routing crossbar prologues for all the operations (can not be op by op to avoid repetition)
+            for port_name, cycles in prologued_ports.items():
+                #print("add prologue for port ", port_name, " with cycles ", cycles)
+                if cycles > 0:
+                    if port_name.startswith('R'):
+                        cluster_no = int(port_name[1:])
+                        routing_xbar_idx = cluster_no + 4 - 1# the mapping from reg cluster to routing xbar index in TileInParams
+                    else:
+                        routing_xbar_idx = direction_to_idx(port_name)
+                    prologue_signals.append(self.makePrologueRoutingCrossbarPackets(instruction['index_per_ii'], routing_xbar_idx + 1, cycles))
+            
+            #print(prologue_signals)
+            # add an addtional prologue packet for PHI_CONST / PHI_START operation
+            for operation in instruction['operations']:
+                if operation['opcode'] == 'PHI_CONST' or operation['opcode'] == "PHI_START":
+                    # only src1 will be prologued once, and only if it is a port, it needs a routing crossbar prologue
+                    if _type(operation['src_operands'][1]) == 'PORT':
+                        routing_xbar_idx = direction_to_idx(operation['src_operands'][1]['operand'])
+                        if operation['src_operands'][1]['operand'] in prologued_ports:
+                            old_prologue_cycles = prologued_ports[operation['src_operands'][1]['operand']]
+                            prologue_signals.append(self.makePrologueRoutingCrossbarPackets(operation['time_step'], routing_xbar_idx + 1, old_prologue_cycles + 1))
+                        else:
+                            prologue_signals.append(self.makePrologueRoutingCrossbarPackets(operation['time_step'], routing_xbar_idx + 1, 1))
+            
+            # mark this time slot is not empty
+            has_addrs.append(instruction['index_per_ii'])
             
             instruction_signals = InstructionSignals(
                 id_ = self.id_,
                 operations = instruction['operations'],
                 opcode_in_EIR = instruction['operations'][0]['opcode'], # transient TODO: make it general
-                ctrl_addr = instruction['timestep'] % self.ii,
+                ctrl_addr = instruction['index_per_ii'],
                 IntraCgraPktType = self.IntraCgraPktType,
                 CgraPayloadType = self.CgraPayloadType,
                 TileInType = self.TileInType,
@@ -594,10 +790,14 @@ class TileSignals:
                 consts.extend(const)
         
         # make the const signals
+        # sort the consts according to the usage order
+        consts.sort(key=lambda x: x[1])
+        #print("\n\n\n\n\n\n\n\n\n\n\n\n\n")
+        #print(consts)
         for idx, const_operand in enumerate(consts):
             const_pkt = self.IntraCgraPktType(0, self.id_, 
                                               payload = self.CgraPayloadType(self.CMD_CONST_,
-                                                                             data = self.DataType(int(const_operand['operand'][1:] if const_operand['operand'].startswith('#') else const_operand['operand']), 1)))
+                                                                             data = self.DataType(int(const_operand[0]['operand'][1:] if const_operand[0]['operand'].startswith('#') else const_operand[0]['operand']), 1)))
             all_signals.append(const_pkt)
             
         # make the pre-configuration
@@ -768,7 +968,7 @@ if __name__ == "__main__":
     print("Test the Basic Functionality of the ScriptFactory")
 
     script_factory = ScriptFactory(
-        path = "./validation/test/fir_acceptance_test.yaml",
+        path = "./validation/test/gemm/gemm.yaml",
         CtrlType = CtrlTypeDummy,
         IntraCgraPktType = IntraCgraPktTypeDummy,
         CgraPayloadType = CgraPayloadTypeDummy,
@@ -776,7 +976,7 @@ if __name__ == "__main__":
         FuOutType = FuOutTypeDummy,
         CMD_CONFIG_input = CMD_CONFIG_Dummy(),
         FuInType = FuInTypeDummy,
-        ii = 4,
+        ii = 17,
         loop_times = 2,
         CMD_CONST_input = CMD_CONST_Dummy(),
         CMD_CONFIG_COUNT_PER_ITER_input = CMD_CONFIG_COUNT_PER_ITER_Dummy(),


### PR DESCRIPTION
## Summary
- extend YAML-to-VectorCGRA opcode and operand translation
- support multi-cycle prologue configuration
- route GEP stride configuration into control memory
- improve constant ordering and lane/register conflict checks

This is the shared prerequisite for the kernel-validation PRs split from #323.

Related to #318. Supersedes the generator portion of #323.