### PR TITLE
Serializer&Deserializer implementation and test.

### DIFF
--- a/noc/DeserializerRTL.py
+++ b/noc/DeserializerRTL.py
@@ -1,0 +1,182 @@
+"""
+==========================================================================
+DeserializerRTL.py
+==========================================================================
+Deserializer for converting multiple NoCFlitType flits into a full
+NoCPktType packet received from the NoC.
+
+The packet payload is deserialized from LSB to MSB. If the packet payload
+width is not an integer multiple of the flit payload width, the padded
+upper bits of the final flit are discarded.
+
+Author : Yufei Yang
+Date   : Aug 27, 2026
+"""
+
+from pymtl3 import *
+from ..lib.basic.val_rdy.ifcs import RecvIfcRTL, SendIfcRTL
+from ..lib.util.common import *
+from ..lib.util.data_struct_attr import *
+
+class DeserializerRTL( Component ):
+
+  def construct( s, NoCPktType, NoCFlitType ):
+
+    # Payload bit widths.
+    pkt_payload_nbits = int( NoCPktType.get_field_type(kAttrPayload).nbits )
+    flit_payload_nbits = int( NoCFlitType.get_field_type(kAttrPayload).nbits )
+
+    # Number of flits required, using ceiling division.
+    num_flits = (
+      pkt_payload_nbits + flit_payload_nbits - 1
+    ) // flit_payload_nbits
+
+    # Counter bit width.
+    counter_nbits = max( clog2( num_flits + 1 ), 1 )
+
+    # FSM state: 0=idle, 1=working, 2=done.
+    StateType = mk_bits( 2 )
+
+    # Interfaces.
+    s.in_flit = RecvIfcRTL( NoCFlitType )
+    s.out_pkt = SendIfcRTL( NoCPktType )
+
+    # Registers.
+    s.counter = Wire( mk_bits( counter_nbits ) )
+    s.header_reg = Wire( NoCFlitType )
+    s.state = Wire( StateType )
+
+    # Internal combinational signals.
+    s.flit_accepted = Wire( 1 )
+    s.start_deserializing = Wire( 1 )
+    s.receiving_last_flit = Wire( 1 )
+    s.consumed_by_controller = Wire( 1 )
+
+    # Flit payload registers.
+    s.flit_payload_regs = [
+      Wire( mk_bits(flit_payload_nbits) )
+      for _ in range( num_flits )
+    ]
+
+    # Reassembled packet payload.
+    s.pkt_payload = Wire( mk_bits(pkt_payload_nbits) )
+
+    # Statically connect flit payload registers to packet payload slices.
+    #
+    # Example for a non-standard 232-bit packet payload and 32-bit flits:
+    #
+    # pkt_payload[0:32] = flit_payload_regs[0]
+    # pkt_payload[32:64] = flit_payload_regs[1]
+    # ...
+    # pkt_payload[192:224] = flit_payload_regs[6]
+    # pkt_payload[224:232] = flit_payload_regs[7][0:8]
+    #
+    # start and end are Python integers evaluated during elaboration,
+    # so all slice bounds are static constants for RTL translation.
+    for i in range( num_flits ):
+      start = i * flit_payload_nbits
+      end = min( start + flit_payload_nbits, pkt_payload_nbits )
+      valid_nbits = end - start
+
+      if valid_nbits == flit_payload_nbits:
+        connect(
+          s.pkt_payload[start:end],
+          s.flit_payload_regs[i]
+        )
+      else:
+        connect(
+          s.pkt_payload[start:end],
+          s.flit_payload_regs[i][0:valid_nbits]
+        )
+
+    @update
+    def update_comb_logic():
+
+      # FSM output control.
+      if s.state == 0:  # idle
+        s.in_flit.rdy @= 1
+        s.out_pkt.val @= 0
+      elif s.state == 1:  # working
+        s.in_flit.rdy @= 1
+        s.out_pkt.val @= 0
+      else:  # done
+        s.in_flit.rdy @= 0
+        s.out_pkt.val @= 1
+
+      # Handshake signals.
+      s.flit_accepted @= s.in_flit.val & s.in_flit.rdy
+      s.start_deserializing @= \
+        ( s.state == 0 ) & s.flit_accepted
+      s.receiving_last_flit @= \
+        ( s.counter == num_flits - 1 ) & s.flit_accepted
+      s.consumed_by_controller @= \
+        s.out_pkt.val & s.out_pkt.rdy
+
+      # Copy stored flit header fields into the output packet.
+      s.out_pkt.msg.src @= s.header_reg.src
+      s.out_pkt.msg.dst @= s.header_reg.dst
+      s.out_pkt.msg.src_x @= s.header_reg.src_x
+      s.out_pkt.msg.src_y @= s.header_reg.src_y
+      s.out_pkt.msg.dst_x @= s.header_reg.dst_x
+      s.out_pkt.msg.dst_y @= s.header_reg.dst_y
+      s.out_pkt.msg.src_tile_id @= s.header_reg.src_tile_id
+      s.out_pkt.msg.dst_tile_id @= s.header_reg.dst_tile_id
+      s.out_pkt.msg.remote_src_port @= s.header_reg.remote_src_port
+      s.out_pkt.msg.opaque @= s.header_reg.opaque
+      s.out_pkt.msg.vc_id @= s.header_reg.vc_id
+
+      # Output the reassembled packet payload.
+      s.out_pkt.msg.payload @= s.pkt_payload
+
+    @update_ff
+    def up_state():
+      if s.reset:
+        s.state <<= StateType( 0 )
+      else:
+        if ( s.state == 0 ) & s.start_deserializing:
+            s.state <<= StateType( 1 )
+        elif ( s.state == 1 ) & s.receiving_last_flit:
+          s.state <<= StateType( 2 )
+        elif ( s.state == 2 ) & s.consumed_by_controller:
+          s.state <<= StateType( 0 )
+
+    @update_ff
+    def up_header_reg():
+      if s.reset:
+        s.header_reg <<= NoCFlitType()
+      elif s.consumed_by_controller:
+        s.header_reg <<= NoCFlitType()
+      elif s.start_deserializing:
+        s.header_reg <<= s.in_flit.msg
+
+    @update_ff
+    def up_flit_payload_regs():
+      if s.reset:
+        for i in range( num_flits ):
+          s.flit_payload_regs[i] <<= 0
+      elif s.consumed_by_controller:
+        for i in range( num_flits ):
+          s.flit_payload_regs[i] <<= 0
+      elif s.flit_accepted:
+        for i in range( num_flits ):
+          if s.counter == i:
+            s.flit_payload_regs[i] <<= s.in_flit.msg.payload
+
+    @update_ff
+    def up_counter():
+      if s.reset:
+        s.counter <<= 0
+      elif s.consumed_by_controller:
+        s.counter <<= 0
+      elif s.flit_accepted & ~s.receiving_last_flit:
+        # Do not increment after the last flit.
+        s.counter <<= s.counter + 1
+
+  def line_trace( s ):
+    state_str = "idle" if s.state == 0 else \
+                ("working" if s.state == 1 else "done")
+    return f"{state_str} | ctr:{s.counter} | " \
+           f"in_val:{s.in_flit.val} in_rdy:{s.in_flit.rdy} | " \
+           f"in_payload:{s.in_flit.msg.payload} | " \
+           f"out_val:{s.out_pkt.val} out_rdy:{s.out_pkt.rdy} | " \
+           f"out_payload:{s.out_pkt.msg.payload}"

