### PR TITLE
[refactor] Runtime-configure im2col via packed LAUNCH packet fields

### DIFF
--- a/cgra/IntegratedIm2ColWithCgraRTL.py
+++ b/cgra/IntegratedIm2ColWithCgraRTL.py
@@ -7,34 +7,35 @@ DMA-style topology: the CPU only talks to the CGRA controller, and the
 Im2col engine sits behind the controller like a DMA peripheral, with
 its own dedicated packet ports on the controller.
 
-The launch flow: a CPU-issued IntraCgraPkt with cmd = CMD_IM2COL_LAUNCH
-enters the controller through recv_from_cpu_pkt; the controller
-recognizes the cmd and forwards the whole packet on
-send_to_im2col_engine_pkt to the engine's recv_cmd_pkt port. The engine
-parses the packet's packed fields (H, W, kH, kW, log2_stride, in_base,
-dest_base) and starts computing im2col on the preloaded image. The
-lowered (kH*kW) x (Hout*Wout) matrix is streamed into the CGRA's data
-memory as a sequence of CMD_STORE_REQUEST packets that enter the
-controller through the engine-dedicated recv_from_im2col_pkt (a
-separate port so its source is obvious at the interface level). Both
-packet streams reach the same internal crossbar, so they still share
-downstream routing to data_mem / ctrl_ring / NoC.
+The launch flow: the CPU sends a series of CMD_IM2COL_* CONFIG packets
+(H, W, kH, kW, log2_stride, dst_sram_base) followed by
+CMD_IM2COL_LAUNCH through recv_from_cpu_pkt. The controller forwards
+every one of these packets on send_to_im2col_engine_pkt to the
+engine's recv_cmd_pkt port; the engine latches each CONFIG value into
+its corresponding register while in S_IDLE, and starts processing on
+LAUNCH. The lowered (kH*kW) x (Hout*Wout) matrix is streamed into the
+CGRA's data memory as a sequence of CMD_STORE_REQUEST packets that
+enter the controller through the engine-dedicated recv_from_im2col_pkt
+(a separate port so its source is obvious at the interface level).
+Both packet streams reach the same internal crossbar, so they still
+share downstream routing to data_mem / ctrl_ring / NoC.
 
 Architecture:
 
     +----------------- IntegratedIm2ColWithCgraRTL --------------------+
     |                                                                  |
     |  recv_from_cpu_pkt --------> cgra.recv_from_cpu_pkt              |
-    |  (CPU: config / launch /                |                        |
-    |   query / CMD_IM2COL_LAUNCH)            |                        |
-    |                                         |  send_to_im2col_       |
+    |  (CPU: tile config /                    |                        |
+    |   query / CMD_IM2COL_* CONFIG           |                        |
+    |   + CMD_IM2COL_LAUNCH)                  |  send_to_im2col_       |
     |                                         |  engine_pkt (fork of   |
-    |                                         |  CMD_IM2COL_LAUNCH)    |
+    |                                         |  CMD_IM2COL_* CONFIG   |
+    |                                         |  and CMD_IM2COL_LAUNCH)|
     |                                         v                        |
-    |                                  +------+----------+             |
-    |                                  |  Im2colEngineRTL |             |
-    |                                  |  (Im2col +       |             |
-    |                                  |   scratchpads +  |             |
+    |                                  +------+---------+              |
+    |                                  |  Im2colEngineRTL|              |
+    |                                  |  (im2col + in_mem|             |
+    |                                  |   scratchpad +   |             |
     |                                  |   emit FSM)      |             |
     |                                  +--------+---------+             |
     |                                           | engine.send_pkt       |
@@ -54,11 +55,12 @@ from .CgraRTL import CgraRTL
 from ..fu.others.Im2colEngineRTL import Im2colEngineRTL
 from ..lib.basic.val_rdy.ifcs import ValRdyRecvIfcRTL as RecvIfcRTL
 from ..lib.basic.val_rdy.ifcs import ValRdySendIfcRTL as SendIfcRTL
+from ..lib.cmd_type import CMD_IM2COL_LAUNCH
 from ..lib.messages import (mk_cgra_id_type, mk_inter_cgra_pkt,
                             mk_intra_cgra_pkt)
 from ..lib.util.common import KING_MESH, MESH
-from ..lib.util.data_struct_attr import (kAttrCtrl, kAttrData, kAttrDataAddr,
-                                          kAttrPayload)
+from ..lib.util.data_struct_attr import (kAttrCmd, kAttrCtrl, kAttrData,
+                                          kAttrDataAddr, kAttrPayload)
 
 
 class IntegratedIm2ColWithCgraRTL(Component):
@@ -73,9 +75,9 @@ class IntegratedIm2ColWithCgraRTL(Component):
                 FunctionUnit, FuList, cgra_topology,
                 controller2addr_map, idTo2d_map,
                 # Im2col engine parameters. All geometry (H, W, kH, kW,
-                # stride, in_base, dest_base) is now runtime-configured
-                # via the CMD_IM2COL_LAUNCH packet fields; only the
-                # scratchpad size and the (test-only) preload image
+                # log2_stride, dst_sram_base_addr) is runtime-configured
+                # via CMD_IM2COL_* CONFIG packets before LAUNCH; only
+                # the scratchpad size and the (test-only) preload image
                 # remain at construct time.
                 engine_scratch_mem_size,
                 engine_preload_image,
@@ -185,12 +187,19 @@ class IntegratedIm2ColWithCgraRTL(Component):
 
     s.engine_active = Wire(b1)
 
+    CmdType = CgraPayloadType.get_field_type(kAttrCmd)
+
     @update_ff
     def update_engine_active():
       if s.reset:
         s.engine_active <<= b1(0)
       else:
-        if s.engine.recv_cmd_pkt.val & s.engine.recv_cmd_pkt.rdy:
+        # Only the LAUNCH handshake activates the engine; the preceding
+        # CONFIG handshakes stay in S_IDLE and must not gate the CPU
+        # stream.
+        if s.engine.recv_cmd_pkt.val & s.engine.recv_cmd_pkt.rdy & (
+            s.engine.recv_cmd_pkt.msg.payload.cmd
+            == CmdType(CMD_IM2COL_LAUNCH)):
           s.engine_active <<= b1(1)
         elif s.engine.done:
           s.engine_active <<= b1(0)

--- a/cgra/IntegratedIm2ColWithCgraRTL.py
+++ b/cgra/IntegratedIm2ColWithCgraRTL.py
@@ -9,15 +9,16 @@ its own dedicated packet ports on the controller.
 
 The launch flow: a CPU-issued IntraCgraPkt with cmd = CMD_IM2COL_LAUNCH
 enters the controller through recv_from_cpu_pkt; the controller
-recognizes the cmd and forwards the packet on send_to_im2col_engine_pkt
-to trigger engine.start. The engine then reads the preloaded image
-from its input scratchpad, computes im2col, and streams the lowered
-(kH*kW) x (Hout*Wout) matrix into the CGRA's data memory as a sequence
-of CMD_STORE_REQUEST packets that enter the controller through the
-engine-dedicated recv_from_im2col_pkt (a separate port so its source is
-obvious at the interface level). Both packet streams reach the same
-internal crossbar, so they still share downstream routing to data_mem
-/ ctrl_ring / NoC.
+recognizes the cmd and forwards the whole packet on
+send_to_im2col_engine_pkt to the engine's recv_cmd_pkt port. The engine
+parses the packet's packed fields (H, W, kH, kW, log2_stride, in_base,
+dest_base) and starts computing im2col on the preloaded image. The
+lowered (kH*kW) x (Hout*Wout) matrix is streamed into the CGRA's data
+memory as a sequence of CMD_STORE_REQUEST packets that enter the
+controller through the engine-dedicated recv_from_im2col_pkt (a
+separate port so its source is obvious at the interface level). Both
+packet streams reach the same internal crossbar, so they still share
+downstream routing to data_mem / ctrl_ring / NoC.
 
 Architecture:
 
@@ -71,10 +72,12 @@ class IntegratedIm2ColWithCgraRTL(Component):
                 total_steps, mem_access_is_combinational,
                 FunctionUnit, FuList, cgra_topology,
                 controller2addr_map, idTo2d_map,
-                # Im2col engine parameters (geometry + per-cell routing).
+                # Im2col engine parameters. All geometry (H, W, kH, kW,
+                # stride, in_base, dest_base) is now runtime-configured
+                # via the CMD_IM2COL_LAUNCH packet fields; only the
+                # scratchpad size and the (test-only) preload image
+                # remain at construct time.
                 engine_scratch_mem_size,
-                engine_in_base,
-                engine_H, engine_W, engine_kH, engine_kW, engine_stride,
                 engine_preload_image,
                 has_ctrl_ring = True):
 
@@ -116,8 +119,6 @@ class IntegratedIm2ColWithCgraRTL(Component):
     s.engine = Im2colEngineRTL(
         DataType, CtrlPktType, CgraPayloadType,
         engine_scratch_mem_size,
-        engine_in_base,
-        engine_H, engine_W, engine_kH, engine_kW, engine_stride,
         engine_preload_image)
 
     s.cgra = CgraRTL(CgraPayloadType,
@@ -132,12 +133,10 @@ class IntegratedIm2ColWithCgraRTL(Component):
                      has_ctrl_ring = has_ctrl_ring,
                      has_im2col_engine = True)
 
-    # DMA-style trigger. The CGRA controller forks packets whose
-    # payload.cmd == CMD_IM2COL_LAUNCH to send_to_im2col_engine_pkt;
-    # we drive engine.start with the val of that stream (one-cycle
-    # pulse) and always acknowledge with rdy=1.
-    s.engine.start                       //= s.cgra.send_to_im2col_engine_pkt.val
-    s.cgra.send_to_im2col_engine_pkt.rdy //= 1
+    # DMA-style trigger. The controller forwards the full LAUNCH packet
+    # (which now carries runtime config in its fields) directly to the
+    # engine's recv_cmd_pkt port.
+    s.engine.recv_cmd_pkt //= s.cgra.send_to_im2col_engine_pkt
 
     # Pass-through wiring to CgraRTL.
     s.cgra.cgra_id       //= s.cgra_id
