### PR TITLE
Fix predicated-off stores in MemUnitRTL

### DIFF
--- a/fu/single/MemUnitRTL.py
+++ b/fu/single/MemUnitRTL.py
@@ -199,12 +199,16 @@ class MemUnitRTL(Component):
           s.recv_in[s.in0_idx].rdy @= s.recv_all_val & s.to_mem_waddr.rdy & s.to_mem_wdata.rdy
           s.recv_in[s.in1_idx].rdy @= s.recv_all_val & s.to_mem_waddr.rdy & s.to_mem_wdata.rdy
           s.to_mem_waddr.msg @= AddrType(s.recv_in[s.in0_idx].msg.payload[0:AddrType.nbits])
-          s.to_mem_waddr.val @= s.recv_all_val
+          s.to_mem_waddr.val @= s.recv_all_val & \
+                                s.recv_in[s.in0_idx].msg.predicate & \
+                                s.recv_in[s.in1_idx].msg.predicate
           s.to_mem_wdata.msg @= s.recv_in[s.in1_idx].msg
           s.to_mem_wdata.msg.predicate @= s.recv_in[s.in0_idx].msg.predicate & \
                                           s.recv_in[s.in1_idx].msg.predicate & \
                                           s.reached_vector_factor
-          s.to_mem_wdata.val @= s.recv_all_val
+          s.to_mem_wdata.val @= s.recv_all_val & \
+                                s.recv_in[s.in0_idx].msg.predicate & \
+                                s.recv_in[s.in1_idx].msg.predicate
 
           # `send_out` is meaningless for store operation.
           s.send_out[0].val @= b1(0)

--- a/fu/single/test/MemUnitRTL_test.py
+++ b/fu/single/test/MemUnitRTL_test.py
@@ -8,7 +8,10 @@ Author : Cheng Tan
   Date : November 27, 2019
 """
 
+import pytest
+
 from pymtl3 import *
+from pymtl3.stdlib.test_utils import run_sim as run_test_sim
 
 from ..MemUnitRTL import MemUnitRTL
 from ....lib.messages import *
@@ -107,6 +110,31 @@ def test_Mem():
                    src_in0, src_in1, src_const, src_opt,
                    sink_out)
   run_sim(th)
+
+@pytest.mark.parametrize('addr_pred, data_pred', [(0, 1), (1, 0)])
+def test_store_predicate(cmdline_opts, addr_pred, data_pred):
+  DataType = mk_data(16, 1)
+  num_inports = 2
+  num_outports = 1
+  ConfigType = mk_ctrl(num_inports, num_outports)
+  data_mem_size = 8
+  DataAddrType = mk_bits(clog2(data_mem_size))
+  CtrlAddrType = mk_bits(3)
+  CgraPayloadType = mk_cgra_payload(DataType, DataAddrType, ConfigType, CtrlAddrType)
+  IntraCgraPktType = mk_intra_cgra_pkt(1, 1, 1, CgraPayloadType)
+  FuInType = mk_bits(clog2(num_inports + 1))
+  pickRegister = [FuInType(x + 1) for x in range(num_inports)]
+
+  # A predicated-off store must drain its operands without changing memory.
+  src_in0 = [DataType(0, 1), DataType(0, addr_pred), DataType(0, 1)]
+  src_in1 = [DataType(40, 1), DataType(99, data_pred)]
+  src_opt = [ConfigType(OPT_STR, pickRegister),
+             ConfigType(OPT_STR, pickRegister),
+             ConfigType(OPT_LD, pickRegister)]
+  th = TestHarness(MemUnitRTL, DataMemRTL, IntraCgraPktType, DataType,
+                   ConfigType, num_inports, num_outports, data_mem_size,
+                   src_in0, src_in1, [], src_opt, [DataType(40, 1)])
+  run_test_sim(th, cmdline_opts, duts = ['dut'])
 
 def test_PseudoMem():
   FU = MemUnitRTL


### PR DESCRIPTION
## Problem

`OPT_STR` asserts both memory write valid signals whenever its input tokens are available, even when the address or data predicate is zero. Although the output data carries the combined predicate, the downstream memory writes on the valid handshake without checking that predicate. A predicated-off store can therefore overwrite a valid result.

This was investigated while checking incorrect first outputs in GEMV and AXPY reported in [coredac/CGRA-SoC#3](https://github.com/coredac/CGRA-SoC/issues/3).

## Reproduction

The new `test_store_predicate` regression uses the existing MemUnit and data-memory harness:

1. Store `40` at address `0` with both predicates set.
2. Attempt to store `99` at the same address with either the address predicate or the data predicate cleared.
3. Load address `0` and expect `40` with predicate `1`.

With the regression present, run from the repository root:

```bash
pytest fu/single/test/MemUnitRTL_test.py -k store_predicate -q --tb=short
```

Both variants fail against the unmodified `master` implementation at `ac96a7a`: the load returns `99` with predicate `0` instead of preserving `40` with predicate `1`.

## Fix

Gate both `to_mem_waddr.val` and `to_mem_wdata.val` with the address and data predicates, matching the existing `OPT_STR_CONST` behavior. Keep operand and control readiness unchanged so predicated-off stores can consume their inputs and complete without issuing a memory write.

## Tests

- All four MemUnit tests pass after the fix, including both regression variants.
- Both new regression variants pass with `--test-verilog`. Local validation used an explicit Verilator C++ prefix to resolve the installed PyMTL/Verilator naming mismatch.
- Applying the same MemUnit patch to an isolated `kernel-submit` checkout at `57f0bda` restores complete output correctness for GEMV (`30, 70, 110, 150`) and AXPY (`40` through `100`, step `4`). These kernel checks inspect every output, including the first.

The kernel results above are from `kernel-submit`, not latest `master`. The borrowed GEMV fixture does not complete within 600 cycles on latest `master`, both before and after this fix. Full-suite CI and Chipyard validation have not been run.