--- a/noc/SerializerRTL.py
+++ b/noc/SerializerRTL.py
@@ -1,0 +1,177 @@
+"""
+==========================================================================
+SerializerRTL.py
+==========================================================================
+Serializer for converting a full NoCPktType packet into multiple
+NoCFlitType flits to be sent over the NoC.
+
+The packet payload is serialized from LSB to MSB. If the packet payload
+width is not an integer multiple of the flit payload width, the final
+flit is padded with zeros in its upper bits.
+
+Author : Yufei Yang
+Date   : Aug 24, 2026
+"""
+
+from pymtl3 import *
+from ..lib.basic.val_rdy.ifcs import RecvIfcRTL, SendIfcRTL
+from ..lib.util.common import *
+from ..lib.util.data_struct_attr import *
+
+class SerializerRTL( Component ):
+
+  def construct( s, NoCPktType, NoCFlitType ):
+
+    # Payload bit widths.
+    pkt_payload_nbits = int( NoCPktType.get_field_type(kAttrPayload).nbits )
+    flit_payload_nbits = int( NoCFlitType.get_field_type(kAttrPayload).nbits )
+
+    # Number of flits required, using ceiling division.
+    num_flits = (
+      pkt_payload_nbits + flit_payload_nbits - 1
+    ) // flit_payload_nbits
+
+    # Counter bit width.
+    counter_nbits = max( clog2( num_flits + 1 ), 1 )
+
+    # FSM state: 0=idle, 1=working, 2=done.
+    StateType = mk_bits( 2 )
+
+    # Interfaces.
+    s.in_pkt = RecvIfcRTL( NoCPktType )
+    s.out_flit = SendIfcRTL( NoCFlitType )
+
+    # Registers.
+    s.counter = Wire( mk_bits( counter_nbits ) )
+    s.in_pkt_reg = Wire( NoCPktType )
+    s.state = Wire( StateType )
+
+    # Internal combinational signals.
+    s.start_serializing = Wire( 1 )
+    s.flit_consumed_by_noc = Wire( 1 )
+    s.sending_last_flit = Wire( 1 )
+
+    # Pre-sliced payload flits.
+    #
+    # The packet payload is statically divided into flit-sized wires
+    # during elaboration. Runtime logic only selects one of these wires
+    # according to the counter, avoiding variable slicing and shifting.
+    s.flit_payloads = [
+      Wire( mk_bits(flit_payload_nbits) )
+      for _ in range( num_flits )
+    ]
+
+    # Statically connect packet payload slices to each flit payload.
+    #
+    # Example for a non-standard 232-bit packet payload and 32-bit flits:
+    #
+    # flit_payloads[0] = payload[0:32]
+    # flit_payloads[1] = payload[32:64]
+    # ...
+    # flit_payloads[6] = payload[192:224]
+    # flit_payloads[7][0:8] = payload[224:232]
+    # flit_payloads[7][8:32] = 0
+    #
+    # start and end are Python integers evaluated during elaboration,
+    # so all slice bounds are static constants for RTL translation.
+    for i in range( num_flits ):
+      start = i * flit_payload_nbits
+      end = min( start + flit_payload_nbits, pkt_payload_nbits )
+      valid_nbits = end - start
+
+      if valid_nbits == flit_payload_nbits:
+        connect(
+          s.flit_payloads[i],
+          s.in_pkt_reg.payload[start:end]
+        )
+      else:
+        # Connect remaining valid payload bits to the lower bits.
+        connect(
+          s.flit_payloads[i][0:valid_nbits],
+          s.in_pkt_reg.payload[start:end]
+        )
+
+        # Zero-pad the unused upper bits of the final flit.
+        connect(
+          s.flit_payloads[i][valid_nbits:flit_payload_nbits],
+          mk_bits(flit_payload_nbits-valid_nbits)(0)
+        )
+
+    @update
+    def update_comb_logic():
+
+      # FSM output control.
+      if s.state == 0:  # idle
+        s.in_pkt.rdy @= 1
+        s.out_flit.val @= 0
+      elif s.state == 1:  # working
+        s.in_pkt.rdy @= 0
+        s.out_flit.val @= 1
+      else:  # done
+        s.in_pkt.rdy @= 0
+        s.out_flit.val @= 0
+
+      # Handshake signals.
+      s.start_serializing @= s.in_pkt.val & s.in_pkt.rdy
+      s.flit_consumed_by_noc @= s.out_flit.val & s.out_flit.rdy
+      s.sending_last_flit @= \
+        ( s.counter == num_flits - 1 ) & s.flit_consumed_by_noc
+
+      # Copy packet header fields into each output flit.
+      s.out_flit.msg.src @= s.in_pkt_reg.src
+      s.out_flit.msg.dst @= s.in_pkt_reg.dst
+      s.out_flit.msg.src_x @= s.in_pkt_reg.src_x
+      s.out_flit.msg.src_y @= s.in_pkt_reg.src_y
+      s.out_flit.msg.dst_x @= s.in_pkt_reg.dst_x
+      s.out_flit.msg.dst_y @= s.in_pkt_reg.dst_y
+      s.out_flit.msg.src_tile_id @= s.in_pkt_reg.src_tile_id
+      s.out_flit.msg.dst_tile_id @= s.in_pkt_reg.dst_tile_id
+      s.out_flit.msg.remote_src_port @= s.in_pkt_reg.remote_src_port
+      s.out_flit.msg.opaque @= s.in_pkt_reg.opaque
+      s.out_flit.msg.vc_id @= s.in_pkt_reg.vc_id
+
+      # Select the current payload flit.
+      # This synthesizes to a counter-controlled MUX. There is no
+      # multiplier, variable shifter, or runtime variable slice.
+      s.out_flit.msg.payload @= 0
+      for i in range( num_flits ):
+        if s.counter == i:
+          s.out_flit.msg.payload @= s.flit_payloads[i]
+
+    @update_ff
+    def up_state():
+      if s.reset:
+        s.state <<= StateType( 0 )
+      else:
+        if ( s.state == 0 ) & s.start_serializing:
+          s.state <<= StateType( 1 )
+        elif ( s.state == 1 ) & s.sending_last_flit:
+          s.state <<= StateType( 2 )
+        elif s.state == 2:
+          s.state <<= StateType( 0 )
+
+    @update_ff
+    def up_in_pkt_reg():
+      if s.reset:
+        s.in_pkt_reg <<= NoCPktType()
+      elif s.start_serializing:
+        s.in_pkt_reg <<= s.in_pkt.msg
+
+    @update_ff
+    def up_counter():
+      if s.reset:
+        s.counter <<= 0
+      elif s.state == 2:
+        s.counter <<= 0
+      elif s.flit_consumed_by_noc & ~s.sending_last_flit:
+        # Do not increment after the last flit.
+        s.counter <<= s.counter + 1
+
+  def line_trace( s ):
+    state_str = "idle" if s.state == 0 else \
+                ("working" if s.state == 1 else "done")
+    return f"in_pkt_reg.payload:{s.in_pkt_reg.payload} | " \
+           f"{state_str} | ctr:{s.counter} | " \
+           f"in_val:{s.in_pkt.val} in_rdy:{s.in_pkt.rdy} | " \
+           f"out_val:{s.out_flit.val} out_rdy:{s.out_flit.rdy} | " \
+           f"out_payload:{s.out_flit.msg.payload}"