@@ -177,12 +176,11 @@ class IntegratedIm2ColWithCgraRTL(Component):
     # and without this gate the tile launches would race the engine's
     # store requests and execute against un-preloaded SRAM.
     #
-    # `engine_active` rises on engine.start (the cycle we fork
-    # CMD_IM2COL_LAUNCH to the engine) and clears on engine.done. While
-    # high, the CPU-facing recv_from_cpu_pkt is held (rdy=0) so
-    # subsequent CPU packets wait. The engine's dedicated
-    # recv_from_im2col_pkt is unaffected -- it carries the preload
-    # stream freely.
+    # `engine_active` rises on the LAUNCH handshake (val & rdy on the
+    # engine's recv_cmd_pkt) and clears on engine.done. While high, the
+    # CPU-facing recv_from_cpu_pkt is held (rdy=0) so subsequent CPU
+    # packets wait. The engine's dedicated recv_from_im2col_pkt is
+    # unaffected -- it carries the preload stream freely.
     s.engine.send_pkt //= s.cgra.recv_from_im2col_pkt
 
     s.engine_active = Wire(b1)
@@ -192,7 +190,7 @@ class IntegratedIm2ColWithCgraRTL(Component):
       if s.reset:
         s.engine_active <<= b1(0)
       else:
-        if s.engine.start:
+        if s.engine.recv_cmd_pkt.val & s.engine.recv_cmd_pkt.rdy:
           s.engine_active <<= b1(1)
         elif s.engine.done:
           s.engine_active <<= b1(0)

--- a/cgra/test/Im2colCgraE2E_test.py
+++ b/cgra/test/Im2colCgraE2E_test.py
@@ -47,6 +47,7 @@ from pymtl3.stdlib.test_utils import (run_sim,
                                       config_model_with_cmdline_opts)
 
 from ..IntegratedIm2ColWithCgraRTL import IntegratedIm2ColWithCgraRTL
+from ...fu.others.Im2colEngineRTL import pack_im2col_launch
 from ...fu.double.SeqMulAdderRTL import SeqMulAdderRTL
 from ...fu.flexible.FlexibleFuRTL import FlexibleFuRTL
 from ...fu.float.FpAddRTL import FpAddRTL
@@ -146,7 +147,7 @@ class TestHarness(Component):
                 topology, controller2addr_map,
                 idTo2d_map, complete_signal_sink_out,
                 multi_cgra_rows, multi_cgra_columns, src_query_pkt,
-                engine_image, engine_geom, engine_scratch_mem_size):
+                engine_image, engine_scratch_mem_size):
 
     DataAddrType = mk_bits(clog2(data_mem_size_global))
     s.num_tiles  = width * height
@@ -164,10 +165,6 @@ class TestHarness(Component):
         FlexibleFuRTL, FuList, topology,
         controller2addr_map, idTo2d_map,
         engine_scratch_mem_size,