--- a/noc/test/DeserializerRTL_test.py
+++ b/noc/test/DeserializerRTL_test.py
@@ -1,0 +1,165 @@
+'''
+=========================================================================
+DeserializerRTL_test.py
+=========================================================================
+Simple test for DeserializerRTL.
+
+Author : Yufei Yang
+  Date : Aug 27, 2026
+'''
+
+from pymtl3 import *
+from pymtl3.stdlib.test_utils import config_model_with_cmdline_opts
+
+from ..DeserializerRTL import DeserializerRTL
+from ...lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL
+from ...lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
+from ...lib.messages import *
+from ...lib.util.common import *
+
+
+#-------------------------------------------------------------------------
+# TestHarness
+#-------------------------------------------------------------------------
+
+class TestHarness(Component):
+
+  def construct(s, NoCPktType, NoCFlitType, flit_msgs, expected_pkt_msgs):
+
+    # Instantiates the DUT and the test source/sink.
+    s.dut = DeserializerRTL( NoCPktType, NoCFlitType )
+    s.src = TestSrcRTL( NoCFlitType, flit_msgs )
+
+    # Delays consuming the output packet to test backpressure on incoming flits.
+    s.sink = TestSinkRTL( NoCPktType, expected_pkt_msgs, initial_delay=10, interval_delay=10 )
+
+    # Connects the modules.
+    s.src.send //= s.dut.in_flit
+    s.dut.out_pkt //= s.sink.recv
+
+  def done(s):
+    return s.src.done() and s.sink.done()
+
+  def line_trace(s):
+    return s.dut.line_trace()
+
+
+#-------------------------------------------------------------------------
+# run_sim
+#-------------------------------------------------------------------------
+
+def run_sim(test_harness, max_cycles = 100):
+
+  # Creates a simulator.
+  test_harness.elaborate()
+  test_harness.apply( DefaultPassGroup() )
+  test_harness.sim_reset()
+
+  # Tracks whether the next flit is blocked while the current packet waits.
+  saw_blocked_next_flit = False
+
+  # Runs the simulation.
+  ncycles = 0
+  print()
+  print("{}:{}".format(ncycles, test_harness.line_trace()))
+  while not test_harness.done() and ncycles < max_cycles:
+
+    # Checks that no new flit can enter while an output packet is waiting.
+    if ( test_harness.dut.out_pkt.val and
+         not test_harness.dut.out_pkt.rdy and
+         test_harness.dut.in_flit.val ):
+
+      saw_blocked_next_flit = True
+      assert not test_harness.dut.in_flit.rdy
+
+    test_harness.sim_tick()
+    ncycles += 1
+    print("{}:{}".format(ncycles, test_harness.line_trace()))
+
+  # Checks timeout.
+  assert ncycles < max_cycles
+
+  # Checks that the backpressure case was actually exercised.
+  assert saw_blocked_next_flit
+
+  test_harness.sim_tick()
+  test_harness.sim_tick()
+  test_harness.sim_tick()
+
+
+#-------------------------------------------------------------------------
+# Test cases
+#-------------------------------------------------------------------------
+
+def test_simple(cmdline_opts):
+
+  # Defines parameters. Sets data_nbits to 128 to generate 4 flits per packet.
+  flit_width = 32
+  pkt_width = 128
+  num_cgra_columns = 1
+  num_cgra_rows = 1
+  num_tiles = 1
+  num_rd_tiles = 1
+
+  # Constructs NoCPktType and NoCFlitType.
+  PktType = mk_bits(pkt_width)
+  NoCPktType = mk_inter_cgra_pkt(
+    num_cgra_columns,
+    num_cgra_rows,
+    num_tiles,
+    num_rd_tiles,
+    PktType
+  )
+
+  # Defines FlitType with a 32-bit width.
+  FlitType = mk_bits(flit_width)
+  NoCFlitType = mk_inter_cgra_pkt(
+    num_cgra_columns,
+    num_cgra_rows,
+    num_tiles,
+    num_rd_tiles,
+    FlitType
+  )
+
+  # Constructs input flits for Packet 1.
+  flit1_1 = NoCFlitType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, FlitType(0xFFFFFFFF))
+  flit1_2 = NoCFlitType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, FlitType(0xEEEEEEEE))
+  flit1_3 = NoCFlitType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, FlitType(0xDDDDDDDD))
+  flit1_4 = NoCFlitType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, FlitType(0xCCCCCCCC))
+  
+  # Constructs input flits for Packet 2.
+  flit2_1 = NoCFlitType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, FlitType(0x77777777))
+  flit2_2 = NoCFlitType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, FlitType(0x66666666))
+  flit2_3 = NoCFlitType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, FlitType(0x55555555))
+  flit2_4 = NoCFlitType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, FlitType(0x44444444))
+
+  flit_msgs = [
+    flit1_1, flit1_2, flit1_3, flit1_4,
+    flit2_1, flit2_2, flit2_3, flit2_4
+  ]
+
+  # Expected Packet 1.
+  pkt1 = NoCPktType(
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    PktType(0xCCCCCCCCDDDDDDDDEEEEEEEEFFFFFFFF)
+  )
+
+  # Expected Packet 2.
+  pkt2 = NoCPktType(
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    PktType(0x44444444555555556666666677777777)
+  )
+
+  expected_pkt_msgs = [ pkt1, pkt2 ]
+
+  # Generates TestHarness and runs the simulation.
+  th = TestHarness(
+    NoCPktType,
+    NoCFlitType,
+    flit_msgs,
+    expected_pkt_msgs
+  )
+
+  th.elaborate()
+  th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
+  run_sim(th)