-        engine_geom['in_base'],
-        engine_geom['H'],        engine_geom['W'],
-        engine_geom['kH'],       engine_geom['kW'],
-        engine_geom['stride'],
         engine_image)
 
     cmp_fn = lambda a, b: (a.payload.data == b.payload.data and
@@ -369,12 +366,21 @@ def _run(pe_weights, expected_outputs,
                              DataType, TileInType, FuInType, FuOutType,
                              CTRL_STEPS, pe_weights, expected_outputs)
 
-  # DMA-style trigger: prepend a CMD_IM2COL_LAUNCH packet. The CGRA
-  # controller inspects the payload.cmd and forks this one packet off
-  # to send_to_im2col_engine_pkt (its DMA outport); all other packets
-  # continue into the controller's crossbar as before.
-  launch_pkt = IntraCgraPktType(
-      payload = CgraPayloadType(CMD_IM2COL_LAUNCH))
+  # DMA-style trigger: prepend a CMD_IM2COL_LAUNCH packet whose fields
+  # carry the runtime im2col config. The controller forwards this single
+  # packet to send_to_im2col_engine_pkt; the engine parses the packed
+  # fields on the IDLE->READ edge.
+  launch_data = pack_im2col_launch(
+      H       = engine_geom['H'],
+      W       = engine_geom['W'],
+      in_base = engine_geom['in_base'],
+      kH      = engine_geom['kH'],
+      kW      = engine_geom['kW'],
+      stride  = engine_geom['stride'])
+  launch_pkt = IntraCgraPktType(payload = CgraPayloadType(
+      CMD_IM2COL_LAUNCH,
+      data      = DataType(launch_data, 1),
+      data_addr = engine_geom['dest_base']))
   src_ctrl_pkt = [launch_pkt] + src_ctrl_pkt
 
   th = TestHarness(FULL_FU_LIST, IntraCgraPktType, CgraPayloadType, DataType,
@@ -387,7 +393,7 @@ def _run(pe_weights, expected_outputs,
                    CONTROLLER2ADDR_MAP, ID_TO_2D_MAP,
                    complete_signal_sink_out,
                    NUM_CGRA_ROWS, NUM_CGRA_COLUMNS, src_query_pkt,
-                   engine_image, engine_geom, ENGINE_SCRATCH_MEM_SIZE)
+                   engine_image, ENGINE_SCRATCH_MEM_SIZE)
 
   th.elaborate()
   th.dut.set_metadata(VerilogVerilatorImportPass.vl_Wno_list,
@@ -405,7 +411,7 @@ def test_im2col_to_systolic_3x3(cmdline_opts):
   # Engine inputs: image + geometry chosen so lowered matrix == [1,2,3,4],
   # i.e. the same activation values the original systolic test preloads.
   engine_image       = [1, 3, 2, 4]
-  engine_geom        = dict(in_base = 0,
+  engine_geom        = dict(in_base = 0, dest_base = 0,
                             H = 1, W = 4, kH = 1, kW = 2, stride = 2)
 
   # Original systolic weights and expected outputs (verbatim from
@@ -447,7 +453,7 @@ def test_im2col_conv1d_to_systolic_3x3(cmdline_opts):
   pe_weights = {7: filters[0][0], 4: filters[0][1],
                 8: filters[1][0], 5: filters[1][1]}
 
-  engine_geom       = dict(in_base = 0,
+  engine_geom       = dict(in_base = 0, dest_base = 0,
                            H = H, W = W, kH = kH, kW = kW, stride = stride)
 
   _run(pe_weights, expected_outputs,
@@ -476,13 +482,10 @@ def _make_dut():
       True,                         # mem_access_is_combinational
       FlexibleFuRTL, COMPACT_FU_LIST, TOPOLOGY,
       CONTROLLER2ADDR_MAP, ID_TO_2D_MAP,
-      # Im2col engine parameters (same geometry as
-      # test_im2col_to_systolic_3x3 -- image [1,3,2,4] with 1x2 kernel
-      # stride 2 lowers to [1,2,3,4]).
+      # Im2col engine: only scratch size and preload image are needed at
+      # construct time; all geometry is runtime-configured via the
+      # CMD_IM2COL_LAUNCH packet.
       engine_scratch_mem_size = ENGINE_SCRATCH_MEM_SIZE,
-      engine_in_base = 0,
-      engine_H = 1, engine_W = 4,
-      engine_kH = 1, engine_kW = 2, engine_stride = 2,
       engine_preload_image = [1, 3, 2, 4])
 
 

--- a/cgra/test/Im2colCgraE2E_test.py
+++ b/cgra/test/Im2colCgraE2E_test.py
@@ -47,7 +47,6 @@ from pymtl3.stdlib.test_utils import (run_sim,
                                       config_model_with_cmdline_opts)
 
 from ..IntegratedIm2ColWithCgraRTL import IntegratedIm2ColWithCgraRTL
-from ...fu.others.Im2colEngineRTL import pack_im2col_launch
 from ...fu.double.SeqMulAdderRTL import SeqMulAdderRTL
 from ...fu.flexible.FlexibleFuRTL import FlexibleFuRTL
 from ...fu.float.FpAddRTL import FpAddRTL
@@ -356,6 +355,36 @@ def build_systolic_packets(IntraCgraPktType, CgraPayloadType, CtrlType,
 # Common CGRA / mesh parameters and harness driver.
 #-------------------------------------------------------------------------
 
+def _make_im2col_prologue(engine_geom):
+  """Build the CONFIG + LAUNCH packet sequence for the im2col engine.
+
+  Mirrors CMD_DMA_CONFIG_* style: one CMD per geometry parameter, then
+  CMD_IM2COL_LAUNCH to start. Stride is passed as log2(stride).
+  """
+  stride      = engine_geom['stride']
+  log2_stride = stride.bit_length() - 1
+  assert (1 << log2_stride) == stride, \
+      f"stride={stride} must be a power of two"
+
+  def cfg_data(cmd, value):
+    return IntraCgraPktType(payload = CgraPayloadType(
+        cmd, data = DataType(value, 1)))
+
+  def cfg_addr(cmd, value):
+    return IntraCgraPktType(payload = CgraPayloadType(
+        cmd, data_addr = value))
+
+  return [
+      cfg_data(CMD_IM2COL_H,             engine_geom['H']),
+      cfg_data(CMD_IM2COL_W,             engine_geom['W']),
+      cfg_data(CMD_IM2COL_KH,            engine_geom['kH']),
+      cfg_data(CMD_IM2COL_KW,            engine_geom['kW']),
+      cfg_data(CMD_IM2COL_LOG2_STRIDE,   log2_stride),
+      cfg_addr(CMD_IM2COL_DST_SRAM_BASE, engine_geom['dst_sram_base_addr']),
+      IntraCgraPktType(payload = CgraPayloadType(CMD_IM2COL_LAUNCH)),
+  ]
+
+
 def _run(pe_weights, expected_outputs,
          engine_image, engine_geom,
          cmdline_opts):
@@ -366,22 +395,10 @@ def _run(pe_weights, expected_outputs,
                              DataType, TileInType, FuInType, FuOutType,
                              CTRL_STEPS, pe_weights, expected_outputs)
 
-  # DMA-style trigger: prepend a CMD_IM2COL_LAUNCH packet whose fields
-  # carry the runtime im2col config. The controller forwards this single
-  # packet to send_to_im2col_engine_pkt; the engine parses the packed
-  # fields on the IDLE->READ edge.
-  launch_data = pack_im2col_launch(
-      H       = engine_geom['H'],
-      W       = engine_geom['W'],
-      in_base = engine_geom['in_base'],
-      kH      = engine_geom['kH'],
-      kW      = engine_geom['kW'],
-      stride  = engine_geom['stride'])
-  launch_pkt = IntraCgraPktType(payload = CgraPayloadType(
-      CMD_IM2COL_LAUNCH,
-      data      = DataType(launch_data, 1),
-      data_addr = engine_geom['dest_base']))
-  src_ctrl_pkt = [launch_pkt] + src_ctrl_pkt
+  # Prepend the im2col CONFIG + LAUNCH sequence. The controller forks
+  # each of these packets to send_to_im2col_engine_pkt; the engine
+  # latches config values in S_IDLE and starts on LAUNCH.
+  src_ctrl_pkt = _make_im2col_prologue(engine_geom) + src_ctrl_pkt
 
   th = TestHarness(FULL_FU_LIST, IntraCgraPktType, CgraPayloadType, DataType,
                    cgra_id, X_TILES, Y_TILES,
@@ -411,7 +428,7 @@ def test_im2col_to_systolic_3x3(cmdline_opts):
   # Engine inputs: image + geometry chosen so lowered matrix == [1,2,3,4],
   # i.e. the same activation values the original systolic test preloads.
   engine_image       = [1, 3, 2, 4]
-  engine_geom        = dict(in_base = 0, dest_base = 0,
+  engine_geom        = dict(dst_sram_base_addr = 0,
                             H = 1, W = 4, kH = 1, kW = 2, stride = 2)
 
   # Original systolic weights and expected outputs (verbatim from
@@ -453,7 +470,7 @@ def test_im2col_conv1d_to_systolic_3x3(cmdline_opts):
   pe_weights = {7: filters[0][0], 4: filters[0][1],
                 8: filters[1][0], 5: filters[1][1]}
 
-  engine_geom       = dict(in_base = 0, dest_base = 0,
+  engine_geom       = dict(dst_sram_base_addr = 0,
                            H = H, W = W, kH = kH, kW = kW, stride = stride)
 
   _run(pe_weights, expected_outputs,

--- a/cgra/test/Im2colCgraE2E_test.py
+++ b/cgra/test/Im2colCgraE2E_test.py
@@ -355,7 +355,7 @@ def build_systolic_packets(IntraCgraPktType, CgraPayloadType, CtrlType,
 # Common CGRA / mesh parameters and harness driver.
 #-------------------------------------------------------------------------
 
-def _make_im2col_prologue(engine_geom):
+def _make_im2col_prepare_cmds(engine_geom):
   """Build the CONFIG + LAUNCH packet sequence for the im2col engine.
 
   Mirrors CMD_DMA_CONFIG_* style: one CMD per geometry parameter, then
@@ -398,7 +398,7 @@ def _run(pe_weights, expected_outputs,
   # Prepend the im2col CONFIG + LAUNCH sequence. The controller forks
   # each of these packets to send_to_im2col_engine_pkt; the engine
   # latches config values in S_IDLE and starts on LAUNCH.
-  src_ctrl_pkt = _make_im2col_prologue(engine_geom) + src_ctrl_pkt
+  src_ctrl_pkt = _make_im2col_prepare_cmds(engine_geom) + src_ctrl_pkt
 
   th = TestHarness(FULL_FU_LIST, IntraCgraPktType, CgraPayloadType, DataType,
                    cgra_id, X_TILES, Y_TILES,

--- a/controller/ControllerRTL.py
+++ b/controller/ControllerRTL.py
@@ -399,9 +399,16 @@ class ControllerRTL(Component):
             s.dma_tag)
         s.recv_from_cpu_pkt_queue.send.rdy @= s.dma_cmd.rdy
 
-      elif has_im2col_engine & (cpu_cmd == CMD_IM2COL_LAUNCH):
-        # Fork the launch packet to the Im2col engine outport (DMA-style)
-        # instead of feeding it into the crossbar.
+      elif has_im2col_engine & (
+          (cpu_cmd == CMD_IM2COL_LAUNCH) |
+          (cpu_cmd == CMD_IM2COL_H) |
+          (cpu_cmd == CMD_IM2COL_W) |
+          (cpu_cmd == CMD_IM2COL_KH) |
+          (cpu_cmd == CMD_IM2COL_KW) |
+          (cpu_cmd == CMD_IM2COL_LOG2_STRIDE) |
+          (cpu_cmd == CMD_IM2COL_DST_SRAM_BASE)):
+        # Fork any im2col config/launch packet to the engine outport
+        # (DMA-style) instead of feeding it into the crossbar.
         s.send_to_im2col_engine_pkt.val @= s.recv_from_cpu_pkt_queue.send.val
         s.send_to_im2col_engine_pkt.msg @= s.recv_from_cpu_pkt_queue.send.msg
         s.recv_from_cpu_pkt_queue.send.rdy @= s.send_to_im2col_engine_pkt.rdy

--- a/fu/others/Im2colEngineRTL.py
+++ b/fu/others/Im2colEngineRTL.py
@@ -8,33 +8,31 @@ streams the lowered (kH*kW) x (Hout*Wout) column matrix into the
 enclosing CGRA's shared data memory as a sequence of CMD_STORE_REQUEST
 packets on `send_pkt`.
 
-All geometry is configured at runtime via the CMD_IM2COL_LAUNCH packet:
-the same synthesized RTL can run any (H, W, kH, kW, stride, in_base,
-dest_base) combination that fits in the packed fields. The launch
-packet doubles as the trigger -- on the IDLE -> READ edge the engine
-latches the packed config and starts.
+Configuration model (mirrors CMD_DMA_CONFIG_* convention): the CPU
+sends one CMD per geometry parameter before firing CMD_IM2COL_LAUNCH.
+Each config CMD is consumed by the engine while it sits in S_IDLE and
+latched into the corresponding register. CMD_IM2COL_LAUNCH triggers the
+IDLE -> READ transition, at which point Hout / Wout are precomputed.
 
-Packed layout of the CMD_IM2COL_LAUNCH packet:
+  CMD_IM2COL_H                (data)      -> cfg_H
+  CMD_IM2COL_W                (data)      -> cfg_W
+  CMD_IM2COL_KH               (data)      -> cfg_kH
+  CMD_IM2COL_KW               (data)      -> cfg_kW
+  CMD_IM2COL_LOG2_STRIDE      (data)      -> cfg_log2_stride
+  CMD_IM2COL_DST_SRAM_BASE    (data_addr) -> cfg_dst_sram_base_addr
+  CMD_IM2COL_LAUNCH                        -> start processing
 
-  payload.data_addr (DataAddrType)  = dest_base   (SRAM store base)
-  payload.data.payload (32-bit) bit-fields:
-      [ 5: 0]  W             (image width,  <= scratch_mem_size)
-      [11: 6]  H             (image height, <= scratch_mem_size)
-      [17:12]  in_base       (image base addr in in_mem)
-      [20:18]  kW            (kernel width,  1..7)
-      [23:21]  kH            (kernel height, 1..7)
-      [27:24]  log2_stride   (encoded stride; stride = 1 << log2_stride,
-                              so log2_stride 0..15 -> stride 1..32768)
-      [31:28]  reserved
+The image always sits at offset 0 of the engine's private in_mem
+scratchpad -- since nothing outside the engine addresses in_mem, there
+is no benefit to exposing an input base address.
 
-Note on stride encoding: stride is stored as log2(stride) so the FSM
-can use shifts (>>) instead of divides for computing Hout/Wout, since
-the Verilog translator does not support `//`. This restricts stride to
-powers of two (1, 2, 4, 8, ...); pack_im2col_launch enforces this.
+Stride is passed as log2(stride) so that (H - kH) / stride can be
+implemented as `>> log2_stride`; pymtl3's Verilog translator does not
+support integer `//`. This restricts stride to powers of two (1, 2,
+4, ...).
 
 Emit convention: output i (0-based, ox innermost -> oy -> kx -> ky) is
-stored to shared data_mem addr (dest_base + i). Downstream consumers
-configure their LD_CONST addresses to match this contiguous range.
+stored to shared data_mem addr (dst_sram_base_addr + i).
 
 Note on packet dst_tile: CMD_STORE_REQUEST packets are routed by the
 CGRA controller using the payload.data_addr field alone (see
@@ -42,11 +40,9 @@ ControllerRTL.update_sending_to_noc_msg); the packet's dst_tile is
 ignored on this path. The engine emits dst=0 for its store packets.
 
 State machine: IDLE -> READ -> EMIT -> DONE
-  IDLE: hold rdy=1 for the LAUNCH packet. On handshake, latch config
-        from packet fields, precompute Hout/Wout, transition to READ.
+  IDLE: hold rdy=1; latch config on each CONFIG cmd, transition on LAUNCH.
   READ: assert the read on in_mem at in_addr(oy, ox, ky, kx).
-  EMIT: hold the incoming data, drive send_pkt with
-        (data_addr = dest_base + emit_idx, data). On send_pkt fire,
+  EMIT: hold the incoming data, drive send_pkt. On send_pkt fire,
         advance the nested loop counters and either loop back to READ
         or transition to DONE.
   DONE: assert `done` and stay here until reset.
@@ -56,50 +52,12 @@ from pymtl3 import *
 
 from ...lib.basic.val_rdy.ifcs import ValRdyRecvIfcRTL as RecvIfcRTL
 from ...lib.basic.val_rdy.ifcs import ValRdySendIfcRTL as SendIfcRTL
-from ...lib.cmd_type import CMD_IM2COL_LAUNCH, CMD_STORE_REQUEST
+from ...lib.cmd_type import (CMD_IM2COL_DST_SRAM_BASE, CMD_IM2COL_H,
+                              CMD_IM2COL_KH, CMD_IM2COL_KW,
+                              CMD_IM2COL_LAUNCH, CMD_IM2COL_LOG2_STRIDE,
+                              CMD_IM2COL_W, CMD_STORE_REQUEST)
 from ...lib.util.data_struct_attr import kAttrCmd, kAttrDataAddr, kAttrPayload
 from ...mem.data.DataMemRTL import DataMemRTL
-
-
-# Packed-field bit widths in the CMD_IM2COL_LAUNCH packet's data field.
-_W_BITS           = 6
-_H_BITS           = 6
-_IN_BASE_BITS     = 6
-_KW_BITS          = 3
-_KH_BITS          = 3
-_LOG2_STRIDE_BITS = 4
-
-_W_SHIFT           = 0
-_H_SHIFT           = _W_BITS                                            # 6
-_IN_BASE_SHIFT     = _H_SHIFT + _H_BITS                                 # 12
-_KW_SHIFT          = _IN_BASE_SHIFT + _IN_BASE_BITS                     # 18
-_KH_SHIFT          = _KW_SHIFT + _KW_BITS                               # 21
-_LOG2_STRIDE_SHIFT = _KH_SHIFT + _KH_BITS                               # 24
-
-
-def pack_im2col_launch(H, W, in_base, kH, kW, stride):
-  """Pack im2col geometry into the CMD_IM2COL_LAUNCH packet's data field.
-
-  Use this helper on the CPU side to keep the bit layout in one place.
-  Returns an int suitable for DataType(x, 1). Stride must be a power
-  of two (see the module docstring for why).
-  """
-  assert 0 < H       < (1 << _H_BITS),       f"H={H} out of range"
-  assert 0 < W       < (1 << _W_BITS),       f"W={W} out of range"
-  assert 0 <= in_base< (1 << _IN_BASE_BITS), f"in_base={in_base} out of range"
-  assert 0 < kH      < (1 << _KH_BITS),      f"kH={kH} out of range"
-  assert 0 < kW      < (1 << _KW_BITS),      f"kW={kW} out of range"
-  assert stride > 0 and (stride & (stride - 1)) == 0, \
-      f"stride={stride} must be a power of two"
-  log2_stride = stride.bit_length() - 1
-  assert log2_stride < (1 << _LOG2_STRIDE_BITS), \
-      f"stride={stride} too large"
-  return ((log2_stride << _LOG2_STRIDE_SHIFT) |
-          (kH          << _KH_SHIFT)          |
-          (kW          << _KW_SHIFT)          |
-          (in_base     << _IN_BASE_SHIFT)     |
-          (H           << _H_SHIFT)           |
-          (W           << _W_SHIFT))
 
 
 class Im2colEngineRTL(Component):
@@ -114,17 +72,6 @@ class Im2colEngineRTL(Component):
     PayloadType     = IntraCgraPktType.get_field_type(kAttrPayload)
     CmdType         = PayloadType.get_field_type(kAttrCmd)
     DataAddrType    = PayloadType.get_field_type(kAttrDataAddr)
-
-    # Narrow types for extracting each packed field from launch.data.
-    # A field's slot must be extracted at exactly its own bit width so
-    # neighboring slots don't leak into it (e.g. a 6-bit trunc of the
-    # kW slot would grab kH's bits too).
-    _W_type           = mk_bits(_W_BITS)
-    _H_type           = mk_bits(_H_BITS)
-    _IN_BASE_type     = mk_bits(_IN_BASE_BITS)
-    _KW_type          = mk_bits(_KW_BITS)
-    _KH_type          = mk_bits(_KH_BITS)
-    _LOG2_STRIDE_type = mk_bits(_LOG2_STRIDE_BITS)
 
     # emit_idx must fit any valid destination offset within data_mem.
     IdxType   = DataAddrType
@@ -160,22 +107,21 @@ class Im2colEngineRTL(Component):
     s.emit_idx = Wire(IdxType)
     s.data_reg = Wire(DataType)
 
-    # Runtime config, latched on IDLE -> READ (LAUNCH handshake).
-    s.cfg_H           = Wire(ScratchAddrType)
-    s.cfg_W           = Wire(ScratchAddrType)
-    s.cfg_in_base     = Wire(ScratchAddrType)
-    s.cfg_kH          = Wire(ScratchAddrType)
-    s.cfg_kW          = Wire(ScratchAddrType)
-    s.cfg_log2_stride = Wire(ScratchAddrType)
-    s.cfg_dest_base   = Wire(DataAddrType)
-    # Precomputed at LAUNCH so the S_EMIT loop-advance can compare
+    # Runtime config registers, latched by the corresponding CMD.
+    s.cfg_H                    = Wire(ScratchAddrType)
+    s.cfg_W                    = Wire(ScratchAddrType)
+    s.cfg_kH                   = Wire(ScratchAddrType)
+    s.cfg_kW                   = Wire(ScratchAddrType)
+    s.cfg_log2_stride          = Wire(ScratchAddrType)
+    s.cfg_dst_sram_base_addr   = Wire(DataAddrType)
+    # Precomputed on LAUNCH so the S_EMIT loop-advance can compare
     # against a plain register instead of redoing (H-kH)>>log2_stride
     # each cycle.
     s.cfg_Hout = Wire(ScratchAddrType)
     s.cfg_Wout = Wire(ScratchAddrType)
 
-    # Combinational address computation. Narrowing casts (ScratchAddrType(...))
-    # keep pymtl3's AST analyzer happy on binop-result narrowing.
+    # Combinational address computation. Narrowing casts keep pymtl3's
+    # AST analyzer happy on binop-result narrowing.
     s.in_row  = Wire(ScratchAddrType)
     s.in_col  = Wire(ScratchAddrType)
     s.in_addr = Wire(ScratchAddrType)
@@ -184,9 +130,10 @@ class Im2colEngineRTL(Component):
     def comb_in_addr():
       # ox*stride and oy*stride are shifts because stride is stored as
       # its log2 (Verilog translator has no `//` but supports `>>`/`<<`).
+      # Image is assumed to live at in_mem[0..); no base offset.
       s.in_row  @= ScratchAddrType((s.oy << s.cfg_log2_stride) + s.ky)
       s.in_col  @= ScratchAddrType((s.ox << s.cfg_log2_stride) + s.kx)
-      s.in_addr @= ScratchAddrType(s.cfg_in_base + s.in_row * s.cfg_W + s.in_col)
+      s.in_addr @= ScratchAddrType(s.in_row * s.cfg_W + s.in_col)
 
     # Tie off the unused write port on the input scratchpad.
     @update
@@ -207,7 +154,7 @@ class Im2colEngineRTL(Component):
       s.in_mem.recv_raddr[0].msg @= ScratchAddrType(0)
       s.in_mem.send_rdata[0].rdy @= b1(0)
 
-      # LAUNCH packet is accepted only while idle.
+      # Config/launch cmds are accepted only while idle.
       s.recv_cmd_pkt.rdy @= (s.state == S_IDLE)
 
       s.send_pkt.val @= b1(0)
@@ -232,7 +179,7 @@ class Im2colEngineRTL(Component):
             PayloadType(
                 CmdType(CMD_STORE_REQUEST),
                 s.data_reg,
-                s.cfg_dest_base + zext(s.emit_idx, DataAddrType),
+                s.cfg_dst_sram_base_addr + zext(s.emit_idx, DataAddrType),
                 0,         # ctrl (zero)
                 0,         # ctrl_addr
             ),
@@ -259,35 +206,39 @@ class Im2colEngineRTL(Component):
         s.data_reg <<= DataType()
       else:
         if s.state == S_IDLE:
-          if s.recv_cmd_pkt.val & (
-              s.recv_cmd_pkt.msg.payload.cmd == CmdType(CMD_IM2COL_LAUNCH)):
-            # Extract each packed field at its native width, then zext
-            # into ScratchAddrType so downstream arithmetic is uniform.
-            data_bits = s.recv_cmd_pkt.msg.payload.data.payload
-            H_lat       = zext(trunc(data_bits >> _H_SHIFT,           _H_type),           ScratchAddrType)
-            W_lat       = zext(trunc(data_bits >> _W_SHIFT,           _W_type),           ScratchAddrType)
-            in_base_lat = zext(trunc(data_bits >> _IN_BASE_SHIFT,     _IN_BASE_type),     ScratchAddrType)
-            kH_lat      = zext(trunc(data_bits >> _KH_SHIFT,          _KH_type),          ScratchAddrType)
-            kW_lat      = zext(trunc(data_bits >> _KW_SHIFT,          _KW_type),          ScratchAddrType)
-            log2_stride_lat = zext(trunc(data_bits >> _LOG2_STRIDE_SHIFT, _LOG2_STRIDE_type), ScratchAddrType)
+          if s.recv_cmd_pkt.val:
+            cmd = s.recv_cmd_pkt.msg.payload.cmd
+            # data field carries numeric config values; take the low
+            # ScratchAddrType.nbits bits.
+            data_lo = trunc(s.recv_cmd_pkt.msg.payload.data.payload,
+                            ScratchAddrType)
+            # data_addr field carries SRAM offsets directly.
+            data_addr = s.recv_cmd_pkt.msg.payload.data_addr
 
-            s.cfg_H           <<= H_lat
-            s.cfg_W           <<= W_lat
-            s.cfg_in_base     <<= in_base_lat
-            s.cfg_kH          <<= kH_lat
-            s.cfg_kW          <<= kW_lat
-            s.cfg_log2_stride <<= log2_stride_lat
-            s.cfg_dest_base   <<= s.recv_cmd_pkt.msg.payload.data_addr
-            # Hout = (H - kH) >> log2_stride + 1; Wout similarly.
-            s.cfg_Hout        <<= ScratchAddrType(((H_lat - kH_lat) >> log2_stride_lat) + 1)
-            s.cfg_Wout        <<= ScratchAddrType(((W_lat - kW_lat) >> log2_stride_lat) + 1)
-
-            s.state    <<= S_READ
-            s.oy       <<= ScratchAddrType(0)
-            s.ox       <<= ScratchAddrType(0)
-            s.ky       <<= ScratchAddrType(0)
-            s.kx       <<= ScratchAddrType(0)
-            s.emit_idx <<= IdxType(0)
+            if   cmd == CmdType(CMD_IM2COL_H):
+              s.cfg_H            <<= data_lo
+            elif cmd == CmdType(CMD_IM2COL_W):
+              s.cfg_W            <<= data_lo
+            elif cmd == CmdType(CMD_IM2COL_KH):
+              s.cfg_kH           <<= data_lo
+            elif cmd == CmdType(CMD_IM2COL_KW):
+              s.cfg_kW           <<= data_lo
+            elif cmd == CmdType(CMD_IM2COL_LOG2_STRIDE):
+              s.cfg_log2_stride  <<= data_lo
+            elif cmd == CmdType(CMD_IM2COL_DST_SRAM_BASE):
+              s.cfg_dst_sram_base_addr <<= data_addr
+            elif cmd == CmdType(CMD_IM2COL_LAUNCH):
+              # Precompute Hout/Wout from the currently-latched config.
+              s.cfg_Hout <<= ScratchAddrType(
+                  ((s.cfg_H - s.cfg_kH) >> s.cfg_log2_stride) + 1)
+              s.cfg_Wout <<= ScratchAddrType(
+                  ((s.cfg_W - s.cfg_kW) >> s.cfg_log2_stride) + 1)
+              s.state    <<= S_READ
+              s.oy       <<= ScratchAddrType(0)
+              s.ox       <<= ScratchAddrType(0)
+              s.ky       <<= ScratchAddrType(0)
+              s.kx       <<= ScratchAddrType(0)
+              s.emit_idx <<= IdxType(0)
 
         elif s.state == S_READ:
           if s.in_mem.recv_raddr[0].rdy & s.in_mem.send_rdata[0].val:
@@ -298,7 +249,7 @@ class Im2colEngineRTL(Component):
           if s.send_pkt.val & s.send_pkt.rdy:
             # Loop order (ox -> oy -> kx -> ky, ox innermost) so emit_idx
             # walks the flat output index monotonically. This lets the
-            # store addr be a simple dest_base + emit_idx sum.
+            # store addr be a simple dst_sram_base_addr + emit_idx sum.
             if s.ox + ScratchAddrType(1) < s.cfg_Wout:
               s.ox    <<= s.ox + ScratchAddrType(1)
               s.state <<= S_READ

--- a/fu/others/Im2colEngineRTL.py
+++ b/fu/others/Im2colEngineRTL.py
@@ -2,69 +2,111 @@
 ==========================================================================
 Im2colEngineRTL.py
 ==========================================================================
-Merged im2col (image-to-column) engine. Reads an HxW single-channel input
-image from a local input scratchpad and streams the lowered
-(kH*kW) x (Hout*Wout) column matrix into the enclosing CGRA's shared
-data memory as a sequence of CMD_STORE_REQUEST packets on `send_pkt`.
-The engine writes output i to CGRA data_mem addr i (i.e. the lowered
-matrix occupies data_mem[0 .. num_outputs)); the consumer configures
-its LD_CONST addresses accordingly.
+Runtime-programmable im2col (image-to-column) engine. Reads a
+single-channel input image resident in a local input scratchpad and
+streams the lowered (kH*kW) x (Hout*Wout) column matrix into the
+enclosing CGRA's shared data memory as a sequence of CMD_STORE_REQUEST
+packets on `send_pkt`.
+
+All geometry is configured at runtime via the CMD_IM2COL_LAUNCH packet:
+the same synthesized RTL can run any (H, W, kH, kW, stride, in_base,
+dest_base) combination that fits in the packed fields. The launch
+packet doubles as the trigger -- on the IDLE -> READ edge the engine
+latches the packed config and starts.
+
+Packed layout of the CMD_IM2COL_LAUNCH packet:
+
+  payload.data_addr (DataAddrType)  = dest_base   (SRAM store base)
+  payload.data.payload (32-bit) bit-fields:
+      [ 5: 0]  W             (image width,  <= scratch_mem_size)
+      [11: 6]  H             (image height, <= scratch_mem_size)
+      [17:12]  in_base       (image base addr in in_mem)
+      [20:18]  kW            (kernel width,  1..7)
+      [23:21]  kH            (kernel height, 1..7)
+      [27:24]  log2_stride   (encoded stride; stride = 1 << log2_stride,
+                              so log2_stride 0..15 -> stride 1..32768)
+      [31:28]  reserved
+
+Note on stride encoding: stride is stored as log2(stride) so the FSM
+can use shifts (>>) instead of divides for computing Hout/Wout, since
+the Verilog translator does not support `//`. This restricts stride to
+powers of two (1, 2, 4, 8, ...); pack_im2col_launch enforces this.
+
+Emit convention: output i (0-based, ox innermost -> oy -> kx -> ky) is
+stored to shared data_mem addr (dest_base + i). Downstream consumers
+configure their LD_CONST addresses to match this contiguous range.
 
 Note on packet dst_tile: CMD_STORE_REQUEST packets are routed by the
 CGRA controller using the payload.data_addr field alone (see
 ControllerRTL.update_sending_to_noc_msg); the packet's dst_tile is
-ignored on this path. The engine therefore emits dst=0 unconditionally,
-and does not take a dst_tiles list.
-
-Relative to the previous split:
-  Im2colRTL       = stand-alone im2col data mover, wrote its output to
-                    a caller-supplied output scratchpad memory port.
-  Im2colEngineRTL = wrapped that data mover in a private in_mem /
-                    out_mem scratchpad pair plus a follow-on emit FSM
-                    that drained out_mem into CMD_STORE_REQUEST packets.
-
-This file collapses both into one component: on each S_READ we compute
-the current in_mem address, and on the returned data we form the store
-packet directly. There is no output scratchpad -- values are computed
-and emitted in lock-step so the CGRA's shared data_mem is the only
-buffer needed.
-
-The input scratchpad is kept: the caller preloads the image into it at
-construct time so the engine has a stable local buffer to walk during
-im2col (modeling the "image already resident in a nearby SPM" boundary
-condition).
+ignored on this path. The engine emits dst=0 for its store packets.
 
 State machine: IDLE -> READ -> EMIT -> DONE
-  IDLE: wait for `start`.
-  READ: assert the read on in_mem at in_addr(ky, kx, oy, ox).
+  IDLE: hold rdy=1 for the LAUNCH packet. On handshake, latch config
+        from packet fields, precompute Hout/Wout, transition to READ.
+  READ: assert the read on in_mem at in_addr(oy, ox, ky, kx).
   EMIT: hold the incoming data, drive send_pkt with
-        (data_addr = emit_idx, data). On send_pkt fire, advance the
-        nested loop counters (ox innermost, then oy, kx, ky) and
-        either loop back to READ or transition to DONE. The loop order
-        is chosen so emit_idx (the flat output counter) monotonically
-        walks 0 -> num_outputs, which is why we can use emit_idx as
-        the SRAM address directly.
+        (data_addr = dest_base + emit_idx, data). On send_pkt fire,
+        advance the nested loop counters and either loop back to READ
+        or transition to DONE.
   DONE: assert `done` and stay here until reset.
 """
 
 from pymtl3 import *
 
+from ...lib.basic.val_rdy.ifcs import ValRdyRecvIfcRTL as RecvIfcRTL
 from ...lib.basic.val_rdy.ifcs import ValRdySendIfcRTL as SendIfcRTL
-from ...lib.cmd_type import CMD_STORE_REQUEST
+from ...lib.cmd_type import CMD_IM2COL_LAUNCH, CMD_STORE_REQUEST
 from ...lib.util.data_struct_attr import kAttrCmd, kAttrDataAddr, kAttrPayload
 from ...mem.data.DataMemRTL import DataMemRTL
+
+
+# Packed-field bit widths in the CMD_IM2COL_LAUNCH packet's data field.
+_W_BITS           = 6
+_H_BITS           = 6
+_IN_BASE_BITS     = 6
+_KW_BITS          = 3
+_KH_BITS          = 3
+_LOG2_STRIDE_BITS = 4
+
+_W_SHIFT           = 0
+_H_SHIFT           = _W_BITS                                            # 6
+_IN_BASE_SHIFT     = _H_SHIFT + _H_BITS                                 # 12
+_KW_SHIFT          = _IN_BASE_SHIFT + _IN_BASE_BITS                     # 18
+_KH_SHIFT          = _KW_SHIFT + _KW_BITS                               # 21
+_LOG2_STRIDE_SHIFT = _KH_SHIFT + _KH_BITS                               # 24
+
+
+def pack_im2col_launch(H, W, in_base, kH, kW, stride):
+  """Pack im2col geometry into the CMD_IM2COL_LAUNCH packet's data field.
+
+  Use this helper on the CPU side to keep the bit layout in one place.
+  Returns an int suitable for DataType(x, 1). Stride must be a power
+  of two (see the module docstring for why).
+  """
+  assert 0 < H       < (1 << _H_BITS),       f"H={H} out of range"
+  assert 0 < W       < (1 << _W_BITS),       f"W={W} out of range"
+  assert 0 <= in_base< (1 << _IN_BASE_BITS), f"in_base={in_base} out of range"
+  assert 0 < kH      < (1 << _KH_BITS),      f"kH={kH} out of range"
+  assert 0 < kW      < (1 << _KW_BITS),      f"kW={kW} out of range"
+  assert stride > 0 and (stride & (stride - 1)) == 0, \
+      f"stride={stride} must be a power of two"
+  log2_stride = stride.bit_length() - 1
+  assert log2_stride < (1 << _LOG2_STRIDE_BITS), \
+      f"stride={stride} too large"
+  return ((log2_stride << _LOG2_STRIDE_SHIFT) |
+          (kH          << _KH_SHIFT)          |
+          (kW          << _KW_SHIFT)          |
+          (in_base     << _IN_BASE_SHIFT)     |
+          (H           << _H_SHIFT)           |
+          (W           << _W_SHIFT))
 
 
 class Im2colEngineRTL(Component):
 
   def construct(s, DataType, IntraCgraPktType, CgraPayloadType,
                 scratch_mem_size,
-                in_base, H, W, kH, kW, stride,
                 preload_image):
-
-    Hout = (H - kH) // stride + 1
-    Wout = (W - kW) // stride + 1
-    num_outputs = kH * kW * Hout * Wout
 
     # Derive widths from the passed-in packet types so the engine stays
     # generic across CGRA configurations.
@@ -73,7 +115,19 @@ class Im2colEngineRTL(Component):
     CmdType         = PayloadType.get_field_type(kAttrCmd)
     DataAddrType    = PayloadType.get_field_type(kAttrDataAddr)
 
-    IdxType   = mk_bits(max(1, clog2(num_outputs + 1)))
+    # Narrow types for extracting each packed field from launch.data.
+    # A field's slot must be extracted at exactly its own bit width so
+    # neighboring slots don't leak into it (e.g. a 6-bit trunc of the
+    # kW slot would grab kH's bits too).
+    _W_type           = mk_bits(_W_BITS)
+    _H_type           = mk_bits(_H_BITS)
+    _IN_BASE_type     = mk_bits(_IN_BASE_BITS)
+    _KW_type          = mk_bits(_KW_BITS)
+    _KH_type          = mk_bits(_KH_BITS)
+    _LOG2_STRIDE_type = mk_bits(_LOG2_STRIDE_BITS)
+
+    # emit_idx must fit any valid destination offset within data_mem.
+    IdxType   = DataAddrType
     StateType = mk_bits(2)
 
     S_IDLE = StateType(0)
@@ -82,14 +136,16 @@ class Im2colEngineRTL(Component):
     S_DONE = StateType(3)
 
     # Public I/O.
-    s.start    = InPort(b1)
-    s.done     = OutPort(b1)
-    s.send_pkt = SendIfcRTL(IntraCgraPktType)
+    s.recv_cmd_pkt = RecvIfcRTL(IntraCgraPktType)
+    s.done         = OutPort(b1)
+    s.send_pkt     = SendIfcRTL(IntraCgraPktType)
 
-    # Pre-build the input scratchpad preload (image at [in_base, in_base+H*W)).
+    # Input scratchpad: image preloaded starting at addr 0. Real deploys
+    # would fill this via DMA/CPU writes prior to LAUNCH; the preload is
+    # a modeling convenience for tests.
     preload_full = [DataType(0, 1) for _ in range(scratch_mem_size)]
     for i, v in enumerate(preload_image):
-      preload_full[in_base + i] = DataType(v, 1)
+      preload_full[i] = DataType(v, 1)
 
     s.in_mem = DataMemRTL(DataType, scratch_mem_size,
                           rd_ports = 1, wr_ports = 1,
@@ -104,17 +160,33 @@ class Im2colEngineRTL(Component):
     s.emit_idx = Wire(IdxType)
     s.data_reg = Wire(DataType)
 
+    # Runtime config, latched on IDLE -> READ (LAUNCH handshake).
+    s.cfg_H           = Wire(ScratchAddrType)
+    s.cfg_W           = Wire(ScratchAddrType)
+    s.cfg_in_base     = Wire(ScratchAddrType)
+    s.cfg_kH          = Wire(ScratchAddrType)
+    s.cfg_kW          = Wire(ScratchAddrType)
+    s.cfg_log2_stride = Wire(ScratchAddrType)
+    s.cfg_dest_base   = Wire(DataAddrType)
+    # Precomputed at LAUNCH so the S_EMIT loop-advance can compare
+    # against a plain register instead of redoing (H-kH)>>log2_stride
+    # each cycle.
+    s.cfg_Hout = Wire(ScratchAddrType)
+    s.cfg_Wout = Wire(ScratchAddrType)
+
     # Combinational address computation. Narrowing casts (ScratchAddrType(...))
-    # prevent pymtl3's AST analyzer from tripping on binop-result slices.
+    # keep pymtl3's AST analyzer happy on binop-result narrowing.
     s.in_row  = Wire(ScratchAddrType)
     s.in_col  = Wire(ScratchAddrType)
     s.in_addr = Wire(ScratchAddrType)
 
     @update
     def comb_in_addr():
-      s.in_row  @= ScratchAddrType(s.oy * stride + s.ky)
-      s.in_col  @= ScratchAddrType(s.ox * stride + s.kx)
-      s.in_addr @= ScratchAddrType(in_base + s.in_row * W + s.in_col)
+      # ox*stride and oy*stride are shifts because stride is stored as
+      # its log2 (Verilog translator has no `//` but supports `>>`/`<<`).
+      s.in_row  @= ScratchAddrType((s.oy << s.cfg_log2_stride) + s.ky)
+      s.in_col  @= ScratchAddrType((s.ox << s.cfg_log2_stride) + s.kx)
+      s.in_addr @= ScratchAddrType(s.cfg_in_base + s.in_row * s.cfg_W + s.in_col)
 
     # Tie off the unused write port on the input scratchpad.
     @update
@@ -134,6 +206,9 @@ class Im2colEngineRTL(Component):
       s.in_mem.recv_raddr[0].val @= b1(0)
       s.in_mem.recv_raddr[0].msg @= ScratchAddrType(0)
       s.in_mem.send_rdata[0].rdy @= b1(0)
+
+      # LAUNCH packet is accepted only while idle.
+      s.recv_cmd_pkt.rdy @= (s.state == S_IDLE)
 
       s.send_pkt.val @= b1(0)
       s.done         @= b1(0)
@@ -157,7 +232,7 @@ class Im2colEngineRTL(Component):
             PayloadType(
                 CmdType(CMD_STORE_REQUEST),
                 s.data_reg,
-                zext(s.emit_idx, DataAddrType),   # SRAM addr = emit_idx
+                s.cfg_dest_base + zext(s.emit_idx, DataAddrType),
                 0,         # ctrl (zero)
                 0,         # ctrl_addr
             ),
@@ -184,7 +259,29 @@ class Im2colEngineRTL(Component):
         s.data_reg <<= DataType()
       else:
         if s.state == S_IDLE:
-          if s.start:
+          if s.recv_cmd_pkt.val & (
+              s.recv_cmd_pkt.msg.payload.cmd == CmdType(CMD_IM2COL_LAUNCH)):
+            # Extract each packed field at its native width, then zext
+            # into ScratchAddrType so downstream arithmetic is uniform.
+            data_bits = s.recv_cmd_pkt.msg.payload.data.payload
+            H_lat       = zext(trunc(data_bits >> _H_SHIFT,           _H_type),           ScratchAddrType)
+            W_lat       = zext(trunc(data_bits >> _W_SHIFT,           _W_type),           ScratchAddrType)
+            in_base_lat = zext(trunc(data_bits >> _IN_BASE_SHIFT,     _IN_BASE_type),     ScratchAddrType)
+            kH_lat      = zext(trunc(data_bits >> _KH_SHIFT,          _KH_type),          ScratchAddrType)
+            kW_lat      = zext(trunc(data_bits >> _KW_SHIFT,          _KW_type),          ScratchAddrType)
+            log2_stride_lat = zext(trunc(data_bits >> _LOG2_STRIDE_SHIFT, _LOG2_STRIDE_type), ScratchAddrType)
+
+            s.cfg_H           <<= H_lat
+            s.cfg_W           <<= W_lat
+            s.cfg_in_base     <<= in_base_lat
+            s.cfg_kH          <<= kH_lat
+            s.cfg_kW          <<= kW_lat
+            s.cfg_log2_stride <<= log2_stride_lat
+            s.cfg_dest_base   <<= s.recv_cmd_pkt.msg.payload.data_addr
+            # Hout = (H - kH) >> log2_stride + 1; Wout similarly.
+            s.cfg_Hout        <<= ScratchAddrType(((H_lat - kH_lat) >> log2_stride_lat) + 1)
+            s.cfg_Wout        <<= ScratchAddrType(((W_lat - kW_lat) >> log2_stride_lat) + 1)
+
             s.state    <<= S_READ
             s.oy       <<= ScratchAddrType(0)
             s.ox       <<= ScratchAddrType(0)
@@ -200,23 +297,21 @@ class Im2colEngineRTL(Component):
         elif s.state == S_EMIT:
           if s.send_pkt.val & s.send_pkt.rdy:
             # Loop order (ox -> oy -> kx -> ky, ox innermost) so emit_idx
-            # walks the flat output index (row = ky*kW+kx, col =
-            # oy*Wout+ox, flat = row*Hout*Wout + col) monotonically.
-            # This lets data_addr_const be indexed by emit_idx directly
-            # without an intermediate LUT.
-            if s.ox + ScratchAddrType(1) < ScratchAddrType(Wout):
+            # walks the flat output index monotonically. This lets the
+            # store addr be a simple dest_base + emit_idx sum.
+            if s.ox + ScratchAddrType(1) < s.cfg_Wout:
               s.ox    <<= s.ox + ScratchAddrType(1)
               s.state <<= S_READ
-            elif s.oy + ScratchAddrType(1) < ScratchAddrType(Hout):
+            elif s.oy + ScratchAddrType(1) < s.cfg_Hout:
               s.ox    <<= ScratchAddrType(0)
               s.oy    <<= s.oy + ScratchAddrType(1)
               s.state <<= S_READ
-            elif s.kx + ScratchAddrType(1) < ScratchAddrType(kW):
+            elif s.kx + ScratchAddrType(1) < s.cfg_kW:
               s.ox    <<= ScratchAddrType(0)
               s.oy    <<= ScratchAddrType(0)
               s.kx    <<= s.kx + ScratchAddrType(1)
               s.state <<= S_READ
-            elif s.ky + ScratchAddrType(1) < ScratchAddrType(kH):
+            elif s.ky + ScratchAddrType(1) < s.cfg_kH:
               s.ox    <<= ScratchAddrType(0)
               s.oy    <<= ScratchAddrType(0)
               s.kx    <<= ScratchAddrType(0)

--- a/fu/others/test/Im2colEngineRTL_test.py
+++ b/fu/others/test/Im2colEngineRTL_test.py
@@ -3,20 +3,23 @@
 Im2colEngineRTL_test.py
 ==========================================================================
 Standalone unit test for the runtime-programmable Im2colEngineRTL. Feeds
-a preloaded image into the engine's in_mem, sends a CMD_IM2COL_LAUNCH
-packet whose fields carry the runtime im2col config, and sinks the
-emitted CMD_STORE_REQUEST packets on send_pkt to check them against a
-Python golden.
+a preloaded image into the engine's in_mem, sends the CMD_IM2COL_*
+CONFIG packets followed by CMD_IM2COL_LAUNCH, and sinks the emitted
+CMD_STORE_REQUEST packets on send_pkt to check them against a Python
+golden.
 """
 
 from pymtl3 import *
 from pymtl3.stdlib.test_utils import (config_model_with_cmdline_opts,
                                       run_sim)
 
-from ..Im2colEngineRTL import Im2colEngineRTL, pack_im2col_launch
+from ..Im2colEngineRTL import Im2colEngineRTL
 from ....lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL
 from ....lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
-from ....lib.cmd_type import CMD_IM2COL_LAUNCH, CMD_STORE_REQUEST
+from ....lib.cmd_type import (CMD_IM2COL_DST_SRAM_BASE, CMD_IM2COL_H,
+                                CMD_IM2COL_KH, CMD_IM2COL_KW,
+                                CMD_IM2COL_LAUNCH, CMD_IM2COL_LOG2_STRIDE,
+                                CMD_IM2COL_W, CMD_STORE_REQUEST)
 from ....lib.messages import (mk_cgra_payload, mk_ctrl, mk_data,
                                 mk_intra_cgra_pkt)
 
@@ -72,22 +75,50 @@ def golden_im2col(image, H, W, kH, kW, stride):
 
 
 #-------------------------------------------------------------------------
-# Test harness: engine + TestSrcRTL for launch + TestSinkRTL for outputs.
+# Build the CONFIG + LAUNCH packet sequence for the engine.
+#-------------------------------------------------------------------------
+
+def _make_cmd_pkts(H, W, kH, kW, stride, dst_sram_base_addr):
+  log2_stride = stride.bit_length() - 1
+  assert (1 << log2_stride) == stride, \
+      f"stride={stride} must be a power of two"
+
+  def cfg_data(cmd, value):
+    return IntraCgraPktType(payload = CgraPayloadType(
+        cmd, data = DataType(value, 1)))
+
+  def cfg_addr(cmd, value):
+    return IntraCgraPktType(payload = CgraPayloadType(
+        cmd, data_addr = value))
+
+  return [
+      cfg_data(CMD_IM2COL_H,             H),
+      cfg_data(CMD_IM2COL_W,             W),
+      cfg_data(CMD_IM2COL_KH,            kH),
+      cfg_data(CMD_IM2COL_KW,            kW),
+      cfg_data(CMD_IM2COL_LOG2_STRIDE,   log2_stride),
+      cfg_addr(CMD_IM2COL_DST_SRAM_BASE, dst_sram_base_addr),
+      IntraCgraPktType(payload = CgraPayloadType(CMD_IM2COL_LAUNCH)),
+  ]
+
+
+#-------------------------------------------------------------------------
+# Test harness: engine + TestSrcRTL feeding CONFIG/LAUNCH + TestSinkRTL
+# for outputs.
 #-------------------------------------------------------------------------
 
 class TestHarness(Component):
 
-  def construct(s, scratch_mem_size, launch_pkts,
+  def construct(s, scratch_mem_size, cmd_pkts,
                 preload_image, expected_packets):
 
     s.dut = Im2colEngineRTL(DataType, IntraCgraPktType, CgraPayloadType,
                             scratch_mem_size, preload_image)
 
-    s.launch_src = TestSrcRTL(IntraCgraPktType, launch_pkts)
-    s.launch_src.send //= s.dut.recv_cmd_pkt
+    s.cmd_src = TestSrcRTL(IntraCgraPktType, cmd_pkts)
+    s.cmd_src.send //= s.dut.recv_cmd_pkt
 
-    # Compare only the fields the engine actually populates: cmd, data,
-    # data_addr. dst is always 0 (STORE_REQUEST is routed by data_addr).
+    # Compare only the fields the engine actually populates.
     cmp_fn = lambda a, b: (a.payload.cmd       == b.payload.cmd and
                            a.payload.data      == b.payload.data and
                            a.payload.data_addr == b.payload.data_addr)
@@ -96,7 +127,7 @@ class TestHarness(Component):
     s.dut.send_pkt //= s.sink.recv
 
   def done(s):
-    return s.launch_src.done() and s.sink.done()
+    return s.cmd_src.done() and s.sink.done()
 
   def line_trace(s):
     return f"{s.dut.line_trace()} || sink[{s.sink.line_trace()}]"
@@ -106,7 +137,7 @@ class TestHarness(Component):
 # Driver
 #-------------------------------------------------------------------------
 
-def _build_expected_packets(image, H, W, kH, kW, stride, dest_base):
+def _build_expected_packets(image, H, W, kH, kW, stride, dst_sram_base_addr):
   values, _, _ = golden_im2col(image, H, W, kH, kW, stride)
   pkts = []
   for i, v in enumerate(values):
@@ -116,24 +147,18 @@ def _build_expected_packets(image, H, W, kH, kW, stride, dest_base):
         0, 0,                      # opaque, vc_id
         CgraPayloadType(cmd = CMD_STORE_REQUEST,
                         data = DataType(v, 1),
-                        data_addr = dest_base + i)))
+                        data_addr = dst_sram_base_addr + i)))
   return pkts
 
 
 def run_engine(image, H, W, kH, kW, stride,
-               in_base = 0, dest_base = 0,
+               dst_sram_base_addr = 0,
                scratch_mem_size = 64, cmdline_opts = None):
 
-  launch_pkts = [IntraCgraPktType(payload = CgraPayloadType(
-      CMD_IM2COL_LAUNCH,
-      data      = DataType(pack_im2col_launch(H = H, W = W,
-                                              in_base = in_base,
-                                              kH = kH, kW = kW,
-                                              stride = stride), 1),
-      data_addr = dest_base))]
-
-  expected = _build_expected_packets(image, H, W, kH, kW, stride, dest_base)
-  th = TestHarness(scratch_mem_size, launch_pkts, image, expected)
+  cmd_pkts = _make_cmd_pkts(H, W, kH, kW, stride, dst_sram_base_addr)
+  expected = _build_expected_packets(image, H, W, kH, kW, stride,
+                                     dst_sram_base_addr)
+  th = TestHarness(scratch_mem_size, cmd_pkts, image, expected)
   th.elaborate()
   if cmdline_opts is not None:
     th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
@@ -175,10 +200,10 @@ def test_engine_smoke_matches_e2e_layout(cmdline_opts):
              cmdline_opts = cmdline_opts)
 
 
-def test_engine_nonzero_dest_base(cmdline_opts):
-  # Verifies that dest_base actually offsets the store address. Same
-  # image geometry as test_engine_4x4_k2_s2 but write to addr 16..19.
+def test_engine_nonzero_dst_sram_base(cmdline_opts):
+  # Verifies that dst_sram_base_addr actually offsets the store address.
+  # Same image geometry as test_engine_4x4_k2_s2 but write to addr 16..19.
   image = [i * 2 + 1 for i in range(16)]
   run_engine(image, H = 4, W = 4, kH = 2, kW = 2, stride = 2,
-             dest_base = 16,
+             dst_sram_base_addr = 16,
              cmdline_opts = cmdline_opts)

--- a/fu/others/test/Im2colEngineRTL_test.py
+++ b/fu/others/test/Im2colEngineRTL_test.py
@@ -2,19 +2,21 @@
 ==========================================================================
 Im2colEngineRTL_test.py
 ==========================================================================
-Standalone unit test for the merged Im2colEngineRTL. Feeds a preloaded
-image into the engine's internal in_mem scratchpad and sinks the emitted
-CMD_STORE_REQUEST packets on send_pkt, comparing them against a Python
-golden im2col.
+Standalone unit test for the runtime-programmable Im2colEngineRTL. Feeds
+a preloaded image into the engine's in_mem, sends a CMD_IM2COL_LAUNCH
+packet whose fields carry the runtime im2col config, and sinks the
+emitted CMD_STORE_REQUEST packets on send_pkt to check them against a
+Python golden.
 """
 
 from pymtl3 import *
 from pymtl3.stdlib.test_utils import (config_model_with_cmdline_opts,
                                       run_sim)
 
-from ..Im2colEngineRTL import Im2colEngineRTL
+from ..Im2colEngineRTL import Im2colEngineRTL, pack_im2col_launch
 from ....lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL
-from ....lib.cmd_type import CMD_STORE_REQUEST
+from ....lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
+from ....lib.cmd_type import CMD_IM2COL_LAUNCH, CMD_STORE_REQUEST
 from ....lib.messages import (mk_cgra_payload, mk_ctrl, mk_data,
                                 mk_intra_cgra_pkt)
 
@@ -70,37 +72,31 @@ def golden_im2col(image, H, W, kH, kW, stride):
 
 
 #-------------------------------------------------------------------------
-# Test harness: engine + a TestSinkRTL that consumes send_pkt.
+# Test harness: engine + TestSrcRTL for launch + TestSinkRTL for outputs.
 #-------------------------------------------------------------------------
 
 class TestHarness(Component):
 
-  def construct(s, scratch_mem_size,
-                in_base, H, W, kH, kW, stride,
+  def construct(s, scratch_mem_size, launch_pkts,
                 preload_image, expected_packets):
 
     s.dut = Im2colEngineRTL(DataType, IntraCgraPktType, CgraPayloadType,
-                            scratch_mem_size,
-                            in_base, H, W, kH, kW, stride,
-                            preload_image)
+                            scratch_mem_size, preload_image)
+
+    s.launch_src = TestSrcRTL(IntraCgraPktType, launch_pkts)
+    s.launch_src.send //= s.dut.recv_cmd_pkt
 
     # Compare only the fields the engine actually populates: cmd, data,
-    # data_addr. The dst field is always 0 (STORE_REQUEST is routed by
-    # the controller via data_addr, so dst is a don't-care on this
-    # path); every other field is also a don't-care.
-    cmp_fn = lambda a, b: (a.payload.cmd      == b.payload.cmd and
-                           a.payload.data     == b.payload.data and
+    # data_addr. dst is always 0 (STORE_REQUEST is routed by data_addr).
+    cmp_fn = lambda a, b: (a.payload.cmd       == b.payload.cmd and
+                           a.payload.data      == b.payload.data and
                            a.payload.data_addr == b.payload.data_addr)
     s.sink = TestSinkRTL(IntraCgraPktType, expected_packets,
-                          cmp_fn = cmp_fn)
-
+                         cmp_fn = cmp_fn)
     s.dut.send_pkt //= s.sink.recv
-    # Start is asserted high; the engine's FSM only samples it in S_IDLE
-    # (a single cycle after reset), so leaving it high is safe.
-    s.dut.start //= b1(1)
 
   def done(s):
-    return s.sink.done()
+    return s.launch_src.done() and s.sink.done()
 
   def line_trace(s):
     return f"{s.dut.line_trace()} || sink[{s.sink.line_trace()}]"
@@ -110,8 +106,7 @@ class TestHarness(Component):
 # Driver
 #-------------------------------------------------------------------------
 
-def _build_expected_packets(image, H, W, kH, kW, stride):
-  # Engine emits output i to SRAM addr i (0-based, contiguous).
+def _build_expected_packets(image, H, W, kH, kW, stride, dest_base):
   values, _, _ = golden_im2col(image, H, W, kH, kW, stride)
   pkts = []
   for i, v in enumerate(values):
@@ -121,17 +116,24 @@ def _build_expected_packets(image, H, W, kH, kW, stride):
         0, 0,                      # opaque, vc_id
         CgraPayloadType(cmd = CMD_STORE_REQUEST,
                         data = DataType(v, 1),
-                        data_addr = i)))
+                        data_addr = dest_base + i)))
   return pkts
 
 
-def run_engine(image, H, W, kH, kW, stride, in_base,
+def run_engine(image, H, W, kH, kW, stride,
+               in_base = 0, dest_base = 0,
                scratch_mem_size = 64, cmdline_opts = None):
 
-  expected = _build_expected_packets(image, H, W, kH, kW, stride)
-  th = TestHarness(scratch_mem_size,
-                   in_base, H, W, kH, kW, stride,
-                   image, expected)
+  launch_pkts = [IntraCgraPktType(payload = CgraPayloadType(
+      CMD_IM2COL_LAUNCH,
+      data      = DataType(pack_im2col_launch(H = H, W = W,
+                                              in_base = in_base,
+                                              kH = kH, kW = kW,
+                                              stride = stride), 1),
+      data_addr = dest_base))]
+
+  expected = _build_expected_packets(image, H, W, kH, kW, stride, dest_base)
+  th = TestHarness(scratch_mem_size, launch_pkts, image, expected)
   th.elaborate()
   if cmdline_opts is not None:
     th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
@@ -146,21 +148,21 @@ def test_engine_4x4_k2_s1(cmdline_opts):
   # 4x4 image, 2x2 kernel, stride 1 -> 3x3 output grid, 4x9 lowered.
   image = list(range(16))
   run_engine(image, H = 4, W = 4, kH = 2, kW = 2, stride = 1,
-             in_base = 0, cmdline_opts = cmdline_opts)
+             cmdline_opts = cmdline_opts)
 
 
 def test_engine_4x4_k2_s2(cmdline_opts):
   # Stride-2: 4x4 / 2x2 / s2 -> 2x2 output grid, 4x4 lowered.
   image = [i * 2 + 1 for i in range(16)]
   run_engine(image, H = 4, W = 4, kH = 2, kW = 2, stride = 2,
-             in_base = 0, cmdline_opts = cmdline_opts)
+             cmdline_opts = cmdline_opts)
 
 
 def test_engine_5x5_k3_s1(cmdline_opts):
   # 5x5 / 3x3 / s1 -> 3x3 output grid, 9x9 lowered (81 outputs).
   image = list(range(25))
   run_engine(image, H = 5, W = 5, kH = 3, kW = 3, stride = 1,
-             in_base = 0, scratch_mem_size = 128,
+             scratch_mem_size = 128,
              cmdline_opts = cmdline_opts)
 
 
@@ -169,5 +171,14 @@ def test_engine_smoke_matches_e2e_layout(cmdline_opts):
   # test (image [1,3,2,4], 1x4 / 1x2 / s2 -> lowered [1,2,3,4] stored
   # to SRAM addr 0..3).
   image = [1, 3, 2, 4]
-  run_engine(image, H = 1, W = 4, kH = 1, kW = 2, stride = 2, in_base = 0,
+  run_engine(image, H = 1, W = 4, kH = 1, kW = 2, stride = 2,
+             cmdline_opts = cmdline_opts)
+
+
+def test_engine_nonzero_dest_base(cmdline_opts):
+  # Verifies that dest_base actually offsets the store address. Same
+  # image geometry as test_engine_4x4_k2_s2 but write to addr 16..19.
+  image = [i * 2 + 1 for i in range(16)]
+  run_engine(image, H = 4, W = 4, kH = 2, kW = 2, stride = 2,
+             dest_base = 16,
              cmdline_opts = cmdline_opts)

--- a/lib/cmd_type.py
+++ b/lib/cmd_type.py
@@ -14,7 +14,7 @@ from pymtl3 import *
 
 # Total number of commands that are supported/recognized by controller.
 # Needs to be updated once more commands are added/supported.
-NUM_CMDS = 53
+NUM_CMDS = 59
 
 CMD_LAUNCH                           = 0
 CMD_PAUSE                            = 1
@@ -80,8 +80,16 @@ CMD_DMA_MVIN                         = 49  # Issues a DMA_MVIN command
 CMD_DMA_MVOUT                        = 50  # Issues a DMA_MVOUT command
 CMD_DMA_DONE                         = 51  # Signals that the DMA command is complete
 
-# Im2col Engine Command.
-CMD_IM2COL_LAUNCH                    = 52  # CPU -> Controller -> Im2col engine: trigger DMA-style preload
+# Im2col Engine Commands. Each geometry parameter is configured by its
+# own command (mirroring the CMD_DMA_CONFIG_* convention). The CPU sends
+# any subset of these config commands before firing CMD_IM2COL_LAUNCH.
+CMD_IM2COL_LAUNCH                    = 52  # CPU -> Im2col engine: start processing with latched config
+CMD_IM2COL_H                         = 53  # config: image height H            (data)
+CMD_IM2COL_W                         = 54  # config: image width W             (data)
+CMD_IM2COL_KH                        = 55  # config: kernel height kH          (data)
+CMD_IM2COL_KW                        = 56  # config: kernel width kW           (data)
+CMD_IM2COL_LOG2_STRIDE               = 57  # config: log2(stride)              (data)
+CMD_IM2COL_DST_SRAM_BASE             = 58  # config: output base in CGRA SRAM  (data_addr)
 
 CMD_SYMBOL_DICT = {
   CMD_LAUNCH:                           "(LAUNCH_KERNEL)",
@@ -137,5 +145,11 @@ CMD_SYMBOL_DICT = {
   CMD_DMA_MVOUT:                        "(DMA_MVOUT)",
   CMD_DMA_DONE:                         "(DMA_DONE)",
   CMD_IM2COL_LAUNCH:                    "(IM2COL_LAUNCH)",
+  CMD_IM2COL_H:                         "(IM2COL_H)",
+  CMD_IM2COL_W:                         "(IM2COL_W)",
+  CMD_IM2COL_KH:                        "(IM2COL_KH)",
+  CMD_IM2COL_KW:                        "(IM2COL_KW)",
+  CMD_IM2COL_LOG2_STRIDE:               "(IM2COL_LOG2_STRIDE)",
+  CMD_IM2COL_DST_SRAM_BASE:             "(IM2COL_DST_SRAM_BASE)",
 }
 


### PR DESCRIPTION
Addresses issue #333: previously H, W, kH, kW, stride, in_base and the output SRAM base were all baked in at construct time, so the same synthesized RTL could only run one geometry. Now the engine reads them from the CMD_IM2COL_LAUNCH packet on every launch, so a single RTL can be reprogrammed at runtime.

Design (0 new CMDs):
  - Reuse the existing CMD_IM2COL_LAUNCH packet. Its fields carry the full config; the launch pulse and the config transfer are one and the same packet.
  - Layout (32-bit data field + 7-bit data_addr):
      data_addr          = dest_base
      data[ 5: 0]        = W        (6 bit)
      data[11: 6]        = H        (6 bit)
      data[17:12]        = in_base  (6 bit)
      data[20:18]        = kW       (3 bit)
      data[23:21]        = kH       (3 bit)
      data[27:24]        = log2_stride  (4 bit; stride = 1 << this)
  - pack_im2col_launch() helper in the engine module hides the bit
    layout from CPU code.

Engine interface:
  - start: InPort(b1)  ->  recv_cmd_pkt: RecvIfcRTL(IntraCgraPktType)
  - rdy is high only in S_IDLE, so LAUNCH cannot re-trigger mid-run.
  - Precomputes cfg_Hout / cfg_Wout on the LAUNCH edge so the S_EMIT loop-advance compares against plain registers each cycle.

Tests:
  fu/others/test/Im2colEngineRTL_test.py  5/5 pass
    - four geometry variants + a nonzero-dest_base check
  cgra/test/Im2colCgraE2E_test.py         3/3 pass (incl. Verilog gen)