--- a/noc/test/SerializerRTL_test.py
+++ b/noc/test/SerializerRTL_test.py
@@ -1,0 +1,125 @@
+'''
+=========================================================================
+SerializerRTL_test.py
+=========================================================================
+Simple test for SerializerRTL.
+
+Author : Yufei Yang
+  Date : Aug 24, 2026
+'''
+
+from pymtl3 import *
+from pymtl3.stdlib.test_utils import config_model_with_cmdline_opts
+
+from ..SerializerRTL import SerializerRTL
+from ...lib.basic.val_rdy.SinkRTL import SinkRTL as TestSinkRTL
+from ...lib.basic.val_rdy.SourceRTL import SourceRTL as TestSrcRTL
+from ...lib.messages import *
+from ...lib.util.common import *
+
+
+#-------------------------------------------------------------------------
+# TestHarness
+#-------------------------------------------------------------------------
+
+class TestHarness(Component):
+
+  def construct(s, NoCPktType, NoCFlitType, pkt_msgs, expected_flit_msgs):
+    
+    # Instantiates the DUT and the test source/sink.
+    s.dut = SerializerRTL( NoCPktType, NoCFlitType )
+    s.src = TestSrcRTL( NoCPktType, pkt_msgs )
+    
+    # Sets initial_delay and interval_delay to 1 to pull down rdy every 2 cycles, simulating NoC congestion.
+    s.sink = TestSinkRTL( NoCFlitType, expected_flit_msgs, initial_delay=2, interval_delay=2 )
+
+    # Connects the modules.
+    s.src.send //= s.dut.in_pkt
+    s.dut.out_flit //= s.sink.recv
+
+  def done(s):
+    return s.src.done() and s.sink.done()
+
+  def line_trace(s):
+    return s.dut.line_trace()
+
+
+#-------------------------------------------------------------------------
+# run_sim
+#-------------------------------------------------------------------------
+
+def run_sim(test_harness, max_cycles = 50):
+
+  # Creates a simulator.
+  test_harness.elaborate()
+  test_harness.apply( DefaultPassGroup() )
+  test_harness.sim_reset()
+
+  # Runs the simulation.
+  ncycles = 0
+  print()
+  print("{}:{}".format(ncycles, test_harness.line_trace()))
+  while not test_harness.done() and ncycles < max_cycles:
+    test_harness.sim_tick()
+    ncycles += 1
+    print("{}:{}".format(ncycles, test_harness.line_trace()))
+
+  # Checks timeout.
+  assert ncycles < max_cycles
+
+  test_harness.sim_tick()
+  test_harness.sim_tick()
+  test_harness.sim_tick()
+
+
+#-------------------------------------------------------------------------
+# Test cases
+#-------------------------------------------------------------------------
+
+def test_simple(cmdline_opts):
+
+  # Defines parameters. Sets data_nbits to 128 to satisfy the requirement of generating 4 flits.
+  flit_width = 32
+  pkt_width = 128
+  num_cgra_columns = 1
+  num_cgra_rows = 1
+  num_tiles = 1
+  num_rd_tiles = 1
+
+  # Constructs NoCPktType and NoCFlitType.
+  PktType = mk_bits(pkt_width)
+  NoCPktType = mk_inter_cgra_pkt(num_cgra_columns, num_cgra_rows, num_tiles, num_rd_tiles, PktType)
+  
+  # Defines FlitType with a 32-bit width.
+  FlitType = mk_bits(flit_width)
+  NoCFlitType = mk_inter_cgra_pkt(num_cgra_columns, num_cgra_rows, num_tiles, num_rd_tiles, FlitType)
+
+  # Constructs packets. DataType is the only non-zero field; all other fields (Cmd, DataAddr, Ctrl, CtrlAddr.) are zero for easy debugging.
+  # Note: The data is reversed to ensure the output Flit sequence is FFFFFFFF, EEEEEEEE, DDDDDDDD, CCCCCCCC.
+  pkt1 = NoCPktType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, PktType(0xCCCCCCCCDDDDDDDDEEEEEEEEFFFFFFFF))
+  
+  pkt2 = NoCPktType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, PktType(0x44444444555555556666666677777777))
+  
+  pkt_msgs = [ pkt1, pkt2 ]
+
+  # Expected Flits for Packet 1 (4 flits).
+  flit1_1 = NoCFlitType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, Bits(flit_width, 0xFFFFFFFF))
+  flit1_2 = NoCFlitType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, Bits(flit_width, 0xEEEEEEEE))
+  flit1_3 = NoCFlitType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, Bits(flit_width, 0xDDDDDDDD))
+  flit1_4 = NoCFlitType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, Bits(flit_width, 0xCCCCCCCC))
+
+  # Expected Flits for Packet 2 (4 flits).
+  flit2_1 = NoCFlitType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, Bits(flit_width, 0x77777777))
+  flit2_2 = NoCFlitType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, Bits(flit_width, 0x66666666))
+  flit2_3 = NoCFlitType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, Bits(flit_width, 0x55555555))
+  flit2_4 = NoCFlitType(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, Bits(flit_width, 0x44444444))
+
+  expected_flit_msgs = [ flit1_1, flit1_2, flit1_3, flit1_4,
+                         flit2_1, flit2_2, flit2_3, flit2_4 ]
+
+  # Generates TestHarness and runs the simulation.
+  th = TestHarness( NoCPktType, NoCFlitType, pkt_msgs, expected_flit_msgs )
+
+  th.elaborate()
+  th = config_model_with_cmdline_opts(th, cmdline_opts, duts = ['dut'])
+  run_sim(th)


### PR DESCRIPTION
This PR is to support flit for NoC pkg (#59).
### Serializer design
<img width="1419" height="1050" alt="c428bcfe-36ab-4732-b87a-586ce5d2a3eb" src="https://github.com/user-attachments/assets/8119bb42-a928-4b31-962b-dca9be34d574" />

Serializer for converting a full NoCPktType packet into multiple NoCFlitType flits to be sent over the NoC. The packet payload is serialized from LSB to MSB. If the packet payload width is not an integer multiple of the flit payload width, the final flit is padded with zeros in its upper bits.

### Deserializer design
<img width="1419" height="1050" alt="b5bcfa72-c440-4639-9e04-4c9c25c0b541" src="https://github.com/user-attachments/assets/eeb4e05e-6ba7-4827-91d2-e1218f0de0d2" />
Deserializer for converting multiple NoCFlitType flits received from the NoC into a full NoCPktType packet. The packet payload is deserialized from LSB to MSB. If the packet payload width is not an integer multiple of the flit payload width, the padded upper bits of the final flit are discarded.
